### PR TITLE
Set omp private variable time in gfixup.f

### DIFF
--- a/src/2d/shallow/gfixup.f
+++ b/src/2d/shallow/gfixup.f
@@ -147,6 +147,7 @@ c          # "interior" of coarser patch to fill fine grid.
            xr  = rnode(cornxhi,mptr)
            yb  = rnode(cornylo,mptr)
            yt  = rnode(cornyhi,mptr)
+           time  = rnode(timemult, mptr)
            ilo   = node(ndilo, mptr)
            ihi   = node(ndihi, mptr)
            jlo   = node(ndjlo, mptr)

--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -653,7 +653,7 @@ class Fault(object):
         # Read in rest of data
         # (Use genfromtxt to deal with files containing strings, e.g. unit
         # source name, in some column)
-        data = numpy.genfromtxt(path, skiprows=skiprows, delimiter=delimiter)
+        data = numpy.genfromtxt(path, skip_header=skiprows, delimiter=delimiter)
         if len(data.shape) == 1:
             data = numpy.array([data])
 


### PR DESCRIPTION
This bug never showed up since time isn't used, but I'm working on a time-dependent variable sea level option that uncovered it.

I don't know that time really needs to be a private variable in this loop, but this was easiest way to fix.