### PR TITLE
Fgmax interpolate0 index

### DIFF
--- a/src/2d/shallow/fgmax_interpolate0.f90
+++ b/src/2d/shallow/fgmax_interpolate0.f90
@@ -144,8 +144,8 @@ subroutine fgmax_interpolate(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
     ! Determine indices of cell containing fixed grid point (x(k),y(k))
 
     do k=1,fg%npts 
-        ik(k) = int((fg%x(k) - xlower + 0.5d0*dx) / dx)
-        jk(k) = int((fg%y(k) - ylower + 0.5d0*dy) / dy)
+        ik(k) = int((fg%x(k) - xlower + 0.999999d0*dx) / dx)
+        jk(k) = int((fg%y(k) - ylower + 0.999999d0*dy) / dy)
         enddo
 
     if (debug) then

--- a/src/2d/shallow/fgmax_interpolate0.f90
+++ b/src/2d/shallow/fgmax_interpolate0.f90
@@ -144,8 +144,8 @@ subroutine fgmax_interpolate(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
     ! Determine indices of cell containing fixed grid point (x(k),y(k))
 
     do k=1,fg%npts 
-        ik(k) = int((fg%x(k) - xlower + 0.999999d0*dx) / dx)
-        jk(k) = int((fg%y(k) - ylower + 0.999999d0*dy) / dy)
+        ik(k) = int((fg%x(k) - xlower + dx) / dx)
+        jk(k) = int((fg%y(k) - ylower + dy) / dy)
         enddo
 
     if (debug) then


### PR DESCRIPTION
Was computing index incorrectly for cell that fgmax point lies inside. It was sometimes correct and sometimes off by 1 depending on rounding.

Now should be correct, but note that if fgmax point lies right on cell edge then might use cell to left or cell to right depending on rounding. I don't see a way to make this more deterministic.