### PR TITLE
Adding zeroing of very small values in gauge output

### DIFF
--- a/src/2d/shallow/dumpgauge.f
+++ b/src/2d/shallow/dumpgauge.f
@@ -101,14 +101,14 @@ c velocities are zeroed out which can then lead to increase in h again.
      &                 + xoff * yoff * aux(1,iindex+1,jindex+1)
               endif
 
+          ! Extract surfaces
+          eta = var(1) + topo
+
           ! Zero out tiny values to prevent later problems reading data,
           ! as done in valout.f
           do j = 1,3
              if (abs(var(j)) < 1d-90) var(j) = 0.d0
           end do
-              
-          ! Extract surfaces
-          eta = var(1) + topo
           if (abs(eta) < 1d-90) eta = 0.d0
 
 !$OMP CRITICAL (gaugeio)


### PR DESCRIPTION
I just ran into some tiny values in gauge output, which made the Python loading code choke, and decided to put that part of the valout code into dumpgauge as well.
