### PR TITLE
[WIP] Topotypes 2 and 3 - parse values to allow dx and dy on cellsize line

### DIFF
--- a/src/2d/shallow/test_parse_values.f90
+++ b/src/2d/shallow/test_parse_values.f90
@@ -1,0 +1,42 @@
+
+
+program test_parse_values
+
+    ! To test: select a test below and then:
+    !    gfortran utility_module.f90 test_parse_values.f90 
+    !    ./a.out
+
+    use utility_module, only: parse_values
+    use topo_module, only: read_topo_header
+
+    implicit none
+    character(len=150) str,fname
+    integer :: n,i,topo_type,mx,my
+    real(kind=8) :: values(10), xll,yll,xhi,yhi,dx,dy
+
+    if (.true.) then
+        write(6,*) 'input line with mix of character strings and numbers...'
+        read(5,'(a)') str
+        write(6,*) 'read in str  = ',str
+
+        call parse_values(trim(str), n, values)
+        write(6,*) 'n = ',n
+        write(6,*) 'values = ',(values(i), i=1,n)
+        write(6,*) 'integer values = ',(nint(values(i)), i=1,n)
+        endif
+
+    if (.false.) then
+        ! requires also compiling amr_module, topo_module, and setting path:
+        fname = '/Users/rjl/topo/etopo/etopo4min100E69W70S70N.asc'
+        !fname = '/Users/rjl/topo/etopo/etopo4min180E65W65S0N.asc'
+        topo_type = 3
+        call read_topo_header(fname,topo_type,mx,my,xll,yll,xhi,yhi,dx,dy)
+        write(6,*) 'mx = ',mx
+        write(6,*) 'my = ',my
+        write(6,*) 'xll = ',xll
+        write(6,*) 'yll = ',yll
+        write(6,*) 'dx = ',dx
+        write(6,*) 'dy = ',dy
+        endif
+
+end program test_parse_values

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -558,9 +558,11 @@ contains
 
         ! Local
         integer, parameter :: iunit = 19
-        integer :: topo_size, status
+        integer :: topo_size, status, n
         real(kind=8) :: x,y,z,nodata_value
         logical :: found_file
+        real(kind=8) :: values(10)
+        character(len=80) :: str
 
         inquire(file=fname,exist=found_file)
         if (.not. found_file) then
@@ -612,13 +614,32 @@ contains
 
             ! ASCII file with header followed by z data
             case(2:3)
-                read(iunit,*) mx
-                read(iunit,*) my
-                read(iunit,*) xll
-                read(iunit,*) yll
-                read(iunit,*) dx
-                read(iunit,*) nodata_value
-                dy = dx
+                read(iunit,'(a)') str
+                call parse_values(str, n, values)
+                mx = nint(values(1))
+
+                read(iunit,'(a)') str
+                call parse_values(str, n, values)
+                my = nint(values(1))
+
+                read(iunit,'(a)') str
+                call parse_values(str, n, values)
+                xll = values(1)
+
+                read(iunit,'(a)') str
+                call parse_values(str, n, values)
+                yll = values(1)
+
+                read(iunit,'(a)') str
+                call parse_values(str, n, values)
+                dx = values(1)
+                if (n == 2) then
+                    dy = values(2)
+                  else
+                    dy = dx
+                  endif
+                call parse_values(str, n, values)
+                nodata_value = values(1)
                 xhi = xll + (mx-1)*dx
                 yhi = yll + (my-1)*dy
 

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -458,7 +458,10 @@ contains
                 do i=1,5
                     read(iunit,*)
                 enddo
-                read(iunit,*) no_data_value
+                
+                read(iunit,'(a)') str
+                call parse_values(str, n, values)
+                no_data_value = values(1)
 
                 ! Read in data
                 missing = 0
@@ -639,8 +642,11 @@ contains
                   else
                     dy = dx
                   endif
+
+                read(iunit,'(a)') str
                 call parse_values(str, n, values)
                 nodata_value = values(1)
