### PR TITLE
Batch gauge output

### DIFF
--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -166,7 +166,7 @@ c
       subroutine par_advanc (mptr,mitot,mjtot,nvar,naux,dtnew)
 c
       use amr_module
-      use gauges_module, only: print_gauges, num_gauges
+      use gauges_module, only: update_gauges, num_gauges
       implicit double precision (a-h,o-z)
 
 
@@ -242,7 +242,7 @@ c        # now has boundary conditions filled in.
 c     should change the way print_gauges does io - right now is critical section
 
       if (num_gauges > 0) then
-           call print_gauges(alloc(locnew:locnew+nvar*mitot*mjtot), 
+           call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot), 
      .                       alloc(locaux:locnew+nvar*mitot*mjtot),
      .                       xlow,ylow,nvar,mitot,mjtot,naux,mptr)
            endif

--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -240,7 +240,9 @@ c        # now to make linear interpolation easier, since grid
 c        # now has boundary conditions filled in.
 
 c     should change the way print_gauges does io - right now is critical section
-
+c     NOW changed, mjb 2/6/2015.
+c     NOTE that gauge subr called before stepgrid, so never get
+c     the very last gauge time at end of run.
       if (num_gauges > 0) then
            call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot), 
      .                       alloc(locaux:locnew+nvar*mitot*mjtot),

--- a/src/2d/shallow/check.f
+++ b/src/2d/shallow/check.f
@@ -8,11 +8,12 @@ c   check point routine - can only call at end of coarse grid cycle
 c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::;
 
       use amr_module
-      use gauges_module, only: OUTGAUGEUNIT
+      use gauges_module, only: OUTGAUGEUNIT, num_gauges
+      use gauges_module, only: print_gauges_and_reset_nextLoc
       use fgmax_module
 
       implicit double precision (a-h,o-z)
-      integer tchkunit, ifg
+      integer tchkunit, ifg, ii
       parameter (tchkunit = 13)
       character  chkname*13
       character  tchkname*13
@@ -92,7 +93,12 @@ c     # so if code dies it will at least have output up to this checkpoint time
 
       flush(outunit)        ! defined in amr_module.f90
       flush(dbugunit)       ! defined in amr_module.f90
-      flush(OUTGAUGEUNIT)   ! defined in gauges_module.f90
+
+c     now that gauge data is batched, need to write the last batch to file
+     !!  flush(OUTGAUGEUNIT)   ! defined in gauges_module.f90 
+      do ii = 1, num_gauges
+         call print_gauges_and_reset_nextLoc(ii)
+      end do
 
 c     # write the time stamp file last so it's not updated until data is
 c     # all dumped, in case of crash mid-dump.

--- a/src/2d/shallow/check.f
+++ b/src/2d/shallow/check.f
@@ -8,7 +8,8 @@ c   check point routine - can only call at end of coarse grid cycle
 c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::;
 
       use amr_module
-      use gauges_module, only: OUTGAUGEUNIT, num_gauges
+c     !use gauges_module, only: OUTGAUGEUNIT, num_gauges
+      use gauges_module, only: num_gauges
       use gauges_module, only: print_gauges_and_reset_nextLoc
       use fgmax_module
 
@@ -95,7 +96,7 @@ c     # so if code dies it will at least have output up to this checkpoint time
       flush(dbugunit)       ! defined in amr_module.f90
 
 c     now that gauge data is batched, need to write the last batch to file
-     !!  flush(OUTGAUGEUNIT)   ! defined in gauges_module.f90 
+c    ! flush(OUTGAUGEUNIT)   ! defined in gauges_module.f90 
       do ii = 1, num_gauges
          call print_gauges_and_reset_nextLoc(ii)
       end do

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -114,7 +114,8 @@ contains
               rewind OUTGAUGEUNIT
               write(OUTGAUGEUNIT,100) igauge(i),i,xgauge(i),ygauge(i)
  100          format("##  gauge name",i10," gauge number", i5, "loc ",2e15.7)
