### PR TITLE
bc2amr calling sequence wrong in amrclaw routines

### DIFF
--- a/src/2d/shallow/bound.f90
+++ b/src/2d/shallow/bound.f90
@@ -1,0 +1,128 @@
+!
+!  :::::::::::::: BOUND :::::::::::::::::::::::::::::::::::::::::::
+!     This routine sets the boundary values for a given grid 
+!     at level level.
+!     We are setting the values for a strip ng zones wide all
+!     the way around the border, in 4 rectangular strips.
+!
+!     Outputs from this routine:
+!     The values around the border of the grid are inserted
+!     directly into the enlarged valbig array.
+!
+!     This routine calls the routine filpatch
+!     which for any block of mesh points on a given level,
+!     intersects that block with all grids on that level and with
+!     the physical boundaries, copies the values into the
+!     appropriate intersecting regions, and interpolates the remaining
+!     cells from coarser grids as required.
+! :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+subroutine bound(time,nvar,ng,valbig,mitot,mjtot,mptr,aux,naux)
+
+  use amr_module, only: rnode, node, hxposs, hyposs, cornxlo, cornxhi
+  use amr_module, only: cornylo, cornyhi, ndilo, ndihi, ndjlo, ndjhi
+  use amr_module, only: nestlevel, xlower, xupper, ylower, yupper
+  use amr_module, only: xperdom, yperdom, spheredom
+
+  implicit none
+
+  ! Input
+  integer, intent(in) :: nvar, ng, mitot, mjtot, mptr, naux
+  real(kind=8), intent(in) :: time
+  real(kind=8), intent(in out) :: valbig(nvar,mitot,mjtot)
+  real(kind=8), intent(in out) :: aux(naux,mitot,mjtot)
+
+  ! Locals
+  integer :: ilo, ihi, jlo, jhi, level  ! rect(4)
+  real(kind=8) :: xleft, xright, ybot, ytop, hx, hy, xl, xr, yb, yt
+  real(kind=8) :: xloWithGhost,  xhiWithGhost,  yloWithGhost, yhiWithGhost
+  logical      :: patchOnly
+
+  xleft  = rnode(cornxlo, mptr)
+  xright = rnode(cornxhi, mptr)
+  ybot   = rnode(cornylo, mptr)
+  ytop   = rnode(cornyhi, mptr)
+  ilo    = node(ndilo, mptr)
+  ihi    = node(ndihi, mptr)
+  jlo    = node(ndjlo, mptr)
+  jhi    = node(ndjhi, mptr)
+  level  = node(nestlevel, mptr)
+  hx     = hxposs(level)
+  hy     = hyposs(level)
+
+  xloWithGhost = xleft  - ng*hx
+  xhiWithGhost = xright + ng*hx
+  yloWithGhost =  ybot  - ng*hy
+  yhiWithGhost =  ytop  + ng*hy
+  ! used in filaptch for bc2amr: for patches it is called. for full grids called from bound below
+  patchOnly = .false.  
+
+
+
+
+  ! left boundary
+  xl = xleft - ng*hx
+  xr = xleft
+  yb = ybot 
+  yt = ytop
+  if ((xl < xlower) .and. xperdom) then
+     call  prefilrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot,1,ng+1, &
+          ilo-ng,ilo-1,jlo,jhi,ilo-ng,ihi+ng,jlo-ng,jhi+ng,patchOnly)
+  else
+     call filrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot,1,ng+1,ilo-ng,ilo-1,jlo,jhi,patchOnly)
+  endif
+
+  ! right boundary
+  xl = xright
+  xr = xright + ng*hx
+  yb = ybot
+  yt = ytop
+
+  if ((xr .gt. xupper) .and. xperdom) then
+     call  prefilrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot, &
+          mitot-ng+1,ng+1,ihi+1,ihi+ng,jlo,jhi,ilo-ng,ihi+ng,jlo-ng,jhi+ng,patchOnly)
+  else
+     call filrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot, &
+          mitot-ng+1,ng+1,ihi+1,ihi+ng,jlo,jhi,patchOnly)
+  endif
+
+  ! bottom boundary
+  xl = xleft  - ng*hx
+  xr = xright + ng*hx
+  yb = ybot - ng*hy
+  yt = ybot
+
+  if ( ((yb < ylower) .and. (yperdom .or. spheredom)) .or. &
+       ( ((xl < xlower) .or. (xr > xupper)) .and. xperdom) ) then
+     call prefilrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot,   &
+                      1,1,ilo-ng,ihi+ng,jlo-ng,jlo-1,                &
+                      ilo-ng,ihi+ng,jlo-ng,jhi+ng,patchOnly)
+  else
+     call filrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot,1,1,ilo-ng,ihi+ng,jlo-ng,jlo-1,patchOnly)
+  endif
+
+
+  ! top boundary
+  xl = xleft - ng*hx
+  xr = xright + ng*hx
+  yb = ytop
+  yt = ytop + ng*hy
+
+  if ( ((yt .gt. yupper) .and. (yperdom .or. spheredom)) .or. &
+       (((xl .lt. xlower) .or. (xr .gt. xupper)) .and. xperdom) ) then
+     call prefilrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot, &
+          1,mjtot-ng+1,ilo-ng,ihi+ng,jhi+1,jhi+ng,ilo-ng,ihi+ng,jlo-ng,jhi+ng,patchOnly)
+  else
+     call filrecur(level,nvar,valbig,aux,naux,time,mitot,mjtot, &
+          1,mjtot-ng+1,ilo-ng,ihi+ng,jhi+1,jhi+ng,patchOnly)
+  endif
+
+
+  ! set all exterior (physical)  boundary conditions for this grid at once
+  ! used to be done from filpatch, but now only for recursive calls with new patch
+  ! where the info matches. more efficient to do whole grid at once, and avoid copying
+       write(34,*) '+++ in bound, spheredom = ',spheredom
+
+  call bc2amr(valbig,aux,mitot,mjtot,nvar,naux,hx,hy,level,time,xloWithGhost,xhiWithGHost, &
+       yloWithGhost,yhiWithGhost,xlower,ylower,xupper,yupper,xperdom,yperdom,spheredom)
+
+end subroutine bound

