### PR TITLE
Fix `input_units` bug

### DIFF
--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -606,7 +606,7 @@ class Fault(object):
                 raise ValueError("Input parameter subfaults must be a list.")
             self.subfaults = subfaults
             for subfault in self.subfaults:
-                subfault.convert_to_standard_units(input_units)
+                subfault.convert_to_standard_units(self.input_units)
 
 
     def read(self, path, column_map, coordinate_specification="centroid",


### PR DESCRIPTION
If `input_units` were not being specified to the `Fault` class the updated
dictionary was not being used (the input, which was `None`, was being used
instead).