### PR TITLE
Convert all non-conforming tabs to spaces

### DIFF
--- a/src/2d/shallow/fgmax_interpolate.f90
+++ b/src/2d/shallow/fgmax_interpolate.f90
@@ -129,8 +129,8 @@ subroutine fgmax_interpolate(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
     call fgmax_values(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
                    xlower,ylower,mask_patch,values)
     if (debug) then
-		write(65,*) '+++ i,j,x,y,values(1,i,j) '
-		write(65,*) '    at points where mask_patch(i,j) == .true.'
+        write(65,*) '+++ i,j,x,y,values(1,i,j) '
+        write(65,*) '    at points where mask_patch(i,j) == .true.'
         do i=1-mbc,mx+mbc
             x = xlower + (i-0.5d0)*dx
             do j=1-mbc,my+mbc

--- a/src/2d/shallow/fgmax_interpolate0.f90
+++ b/src/2d/shallow/fgmax_interpolate0.f90
@@ -126,8 +126,8 @@ subroutine fgmax_interpolate(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
     call fgmax_values(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
                    xlower,ylower,mask_patch,values)
     if (debug) then
-		write(65,*) '+++ i,j,x,y,values(1,i,j) '
-		write(65,*) '    at points where mask_patch(i,j) == .true.'
+        write(65,*) '+++ i,j,x,y,values(1,i,j) '
+        write(65,*) '    at points where mask_patch(i,j) == .true.'
         do i=1-mbc,mx+mbc
             x = xlower + (i-0.5d0)*dx
             do j=1-mbc,my+mbc

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -167,7 +167,7 @@ c     all aux arrays are consistent with the final topography.
 c     The variable aux_finalized is incremented so that we can check
 c     if this is true by checking if aux_finalized == 2 elsewhere in code.
 
-	  if (aux_finalized .eq. 1 .and. num_dtopo > 0) then
+      if (aux_finalized .eq. 1 .and. num_dtopo > 0) then
 c         # this is only true once, and only if there was moving topo
           deallocate(topo0work)
           endif 


### PR DESCRIPTION
Minor changes to remove tabs from source (gcc 5.x have changed these from warnings to errors by default).