### PR TITLE
Fix seg-fault where synthetic topo was used

### DIFF
--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -165,7 +165,7 @@ c     all aux arrays are consistent with the final topography.
 c     The variable aux_finalized is incremented so that we can check
 c     if this is true by checking if aux_finalized == 2 elsewhere in code.
 
-	  if (aux_finalized .eq. 1) then
+	  if (aux_finalized .eq. 1 .and. num_dtopo > 0) then
 c         # this is only true once, and only if there was moving topo
           deallocate(topo0work)
           endif 

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -288,12 +288,14 @@ contains
         !---------------tests for analytic bathymetry-------------------
         ! Simple jump discontinuity in bathymetry
         else if (test_topography == 1) then
+            topo_finalized = .true.
             read(iunit,"(d16.8)") topo_location
             read(iunit,"(d16.8)") topo_left
             read(iunit,"(d16.8)") topo_right
 
         ! Idealized ocean shelf
         else if (test_topography == 2 .or. test_topography == 3) then
+            topo_finalized = .true.
             read(iunit,"(d16.8)") topo_x0
             read(iunit,"(d16.8)") topo_x1
             read(iunit,"(d16.8)") topo_x2


### PR DESCRIPTION
Since it is not clear how to deal with synthetic topography with dtopo files
it is left up to the specification of the topography to determine the changing
topography if applicable.  This patch corrects for the fact that certain
parameters were not being set (which caused a seg-fault) and also removes
a deallocation problem.