-              write(OUTGAUGEUNIT,*)"##  level  time   h    hu    hv   eta "
+              write(OUTGAUGEUNIT,101)
+ 101          format("##  level  time   h    hu    hv   eta ")
            endif
 
            close(OUTGAUGEUNIT)

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -369,7 +369,7 @@ contains
            end do
         if (abs(eta) < 1d-90) eta = 0.d0
        
-        ! save info for this times 
+        ! save info for this time 
         index = nextLoc(ii)
  
         levelArray(index,ii) = level

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -25,6 +25,13 @@
 !     information in new module variables mbestg1, mbestg2.
 !   - print_gauges no longer uses binary search to locate first gauge handled
 !     by a grid.  Instead loop over gauges specified by mbestg1, mbestg2.
+!
+! Note: Updated for Clawpack 5.4.0
+!   - refactor so each gauge writes to its own file, and batches the writes instead of 
+!     writing one at a time. This will remove the critical section and should speed up gauges a lot
+!   - When array is filled, that gauge will write to file and start over. 
+!   - Need to save index so know position in array where left off
+!   - At checkpoint times, dump all gauges
 
 module gauges_module
 
@@ -32,10 +39,16 @@ module gauges_module
     save
 
     integer, parameter :: OUTGAUGEUNIT=89
-    integer :: num_gauges
+    integer :: num_gauges, inum
     real(kind=8), allocatable :: xgauge(:), ygauge(:), t1gauge(:), t2gauge(:)
     integer, allocatable, dimension(:) ::  mbestsrc, mbestorder, &
-                          igauge, mbestg1, mbestg2
+                          igauge, mbestg1, mbestg2, nextLoc
+    
+    integer, parameter :: MAXDATA=1000
+!!$    real(kind=8), pointer :: gaugeArray(5,MAXDATA,:)    ! 5 is time,h,hu,hv,eta
+!!$    integer, pointer :: levelArray(MAXDATA,:)
+    real(kind=8), pointer :: gaugeArray(:,:,:)
+    integer, pointer :: levelArray(:,:)
 
 contains
 
@@ -50,8 +63,9 @@ contains
         logical, intent(in)  :: restart
 
         ! Locals
-        integer :: i
+        integer :: i, ipos, idigit
         integer, parameter :: iunit = 7
+        character*14 ::  fileName
 
         ! Open file
         if (present(fname)) then
@@ -67,6 +81,10 @@ contains
         allocate(mbestsrc(num_gauges), mbestorder(num_gauges))
         allocate(igauge(num_gauges))
         allocate(mbestg1(maxgr), mbestg2(maxgr))
+
+        allocate(nextLoc(num_gauges))
+        allocate(gaugeArray(5,MAXDATA,num_gauges))
+        allocate(levelArray(MAXDATA,num_gauges))
         
         do i=1,num_gauges
             read(iunit,*) igauge(i),xgauge(i),ygauge(i),t1gauge(i),t2gauge(i)
@@ -76,18 +94,33 @@ contains
         
         ! initialize for starters
         mbestsrc = 0
+        nextLoc  = 1  ! next location to be filled with gauge info
 
-        ! open file for output of gauge data 
-        ! ascii file with format determined by the write(OUTGAUGEUNIT,100)
-        ! statement in print_gauges
-        ! for restarts, add to end instead of clobbering original file
-        if (restart) then
-           open(unit=OUTGAUGEUNIT, file='fort.gauge', status='unknown', &
-                position='append', form='formatted')
-        else
-           open(unit=OUTGAUGEUNIT, file='fort.gauge', status='unknown', &
-                                   form='formatted')
-        endif
+        do i = 1, num_gauges
+           fileName = 'gaugexxxxx.txt'    ! NB different name convention too
+           inum = igauge(i)
+           do ipos = 10,6,-1              ! do this to replace the xxxxx in the name
+              idigit = mod(inum,10)
+              fileName(ipos:ipos) = char(ichar('0') + idigit)
+              inum = inum / 10
+           end do
+
+!          status unknown since might be a restart run. maybe need to test and rewind?
+           if (restart) then
+              open(unit=OUTGAUGEUNIT, file=fileName, status='old',        &
+                   position='append', form='formatted')
+           else
+              open(unit=OUTGAUGEUNIT, file=fileName, status='unknown',        &
+                   position='append', form='formatted')
+              rewind OUTGAUGEUNIT
+              write(OUTGAUGEUNIT,*)"##  gauge name ",igauge(i)
+              write(OUTGAUGEUNIT,*)"##  level  time   h    hu    hv   eta "
+           endif
+
+
+           close(OUTGAUGEUNIT)
+
+        end do
 
     end subroutine set_gauges
 