--- a/src/2d/shallow/bound.f90
+++ b/src/2d/shallow/bound.f90
@@ -123,6 +123,6 @@ subroutine bound(time,nvar,ng,valbig,mitot,mjtot,mptr,aux,naux)
        write(34,*) '+++ in bound, spheredom = ',spheredom
 
   call bc2amr(valbig,aux,mitot,mjtot,nvar,naux,hx,hy,level,time,xloWithGhost,xhiWithGHost, &
-       yloWithGhost,yhiWithGhost,xlower,ylower,xupper,yupper,xperdom,yperdom,spheredom)
+       yloWithGhost,yhiWithGhost,xperdom,yperdom,spheredom)
 
 end subroutine bound

--- a/src/2d/shallow/saveqc.f
+++ b/src/2d/shallow/saveqc.f
@@ -1,0 +1,112 @@
+c
+c  ================================================================
+      subroutine saveqc(level,nvar,naux)
+c  ================================================================
+c
+      use amr_module
+      implicit double precision (a-h,o-z)
+      
+      !for setaux timing
+      integer :: clock_start, clock_finish, clock_rate
+      real(kind=8) :: cpu_start, cpu_finish
+      
+
+      logical sticksout, found
+!     make fliparray largest possible grid size
+      dimension fliparray(2*max1d*nghost*(nvar+naux))
+c
+c ::::::::::::::::::::::::: SAVEQC :::::::::::::::::::::::::::::::::
+c  prepare new fine grids to save fluxes after each integration step
+c  for future conservative fix-up on coarse grids.
+c  save all boundary fluxes of fine grid (even if on a  phys. bndry.) -
+c  but only save space for every intrat of them. 
+c:::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
+c
+      levc = level - 1
+      hxc  = hxposs(levc)
+      hyc  = hyposs(levc)
+      ng   = 0  ! no ghost cells on coarsened enlarged patch
+
+      mkid = lstart(level)
+ 10   if (mkid .eq. 0) go to 99
+          nx    = node(ndihi,mkid)-node(ndilo,mkid) + 1
+          ny    = node(ndjhi,mkid)-node(ndjlo,mkid) + 1
+          ikeep = nx/intratx(level-1)
+          jkeep = ny/intraty(level-1)
+          lenbc = 2*(ikeep+jkeep)
+          ist   = node(ffluxptr,mkid)
+          time = rnode(timemult,mkid)
+
+c         make coarsened enlarged patch for conservative fixup
+          ilo = node(ndilo,mkid)
+          jlo = node(ndjlo,mkid)
+          ihi = node(ndihi,mkid)
+          jhi = node(ndjhi,mkid)
+          iclo = ilo/intratx(level-1) - 1
+          jclo = jlo/intraty(level-1) - 1
+          ichi = (ihi+1)/intratx(level-1)
+          jchi = (jhi+1)/intraty(level-1)
+          nrow = ichi-iclo+1
+          ncol = jchi-jclo+1
+          xl   = rnode(cornxlo,mkid) - hxc
+          yb   = rnode(cornylo,mkid) - hyc
+          xr   = rnode(cornxhi,mkid) + hxc
+          yt   = rnode(cornyhi,mkid) + hyc
+          loctmp = igetsp(nrow*ncol*(nvar+naux))
+          loctx  = loctmp + nrow*ncol*nvar
+          do i = 1, nrow*ncol*naux
+             alloc(loctx+i-1) = NEEDS_TO_BE_SET
+          end do
+          locaux = node(storeaux,mkid)
+
+          if (iclo .lt. 0 .or. ichi .eq. iregsz(levc) .or.
+     &        jclo .lt. 0 .or. jchi .eq. jregsz(levc)) then
+            sticksout = .true.
+          else
+            sticksout = .false.
+          endif
+
+          if (sticksout .and. (xperdom.or.yperdom.or.spheredom)) then
+             !iperim = nrow+ncol 
+             !locflip = igetsp(iperim*nghost*(nvar+naux))
+             call preicall(alloc(loctmp),alloc(loctx),nrow,ncol,nvar,
+     .                     naux,iclo,ichi,jclo,jchi,level-1,
+     .                     fliparray)
+!     .                     alloc(locflip))
+!             call reclam(locflip,iperim*nghost*(nvar+naux))
+          else 
+             call icall(alloc(loctmp),alloc(loctx),nrow,ncol,nvar,naux,
+     .                   iclo,ichi,jclo,jchi,level-1,1,1)
+          endif
+!         in case any part sticks out of domain still need to set remaining aux
+!         cells
+          if (naux .gt. 0 .and. sticksout) then  
+             call system_clock(clock_start,clock_rate)
+             call cpu_time(cpu_start)
+             call setaux(ng,nrow,ncol,xl,yb,hxc,hyc,naux,alloc(loctx))
+             call system_clock(clock_finish,clock_rate)
+             call cpu_time(cpu_finish)
+             timeSetaux = timeSetaux + clock_finish - clock_start
+             timeSetauxCPU = timeSetauxCPU + cpu_finish - cpu_start
+          endif
+!--          found = .false.
+!--          do i = 1, naux*nrow*ncol, naux
+!--             if (alloc(loctx+i-1) .eq. NEEDS_TO_BE_SET) then
+!--                 found = .true.
+!--             endif
+!--          end do
+!--          if (found)  write(*,*) "still have unset aux vals in qad"
+          call bc2amr(alloc(loctmp),alloc(loctx),nrow,ncol,nvar,naux,
+     .                hxc,hyc,level,time,
+     .                xl,xr,yb,yt,
+     .                xlower,ylower,xupper,yupper,
+     .                xperdom,yperdom,spheredom)
+          call cstore(alloc(loctmp),nrow,ncol,nvar,
+     .                alloc(ist+nvar*lenbc),lenbc,naux,alloc(loctx),
+     .                alloc(ist+2*nvar*lenbc))
+          call reclam(loctmp,nrow*ncol*(nvar+naux))
+
+          mkid = node(levelptr,mkid)
+          go to 10
+ 99    return
+       end

