### PR TITLE
fix Makefiles in tests that pointed to wrong amr2.f90

### DIFF
--- a/tests/dtopo1/Makefile
+++ b/tests/dtopo1/Makefile
@@ -83,7 +83,7 @@ SOURCES = \
   $(AMRLIB)/trimbd.f90 \
   $(AMRLIB)/bound.f90 \
   $(AMRLIB)/intfil.f90 \
-  $(AMRLIB)/amr2.f90 \
+  $(GEOLIB)/amr2.f90 \
   $(GEOLIB)/fgmax_read.f90 \
   $(GEOLIB)/fgmax_frompatch.f90 \
   $(GEOLIB)/fgmax_interpolate.f90 \

--- a/tests/storm_surge/Makefile
+++ b/tests/storm_surge/Makefile
@@ -83,7 +83,7 @@ SOURCES = \
   $(AMRLIB)/trimbd.f90 \
   $(AMRLIB)/bound.f90 \
   $(AMRLIB)/intfil.f90 \
-  $(AMRLIB)/amr2.f90 \
+  $(GEOLIB)/amr2.f90 \
   $(GEOLIB)/fgmax_read.f90 \
   $(GEOLIB)/fgmax_frompatch.f90 \
   $(GEOLIB)/fgmax_interpolate.f90 \


### PR DESCRIPTION
Needed by #156.