@@ -187,7 +220,7 @@ contains
 !
 ! -------------------------------------------------------------------------
 !
-      subroutine print_gauges(q,aux,xlow,ylow,nvar,mitot,mjtot,naux,mptr)
+      subroutine update_gauges(q,aux,xlow,ylow,nvar,mitot,mjtot,naux,mptr)
 !
 !     This routine is called each time step for each grid patch, to output
 !     gauge values for all gauges for which this patch is the best one to 
@@ -221,7 +254,7 @@ contains
       real(kind=8) :: xcent,ycent,xoff,yoff,tgrid,hx,hy
       integer :: level,i,j,ioff,joff,iindex,jindex,ivar, ii,i1,i2
       real(kind=8) :: h(4),drytol2,topo,eta
-      integer :: icell,jcell
+      integer :: icell,jcell, index
 
 !     write(*,*) '+++ in print_gauges with num_gauges, mptr = ',num_gauges,mptr
 
@@ -336,19 +369,69 @@ contains
            if (abs(var(j)) < 1d-90) var(j) = 0.d0
            end do
         if (abs(eta) < 1d-90) eta = 0.d0
-
-!$OMP CRITICAL (gaugeio)
-        write(OUTGAUGEUNIT,100) igauge(ii),level,tgrid, &
-                    (var(j),j=1,3),eta
-
-!       # if you want to modify number of digits printed, modify this...
-100     format(2i5,15e15.7)
-
-!$OMP END CRITICAL (gaugeio)
-
+       
+        ! save info for this times 
+        index = nextLoc(ii)
+ 
+        levelArray(index,ii) = level
+        gaugeArray(1,index,ii) = tgrid
+        gaugeArray(2,index,ii) = var(1)
+        gaugeArray(3,index,ii) = var(2)
+        gaugeArray(4,index,ii) = var(3)
+        gaugeArray(5,index,ii) = eta
+        
+        nextLoc(ii) = nextLoc(ii) + 1
+        if (nextLoc(ii) .gt. MAXDATA) then
+          call print_gauges_and_reset_nextLoc(ii)  
+        endif
 
  10     continue  ! end of loop over all gauges
  
-      end subroutine print_gauges
+      end subroutine update_gauges
+!
+! -------------------------------------------------------------------------
+!
+      subroutine print_gauges_and_reset_nextLoc(gaugeNum)
+!
+!    Array of gauge data for this gauge reached max capacity
+!    print to file.
+
+      implicit none
+      integer :: gaugeNum,j,inum,k,idigit,ipos
+      character*14 :: fileName
+
+      ! open file for gauge gaugeNum, figure out name
+      ! not writing gauge number since it is in file name now
+      ! status is old, since file name and info written for
+      ! each file in in set_gauges.
+      !
+      ! NB: output written in different order, losing backward compatibility
+
+      fileName = 'gaugexxxxx.txt'    ! NB different name convention too
+      inum = igauge(gaugeNum)
+      do ipos = 10,6,-1              ! do this to replace the xxxxx in the name
+         idigit = mod(inum,10)
+         fileName(ipos:ipos) = char(ichar('0') + idigit)
+         inum = inum / 10
+      end do
+
+      open(unit=OUTGAUGEUNIT, file=fileName, status='old',    &
+           position='append', form='formatted')
+
+      
+      ! called either because array is full (write MAXDATA amount of gauge data)
+      ! or checkpoint time, so write whatever is in array and reset.
+      ! nextLoc has already been increment before this subr. called
+      write(OUTGAUGEUNIT,100) (levelArray(j,gaugeNum),                   &
+                              (gaugeArray(k,j,gaugeNum),k=1,5),j=1,nextLoc(gaugeNum)-1)
+      nextLoc(gaugeNum) = 1                        
+
+      ! if you want to modify number of digits printed, modify this...
+100     format(i5,5e15.7)
+
+      ! close file
+      close(OUTGAUGEUNIT)
+
+      end subroutine print_gauges_and_reset_nextLoc
 
 end module gauges_module

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -309,10 +309,11 @@ contains
         ycent  = ylow + (jindex-.5d0)*hy
         xoff   = (xgauge(ii)-xcent)/hx
         yoff   = (ygauge(ii)-ycent)/hy
