### PR TITLE
Test GeoClaw run without matplotlib install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
   - sudo apt-get install gfortran liblapack-dev
   # Print NumPy version that is already installed by Travis CI:
   - python -c "import numpy; print numpy.__version__"
-  - python -c "import matplotlib; print matplotlib.__version__"
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - python setup.py symlink-only

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ before_install:
   - sudo apt-get install gfortran liblapack-dev
   # Print NumPy version that is already installed by Travis CI:
   - python -c "import numpy; print numpy.__version__"
-  - pip install matplotlib
   - python -c "import matplotlib; print matplotlib.__version__"
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack

--- a/tests/test_topotools.py
+++ b/tests/test_topotools.py
@@ -116,9 +116,8 @@ def test_against_old():
     # matplotlib is not available (like on Travis)
     try:
         import matplotlib
-    except ImportError as ie:
-        print "Skipping test against old topotools due to missing matplotlib" +
-              " module."
+    except ImportError:
+        print "Skipping test against old topotools due to missing matplotlib."
         return True
 
     import old_topotools

--- a/tests/test_topotools.py
+++ b/tests/test_topotools.py
@@ -112,6 +112,15 @@ def test_against_old():
     Compare bowl.tt1 to bowl_old.tt1
     """
 
+    # This test requires matplotlib for the legacy topofile2griddate so skip if
+    # matplotlib is not available (like on Travis)
+    try:
+        import matplotlib
+    except ImportError as ie:
+        print "Skipping test against old topotools due to missing matplotlib" +
+              " module."
+        return True
+
     import old_topotools
 
     nxpoints = 5


### PR DESCRIPTION
This removes most of the dependency on matplotlib from GeoClaw and "skips" the tests that require it.  This includes only the comparison with the legacy `topotools` module.