### PR TITLE
fixes to make checkpt_style < 0 work in geoclaw

### DIFF
--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -295,12 +295,12 @@ program amr2
         ! Never checkpoint:
         checkpt_interval = iinfinity
 
-    else if (checkpt_style == 2) then
+    else if (abs(checkpt_style) == 2) then
         read(inunit,*) nchkpt
         allocate(tchk(nchkpt))
         read(inunit,*) (tchk(i), i=1,nchkpt)
 
-    else if (checkpt_style == 3) then
+    else if (abs(checkpt_style) == 3) then
         ! Checkpoint every checkpt_interval steps on coarse grid
         read(inunit,*) checkpt_interval
     endif

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -69,7 +69,7 @@ c              # restart: make sure output times start after restart time
       endif
 
       nextchk = 1
-      if ((nstart .gt. 0) .and. (checkpt_style.eq.2)) then
+      if ((nstart .gt. 0) .and. (abs(checkpt_style).eq.2)) then
 c        if this is a restart, make sure chkpt times start after restart time
          do ii = 1, nchkpt
            if (tchk(ii) .gt. time) then
@@ -346,6 +346,7 @@ c
           ncycle  = ncycle + 1
           call conck(1,nvar,naux,time,rest)
 
+
       if ( .not.vtime) goto 201
 
         ! Adjust time steps if variable time step and/or variable
@@ -380,7 +381,7 @@ c             ! use same alg. as when setting refinement when first make new fin
 
       endif
 
- 201  if ((checkpt_style.eq.3 .and. 
+ 201  if ((abs(checkpt_style).eq.3 .and. 
      &      mod(ncycle,checkpt_interval).eq.0) .or. dumpchk) then
                 call check(ncycle,time,nvar,naux)
                 dumpchk = .true.
@@ -424,7 +425,7 @@ c  # checkpoint everything for possible future restart
 c  # (unless we just did it based on dumpchk)
 c
 
-      if ((checkpt_style .gt. 0) .and. (.not. dumpchk)) then
+      if ((checkpt_style .ne. 0) .and. (.not. dumpchk)) then
            call check(ncycle,time,nvar,naux)
          endif
 


### PR DESCRIPTION
I think this fixes the problem, but there might be something else I missed.  I haven't tested much yet.