-        if (xoff .lt. 0.d0 .or. xoff .gt. 1.d0 .or. &
-            yoff .lt. 0.d0 .or. yoff .gt. 1.d0) then
-           write(6,*)" BIG PROBLEM in DUMPGAUGE", i
-        endif
+!  IF WANT TO USE, MODIFY TO TEST FOR ROUNDOFF LEVEL DIFF
+!       if (xoff .lt. 0.d0 .or. xoff .gt. 1.d0 .or. &
+!           yoff .lt. 0.d0 .or. yoff .gt. 1.d0) then
+!          write(6,*)" BIG PROBLEM in DUMPGAUGE", i
+!       endif
 
      ! ## Modified below from amrclaw/src/2d/gauges_module.f90 
      ! ## to interpolate only where all four cells are

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -44,8 +44,8 @@ module gauges_module
     integer, allocatable, dimension(:) ::  mbestsrc, mbestorder, &
                           igauge, mbestg1, mbestg2, nextLoc
     
-    integer, parameter :: MAXDATA=1
-!    integer, parameter :: MAXDATA=1000
+!    integer, parameter :: MAXDATA=1
+    integer, parameter :: MAXDATA=1000
     real(kind=8), pointer :: gaugeArray(:,:,:)
     integer, pointer :: levelArray(:,:)
 

--- a/src/2d/shallow/setprob.f90
+++ b/src/2d/shallow/setprob.f90
@@ -1,7 +1,7 @@
 subroutine setprob()
 
     use regions_module, only: set_regions
-    use gauges_module, only: set_gauges
+    !use gauges_module, only: set_gauges
     use geoclaw_module, only: set_geo
     use topo_module, only: read_topo_settings, read_dtopo_settings
     use qinit_module, only: set_qinit

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -9,7 +9,8 @@ c
       use amr_module
       use topo_module, only: dt_max_dtopo, num_dtopo, topo_finalized,
      &                       aux_finalized, topo0work
-      use gauges_module, only: setbestsrc
+      use gauges_module, only: setbestsrc, num_gauges
+      use gauges_module, only: print_gauges_and_reset_nextLoc
 
 
       implicit double precision (a-h,o-z)
@@ -424,9 +425,18 @@ c  # checkpoint everything for possible future restart
 c  # (unless we just did it based on dumpchk)
 c
 
-      if ((checkpt_style .gt. 0) .and. (.not. dumpchk)) then
-           call check(ncycle,time,nvar,naux)
+c
+      if (checkpt_style .ne. 0) then  ! want a chckpt
+         ! check if just did it so dont do it twice
+         if (.not. dumpchk) call check(ncycle,time,nvar,naux)
+      else  ! no chkpt wanted, so need to print gauges separately
+         if (num_gauges .gt. 0) then
+            do ii = 1, num_gauges
+               call print_gauges_and_reset_nextLoc(ii)
+            end do
          endif
+      endif
+
 
       write(6,*) "Done integrating to time ",time
       return


### PR DESCRIPTION
default array size set to 1000 per gauge. gauge data is output when array is full, or at each checkpoint. when restart just add to file. each thread assigned a different unit name. Files names gaugeXXXXX.txt