### PR TITLE
Remove Non-Conforming Tabs

### DIFF
--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -618,12 +618,12 @@ program amr2
              real(tvoll(level),kind=8) / real(clock_rate,kind=8), tvollCPU(level), rvoll(level)
         write(*,format_string) level, &
              real(tvoll(level),kind=8) / real(clock_rate,kind=8), tvollCPU(level), rvoll(level)
-    	ttotalcpu=ttotalcpu+tvollCPU(level)
-    	ttotal=ttotal+tvoll(level)
+        ttotalcpu=ttotalcpu+tvollCPU(level)
+        ttotal=ttotal+tvoll(level)
     end do
     
     format_string="('total         ',1f15.3,'        ',1f15.3,'    ', e17.3)"
-	write(outunit,format_string) &
+    write(outunit,format_string) &
              real(ttotal,kind=8) / real(clock_rate,kind=8), ttotalCPU, rvol
     write(*,format_string) &
              real(ttotal,kind=8) / real(clock_rate,kind=8), ttotalCPU, rvol
@@ -655,16 +655,16 @@ program amr2
     !regridding time
     format_string="('Regridding    ',1f15.3,'        ',1f15.3,'  ')"
     write(outunit,format_string) &
-    		real(timeRegridding,kind=8) / real(clock_rate,kind=8), timeRegriddingCPU
+            real(timeRegridding,kind=8) / real(clock_rate,kind=8), timeRegriddingCPU
     write(*,format_string) &
-    		real(timeRegridding,kind=8) / real(clock_rate,kind=8), timeRegriddingCPU
+            real(timeRegridding,kind=8) / real(clock_rate,kind=8), timeRegriddingCPU
     
     !output time
     format_string="('Output (valout)',1f14.3,'        ',1f15.3,'  ')"
     write(outunit,format_string) &
-    		real(timeValout,kind=8) / real(clock_rate,kind=8), timeValoutCPU
+            real(timeValout,kind=8) / real(clock_rate,kind=8), timeValoutCPU
     write(*,format_string) &
-    		real(timeValout,kind=8) / real(clock_rate,kind=8), timeValoutCPU
+            real(timeValout,kind=8) / real(clock_rate,kind=8), timeValoutCPU
     
     write(*,*)
     write(outunit,*)
@@ -672,11 +672,11 @@ program amr2
     !Total Time
     format_string="('Total time:   ',1f15.3,'        ',1f15.3,'  ')"
     write(outunit,format_string) &
-    		real(clock_finish - clock_start,kind=8) / real(clock_rate,kind=8), &
-    		cpu_finish-cpu_start
+            real(clock_finish - clock_start,kind=8) / real(clock_rate,kind=8), &
+            cpu_finish-cpu_start
     write(*,format_string) &
-    		real(clock_finish - clock_start,kind=8) / real(clock_rate,kind=8), &
-    		cpu_finish-cpu_start
+            real(clock_finish - clock_start,kind=8) / real(clock_rate,kind=8), &
+            cpu_finish-cpu_start
     
     format_string="('Using',i3,' thread(s)')"
     write(outunit,format_string) maxthreads


### PR DESCRIPTION
A commit that added some new timing information added tabs to `tick.f`.  This removes them.