+
                 xhi = xll + (mx-1)*dx
                 yhi = yll + (my-1)*dy
 

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -547,6 +547,7 @@ contains
     subroutine read_topo_header(fname,topo_type,mx,my,xll,yll,xhi,yhi,dx,dy)
 
         use geoclaw_module
+        use utility_module, only: parse_values
 
         implicit none
 

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -402,6 +402,7 @@ contains
     subroutine read_topo_file(mx,my,topo_type,fname,topo)
 
         use geoclaw_module
+        use utility_module, only: parse_values
 
         implicit none
 
@@ -414,8 +415,10 @@ contains
         integer, parameter :: iunit = 19, miss_unit = 17
         real(kind=8), parameter :: topo_missing = -150.d0
         logical, parameter :: maketype2 = .false.
-        integer :: i,j,num_points,missing,status,topo_start
+        integer :: i,j,num_points,missing,status,topo_start,n
         real(kind=8) :: no_data_value,x,y,z,topo_temp
+        real(kind=8) :: values(10)
+        character(len=20) :: str
 
         print *, ' '
         print *, 'Reading topography file  ', fname

--- a/src/2d/shallow/utility_module.f90
+++ b/src/2d/shallow/utility_module.f90
@@ -45,4 +45,53 @@ Contains
     end function convert2days
 
 
+    !======================================
+    subroutine parse_values(str, n, values)
+    !======================================
+
+    ! Take the input string `str` and parse it to extract any numerical values,
+    ! ignoring any character strings. 
+    ! Returns `n` values in array `values`. 
+    ! Assumes n <= 10.
+    ! If you expect value(i) to be an integer, evaluate as nint(value(i)).
+
+    implicit none
+
+    character(len=*), intent(in) :: str
+    integer, intent(out) :: n
+    real(kind=8), intent(out) :: values(10)
+
+    integer :: pos2,nw,i,e
+    character(len=80) :: word(10), str2
+    real(kind=8) :: x
+
+    nw = 0
+    str2 = trim(adjustl(str))
+    do while (len(trim(adjustl(str2))) > 0) 
+        pos2 = index(str2, " ")
+        
+        if (pos2 == 0) then
+           nw = nw + 1
+           word(nw) = trim(adjustl(str2))
+           exit
+           endif
+
+        nw = nw + 1
+        word(nw) = trim(adjustl(str2(1:pos2-1)))
+        str2 = trim(adjustl(str2(pos2+1:)))
+        enddo
+
+    n = 0
+    do i=1,nw
+        read(word(i),*,IOSTAT=e) x
+        if (e == 0) then
+            ! this token is numerical
+            n = n+1
+            values(n) = x
+            endif
+        enddo
+
+
+    end subroutine parse_values
+
 end module utility_module

--- a/src/2d/shallow/utility_module.f90
+++ b/src/2d/shallow/utility_module.f90
@@ -65,6 +65,9 @@ Contains
     character(len=80) :: word(10), str2
     real(kind=8) :: x
 
+    ! First break into words / tokens based on white space.  
+    ! Each might be character or numerical:
+
     nw = 0
     str2 = trim(adjustl(str))
     do while (len(trim(adjustl(str2))) > 0) 
@@ -81,6 +84,7 @@ Contains
         str2 = trim(adjustl(str2(pos2+1:)))
         enddo
 
+    ! now extract numerical values:
     n = 0
     do i=1,nw
         read(word(i),*,IOSTAT=e) x

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -953,9 +953,10 @@ class Topography(object):
            Must be in the form (x lower,x upper,y lower, y upper).
          - *method* (string) - Method used for interpolation, valid methods are
            found in *scipy.interpolate.griddata*.  Default is *nearest*.
-         - *delta* (float) - Directly set the grid spacing of the interpolation
+         - *delta* (tuple) - Directly set the grid spacing of the interpolation
            rather than determining it from the data itself.  Defaults to *None*
            which causes the method to determine this value itself.
+           Should be a 2-tuple of floats (delta_x, delta_y).
          - *delta_limit* (float) - Limit of finest horizontal resolution, 
            default is 20 meters.
          - *no_data_value* (float) - Value to use if no data was found to fill in a 
