### PR TITLE
Additional fixes for compatibility with Python3

### DIFF
--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -86,7 +86,7 @@ unit_conversion_factor['N-m'] = 1.
 unit_conversion_factor['dyne-cm'] = 1.e-7
 
 # Check that these are consistent:
-check = [unit_conversion_factor[standard_units[param]] is 1. for param in \
+check = [unit_conversion_factor[standard_units[param]] == 1. for param in \
          standard_units.keys()]
 if not numpy.alltrue(check):
     raise ValueError("Conversion factors should be 1 for all standard_units")

--- a/tests/old_dtopotools.py
+++ b/tests/old_dtopotools.py
@@ -726,7 +726,7 @@ def plot_subfaults(subfaults, plot_centerline=False, slip_color=False, \
         if cmin_slip is None:
             cmin_slip = 0.
         if test_random:
-			print("*** test_random == True so slip and rake have been randomized")
+            print("*** test_random == True so slip and rake have been randomized")
         
     y_ave = 0.
     for subfault in subfaults:

--- a/tests/storm_surge/regression_tests.py
+++ b/tests/storm_surge/regression_tests.py
@@ -42,7 +42,7 @@ class IkeTest(test.GeoClawRegressionTest):
         with gzip.GzipFile(path, 'r') as gzip_file:
             file_content = gzip_file.read()
         
-        with open(storm_path, 'w') as out_file:
+        with open(storm_path, 'wb') as out_file:
             out_file.write(file_content)
 
         # Download file


### PR DESCRIPTION
Remove tabs, specify binary file format, and use '==' instead of 'is'.