### PR TITLE
Change `debug` and `dump` from parameters to integers for debugging

### DIFF
--- a/src/2d/shallow/stepgrid.f
+++ b/src/2d/shallow/stepgrid.f
@@ -43,8 +43,8 @@ c      parameter (mwork=msize*(maxvar*maxvar + 13*maxvar + 3*maxaux +2))
       dimension aux(maux,mitot,mjtot)
 c      dimension work(mwork)
 
-      logical, parameter :: debug = .false.
-      logical, parameter :: dump = .false.
+      logical :: debug = .false.
+      logical :: dump = .false.
 c
       
       level = node(nestlevel,mptr)


### PR DESCRIPTION
You can turn on and off these parameters directly in a debugger while the run
code is running.
