### PR TITLE
topotools unstructured bugs

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -1012,8 +1012,8 @@ class Topography(object):
                        numpy.min(self.y) - buffer_degrees, 
                        numpy.max(self.y) + buffer_degrees ]
         if delta is None:
-            delta_x = max( numpy.abs(self.x[1:] - self.x[:-1]), delta_degrees)
-            delta_y = max( numpy.abs(self.y[1:] - self.y[:-1]), delta_degrees)
+            delta_x = max( numpy.abs(self.x[1:] - self.x[:-1]).max(), delta_degrees)
+            delta_y = max( numpy.abs(self.y[1:] - self.y[:-1]).max(), delta_degrees)
         else:   
             try:
                 delta_x, delta_y = delta   # tuple provided

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -1012,8 +1012,8 @@ class Topography(object):
                        numpy.min(self.y) - buffer_degrees, 
                        numpy.max(self.y) + buffer_degrees ]
         if delta is None:
-            delta_x = max( numpy.abs(self.x[1:] - self.x[:-1]).max(), delta_degrees)
-            delta_y = max( numpy.abs(self.y[1:] - self.y[:-1]).max(), delta_degrees)
+            delta_x = max( numpy.abs(self.x[1:] - self.x[:-1]).min(), delta_degrees)
+            delta_y = max( numpy.abs(self.y[1:] - self.y[:-1]).min(), delta_degrees)
         else:   
             try:
                 delta_x, delta_y = delta   # tuple provided


### PR DESCRIPTION
In trying to update the notebook
  http://nbviewer.ipython.org/url/clawpack.github.io/notebooks/topotools_examples.ipynb
I ran into this bug.

But after fixing, it gives a funny result.  The last figure looks wrong

@mandli: can you investigate?

![unstructured](https://cloud.githubusercontent.com/assets/720122/10718586/f21b5354-7b33-11e5-861a-06154d7b92d4.png)

