### PR TITLE
change Makefile.geoclaw to use fgmax_interpolate0.f90

### DIFF
--- a/src/2d/shallow/Makefile.geoclaw
+++ b/src/2d/shallow/Makefile.geoclaw
@@ -145,7 +145,7 @@ COMMON_SOURCES += \
   $(GEOLIB)/amr2.f90 \
   $(GEOLIB)/fgmax_read.f90 \
   $(GEOLIB)/fgmax_frompatch.f90 \
-  $(GEOLIB)/fgmax_interpolate.f90 \
+  $(GEOLIB)/fgmax_interpolate0.f90 \
   $(GEOLIB)/fgmax_values.f90 \
   $(GEOLIB)/fgmax_finalize.f90 \
   $(GEOLIB)/check.f \

--- a/tests/bowl_slosh/Makefile
+++ b/tests/bowl_slosh/Makefile
@@ -41,6 +41,8 @@ include $(GEOLIB)/Makefile.geoclaw
 EXCLUDE_MODULES = \
 
 EXCLUDE_SOURCES = \
+  $(GEOLIB)/fgmax_interpolate0.f90 \
+
 
 # ----------------------------------------
 # List of custom sources for this program:
@@ -51,6 +53,7 @@ MODULES = \
 
 SOURCES = \
   qinit.f90 \
+  $(GEOLIB)/fgmax_interpolate.f90 \
   $(CLAW)/riemann/src/rpn2_geoclaw.f \
   $(CLAW)/riemann/src/rpt2_geoclaw.f \
   $(CLAW)/riemann/src/geoclaw_riemann_utils.f \


### PR DESCRIPTION
As suggested in documentation,
  http://www.clawpack.org/fgmax.html
(which needs to be updated for 5.4.0 Makefile).