--- a/src/2d/shallow/saveqc.f
+++ b/src/2d/shallow/saveqc.f
@@ -99,7 +99,6 @@ c         make coarsened enlarged patch for conservative fixup
           call bc2amr(alloc(loctmp),alloc(loctx),nrow,ncol,nvar,naux,
      .                hxc,hyc,level,time,
      .                xl,xr,yb,yt,
-     .                xlower,ylower,xupper,yupper,
      .                xperdom,yperdom,spheredom)
           call cstore(alloc(loctmp),nrow,ncol,nvar,
      .                alloc(ist+nvar*lenbc),lenbc,naux,alloc(loctx),


### PR DESCRIPTION
I just found a major bug that apparently shows up infrequently but sometimes generates garbage at the boundaries where the ocean should be flat.

The routine `bc2amr.f` in amrclaw has a different calling sequence than in geoclaw.  (Why??  I seem to recall we noticed this before but can't find an issue on it.)

The two routines `bound.f90` and `saveqc.f` both call `bc2amr.f`.  Currently geoclaw application Makefiles point to the amrclaw version of these, which then call the geoclaw version of `bc2amr` with the wrong calling sequence.  

For now I copied these to geoclaw and changed the calling sequence, and point to the new versions in Makefiles where this is a problem.  But ideally we would make the calling sequences identical so that the amrclaw versions of these routines can still be used rather than duplicating code.

So don't merge this yet, let's discuss how to proceed.
