### PR TITLE
Moved call to topo_update to advanc

### DIFF
--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -5,6 +5,8 @@ c
 c
       use amr_module
       use fixedgrids_module
+      use topo_module, only: topo_finalized
+
       implicit double precision (a-h,o-z)
 
 
@@ -76,6 +78,10 @@ c      call fgrid_advance(time,delt)
       
       dtlevnew = rinfinity
       cfl_level = 0.d0    !# to keep track of max cfl seen on each level
+
+      if (.not. topo_finalized) then
+         call topo_update(time)
+         endif
 c 
         
 

--- a/src/2d/shallow/b4step2.f90
+++ b/src/2d/shallow/b4step2.f90
@@ -15,7 +15,7 @@ subroutine b4step2(mbc,mx,my,meqn,q,xlower,ylower,dx,dy,t,dt,maux,aux)
     use geoclaw_module, only: dry_tolerance
     use geoclaw_module, only: g => grav
     use topo_module, only: num_dtopo,topotime
-    use topo_module, only: tfdtopo,t0dtopo,topo_finalized,aux_finalized
+    use topo_module, only: aux_finalized
     use topo_module, only: xlowdtopo,xhidtopo,ylowdtopo,yhidtopo
 
     use amr_module, only: xlowdomain => xlower
@@ -48,12 +48,7 @@ subroutine b4step2(mbc,mx,my,meqn,q,xlower,ylower,dx,dy,t,dt,maux,aux)
         q(2:3,i,j) = 0.d0
     end forall
 
-    ! update topography if needed
-    !if ((num_dtopo>0).and.(topo_finalized.eqv..false.)) then
 
-    if (.not. topo_finalized) then
-        call topo_update(t)
-        endif
     if (aux_finalized < 2) then
         ! topo arrays might have been updated by dtopo more recently than
         ! aux arrays were set unless at least 1 step taken on all levels

--- a/src/2d/shallow/filpatch.f90
+++ b/src/2d/shallow/filpatch.f90
@@ -166,12 +166,6 @@ recursive subroutine filrecur(level,num_eqn,valbig,aux,num_aux,t,mx,my, &
         ! grids
         
         if (num_aux > 0) then
-            ! update topography if needed
-            !if ((num_dtopo>0).and.(topo_finalized.eqv..false.)) then
-            !   if ((minval(topotime)<maxval(tfdtopo)).and.(t>=minval(t0dtopo))) then
-            if (.not. topo_finalized) then
-                call topo_update(t)
-                endif
 
             nghost_patch = 0                           
             call setaux(nghost_patch, mx_coarse, my_coarse,       &


### PR DESCRIPTION
Moved call to topo_update to advanc and removed from b4step2 and filrecur routines.  This call is now before the parallel threads are launched to loop over grids so should be thread safe, and also means topo_update is only called once at this time rather than unnecessarily for every grid.  Still need to check if there are other places we need to update topo during regridding, for example.
