### PR TITLE
Initialize `tcfmax` to `-rinfinity`

### DIFF
--- a/src/2d/shallow/stepgrid.f
+++ b/src/2d/shallow/stepgrid.f
@@ -46,7 +46,7 @@ c      dimension work(mwork)
       logical :: debug = .false.
       logical :: dump = .false.
 c
-      
+      tcfmax = -rinfinity
       level = node(nestlevel,mptr)
 
       if (dump) then


### PR DESCRIPTION
This fixes an uninitialized variable problem that almost never became an issue although in principle could have.  It will stop execution if the compiler was instructed to watch for uninitialized variables.  I think that setting `tcfmax = -rinfinity` should work but if there is a more sensible setting then let me know.