### PR TITLE
Revert "Merge pull request #57 from mandli/add-setaux-flag-mask"

### DIFF
--- a/src/2d/shallow/filpatch.f90
+++ b/src/2d/shallow/filpatch.f90
@@ -57,9 +57,6 @@ recursive subroutine filrecur(level,num_eqn,valbig,aux,num_aux,t,mx,my, &
     real(kind=8) :: slope(2, fill_indices(2) - fill_indices(1) + 2, fill_indices(4) - fill_indices(3) + 2)
     integer :: fine_cell_count(fill_indices(2)-fill_indices(1)+2, fill_indices(4)-fill_indices(3)+2)
 
-    ! Aux masking copy storage
-    integer(kind=1) :: aux_copy_mask(mx, my)
-
     ! Stack storage
     !  use stack-based scratch arrays instead of alloc, since dont really
     !  need to save beyond these routines, and to allow dynami_coarse memory resizing
@@ -71,9 +68,6 @@ recursive subroutine filrecur(level,num_eqn,valbig,aux,num_aux,t,mx,my, &
     ! the +2 is to expand on coarse grid to enclose fine
     real(kind=8) :: valcrse((fill_indices(2)-fill_indices(1)+2) * (fill_indices(4)-fill_indices(3)+2) * num_eqn)  
     real(kind=8) :: auxcrse((fill_indices(2)-fill_indices(1)+2) * (fill_indices(4)-fill_indices(3)+2) * num_aux)  
-
-    ! Temporarily set all aux array values
-    aux_copy_mask = 0
 
     ! We begin by filling values for grids at level level.
     mx_patch = fill_indices(2) - fill_indices(1) + 1 ! nrowp
@@ -169,7 +163,7 @@ recursive subroutine filrecur(level,num_eqn,valbig,aux,num_aux,t,mx,my, &
         if (num_aux > 0) then
             call setaux(nghost, mx_coarse - 2*nghost,my_coarse - 2*nghost, &
                         coarse_rect(1) + nghost * dx_coarse,coarse_rect(3) + nghost * dy_coarse, &
-                        dx_coarse,dy_coarse,num_aux,auxcrse,aux_copy_mask)
+                        dx_coarse,dy_coarse,num_aux,auxcrse)
         endif
 
         ! Fill in the edges of the coarse grid

--- a/src/2d/shallow/gfixup.f
+++ b/src/2d/shallow/gfixup.f
@@ -10,10 +10,6 @@ c
 
       dimension spoh(maxlv)
 
-c     Aux masking copy storage
-      integer(kind=1) :: aux_copy_mask(max1d, max1d)
-      aux_copy_mask = 0
-
 c
 c ::::::::::::::::::::::::: GFIXUP ::::::::::::::::::::::::::::::::;
 c        interpolate initial values for the newly created grids.
@@ -70,7 +66,7 @@ c
                 mx = mitot - 2*nghost
                 my = mjtot - 2*nghost
                 call setaux(nghost,mx,my,corn1,corn2,hx,hy,
-     &                    naux,alloc(locaux),aux_copy_mask)
+     &                    naux,alloc(locaux))
               else
                 locaux = 1
               endif

--- a/src/2d/shallow/ginit.f
+++ b/src/2d/shallow/ginit.f
@@ -7,10 +7,6 @@ c
       implicit double precision (a-h,o-z)
       logical first
 
-c     Aux masking copy storage
-      integer(kind=1) :: aux_copy_mask(max1d, max1d)
-      aux_copy_mask = 0
-
 
 c ::::::::::::::::::::::::::::: GINIT ::::::::::::::::::::::::
 c
@@ -40,7 +36,7 @@ c :::::::::::::::::::::::::::::::::::::::;::::::::::::::::::::
                 mx = mitot - 2*nghost
                 my = mjtot - 2*nghost
                 call setaux(nghost,mx,my,corn1,corn2,hx,hy,
-     &                    naux,alloc(locaux),aux_copy_mask)
+     &                    naux,alloc(locaux))
               else 
                 locaux = 1
               endif

--- a/src/2d/shallow/movetopo.f
+++ b/src/2d/shallow/movetopo.f
@@ -18,15 +18,10 @@ c
       implicit double precision (a-h,o-z)
       dimension aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc)
       dimension dtopo(mxdtopo,mydtopo,mtdtopo)
-    
-c     Aux masking copy storage
-      integer(kind=1) :: aux_copy_mask(1-mbc:mx+mbc, 1-mbc:my+mbc)
 
       logical topoaltered
 
       dimension auxorig(maux,-1:mx+mbc,-1:my+mbc)
-
-      aux_copy_mask = 0
 
         t0=t  !# start of coming timestep
         tf=t+dt !# end of coming timestep
@@ -82,7 +77,7 @@ c       write(26,*) 'MOVETOPO: setting dtopo at time = ',t
 
 c     # recreate original topography:
       call setaux(mbc,mx,my,xlow,ylow,dx,dy,
-     &                  maux,auxorig,aux_copy_mask)
+     &                  maux,auxorig)
 
 c=======loop through the computational grid row by row====================
         do j=1-mbc,my+mbc

--- a/src/2d/shallow/setaux.f90
+++ b/src/2d/shallow/setaux.f90
@@ -1,4 +1,4 @@
-subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux,aux_copy_mask)
+subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux)
 !     ============================================
 !
 !     # set auxiliary arrays
@@ -22,7 +22,6 @@ subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux,aux_copy_mask)
     integer, intent(in) :: mbc,mx,my,maux
     real(kind=8), intent(in) :: xlow,ylow,dx,dy
     real(kind=8), intent(inout) :: aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc)
-    integer(kind=1), intent(in) :: aux_copy_mask(1-mbc:mx+mbc,1-mbc:my+mbc)
     
     ! Locals
     integer :: i,j,m


### PR DESCRIPTION
This reverts commit 94998a3875ff03429e91b3e8c7addf81a3279e2f, reversing
changes made to d252f7bc04abff67d3c40ae5698a7a88f679804e.

We decided there is a better way to flag aux arrays by using aux(1,i,j)
for the flag instead of introducing a new array aux_copy_mask.

For now, revert this commit and leave code alone for 5.0.0 and then add
the flagging to 5.1, without needing to change the calling sequence of
setaux.