@@ -992,11 +993,16 @@ class Topography(object):
                        numpy.min(self.y) - buffer_degrees, 
                        numpy.max(self.y) + buffer_degrees ]
         if delta is None:
-            delta = max( min(numpy.min(numpy.abs(self.x[1:] - self.x[:-1])), 
-                             numpy.min(numpy.abs(self.y[1:] - self.y[:-1])) ),
-                        delta_degrees)
-        N = ( numpy.ceil((extent[1] - extent[0]) / delta),
-              numpy.ceil((extent[3] - extent[2]) / delta) )
+            delta_x = max( numpy.abs(self.x[1:] - self.x[:-1]), delta_degrees)
+            delta_y = max( numpy.abs(self.y[1:] - self.y[:-1]), delta_degrees)
+        else:   
+            try:
+                delta_x, delta_y = delta   # tuple provided
+            except:
+                delta_x = delta_y = delta  # assume float provided
+                
+        N = ( numpy.ceil((extent[1] - extent[0]) / delta_x),
+              numpy.ceil((extent[3] - extent[2]) / delta_y) )
         if not numpy.all(N[:] < numpy.ones((2)) * resolution_limit):
             ValueError("Calculated resolution too high, N=%s!" % str(N))
         self._X, self._Y = numpy.meshgrid( 
@@ -1090,7 +1096,7 @@ class Topography(object):
                                                                   method=method)
 
         self._extent = extent
-        self._delta = delta
+        self._delta = (delta_x, delta_y)
         self.unstructured = False
 
 

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -703,11 +703,30 @@ class Topography(object):
                 num_cells[1] = int(topo_file.readline().split()[value_index])
                 self._extent[0] = float(topo_file.readline().split()[value_index])
                 self._extent[2] = float(topo_file.readline().split()[value_index])
-                self._delta = float(topo_file.readline().split()[value_index])
+                # parse line allowing possibility of dx and dy (or just dx=dy)
+                line = topo_file.readline()
+                tokens = line.split() 
+                values = []
+                for token in tokens:
+                    try:
+                        v = float(token)
+                        values.append(v)
+                    except:
+                        pass
+                if len(values) == 1:
+                    self._delta = (values[0], values[0]) # if only dx given
+                elif len(values) == 2:
+                    self._delta = (values[0], values[1])  # if dx,dy on line
+                else:
+                    raise IOError("Cannot parse dx,dy line: %s" % line)
+                    
+                        
                 self.no_data_value = float(topo_file.readline().split()[value_index])
                 
-                self._extent[1] = self._extent[0] + (num_cells[0]-1)*self.delta
-                self._extent[3] = self._extent[2] + (num_cells[1]-1)*self.delta
+                self._extent[1] = self._extent[0] + \
+                                    (num_cells[0]-1)*self._delta[0]
+                self._extent[3] = self._extent[2] + \
+                                    (num_cells[1]-1)*self._delta[1]
 
         else:
             raise IOError("Cannot read header for topo_type %s" % self.topo_type)

--- a/tests/test_topotools.py
+++ b/tests/test_topotools.py
@@ -249,7 +249,7 @@ def test_unstructured_topo(save=False, plot=False):
         topo.plot(axes=axes, region_extent=[0, 1, 0, 1])
         axes.set_title("Unstructured Field")
 
-    topo.interp_unstructured(fill_topo, extent=[0, 1, 0, 1], delta=1e-2)
+    topo.interp_unstructured(fill_topo, extent=[0, 1, 0, 1], delta=(1e-2,1e-2))
     assert not topo.unstructured
 
     # Load (and save) test data and make the comparison


### PR DESCRIPTION
Replaces #134.

Allows dx and dy on the same line for topotype 2,3 rather than introducing new topotypes. 

Also allows values or labels to come first, so `topotools.swapheader` does not need to be applied to data from NGDC.  Not yet fully tested.

The new subroutine `parse_values` in `utility_module.f90` might be useful more generally.  Contains ugly string manipulation in Fortran -- maybe someone knows a better way to write this...

@mandli: I haven't yet rewritten the Python tools yet to support this.  Is it ok to change `Topography.delta` to always be a tuple `(dx,dy)` as in #134?
