### PR TITLE
Remove test in src/2d/shallow/filval.f90 that xl==xl2 and yb==yb2 

### DIFF
--- a/src/2d/shallow/filval.f90
+++ b/src/2d/shallow/filval.f90
@@ -52,7 +52,6 @@ subroutine filval(val, mitot, mjtot, dx, dy, level, time,  mic, &
     ! External function definitions
     real(kind=8) :: get_max_speed
 
-    real(kind=8) :: xl2,yb2
 
     refinement_ratio_x = intratx(level-1)
     refinement_ratio_y = intraty(level-1)
@@ -97,16 +96,10 @@ subroutine filval(val, mitot, mjtot, dx, dy, level, time,  mic, &
         endif
 
         if (aux_finalized < 2) then
-            xl2 = xlower + iclo*dx_coarse
-            yb2 = ylower + jclo*dy_coarse
-            if ((abs(xl-xl2) > 1.d-13) .or. (abs(yb-yb2) > 1.d-13)) then
-                write(6,*) '*** xl,xl2,yb,by2: '
-                write(6,*) xl,xl2,yb,yb2
-                stop
-            endif
             call setaux(0,mic,mjc,xl,yb,dx_coarse,dy_coarse,naux,auxc)
         endif
     endif
+
     call bc2amr(valc,auxc,mic,mjc,nvar,naux,dx_coarse,dy_coarse,level-1,time,xl,xr,yb, &
                 yt,xlower,ylower,xupper,yupper,xperdom,yperdom,spheredom)
 


### PR DESCRIPTION
Remove test in src/2d/shallow/filval.f90 that xl==xl2 and yb==yb2 -- originally for debugging in @ca673af7d and uses absolute error in way that can fail, as discovered by a user,
 https://groups.google.com/forum/?fromgroups#!topic/claw-users/NO0m1UAczw4