### PR TITLE
Remove extraneous `fi` from travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   - nosetests -sv
 
 after_failure:
- - for failed_test_path in *_output ; do cat $failed_test_path/run_output.txt ; cat $failed_test_path/error_output.txt ; done ; fi
+ - for failed_test_path in *_output ; do cat $failed_test_path/run_output.txt ; cat $failed_test_path/error_output.txt ; done
   
 notifications:
   email: false


### PR DESCRIPTION
Only run if tests failed but was failing itself because of a syntax error.  Addresses #169.