### PR TITLE
waves and s declared with wrong dimensions in qad 

### DIFF
--- a/src/2d/shallow/qad.f
+++ b/src/2d/shallow/qad.f
@@ -40,7 +40,7 @@ c      #  ok as long as meqn, mwaves < maxvar
 
        parameter (max1dp1 = max1d+1)
        dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,max1dp1,maxvar), s(max1dp1,nvar)
+       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
        dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
        dimension auxl(maxaux*max1dp1),  auxr(maxaux*max1dp1)
 c


### PR DESCRIPTION
 not used in qad but passed in to rpn2 and could cause problems there.