### PR TITLE
Level specific wave tolerance

### DIFF
--- a/src/2d/shallow/flag2refine2.f90
+++ b/src/2d/shallow/flag2refine2.f90
@@ -177,7 +177,7 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
                     eta = q(1,i,j) + aux(1,i,j)
 
                     ! Check wave criteria
-		    !New method - level specific wave tolerance
+		    ! New method - level specific wave tolerance
                     do m=1,min(size(wave_tolerance),mxnest)
                         if (abs(eta - sea_level) > wave_tolerance(m) .and. level <= m) then
                             ! Check to see if we are near shore
@@ -192,7 +192,8 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
                             endif
                         endif
                     enddo
-		    
+		    ! Check if wave tolerance array size is smaller than max level
+		    ! then refine with the last wave tolerance value for the rest of the levels
 		    if (size(wave_tolerance) < mxnest-1) then
                         if (abs(eta - sea_level) > wave_tolerance(size(wave_tolerance)) .and. level > size(wave_tolerance)) then
                             ! Check to see if we are near shore

--- a/src/2d/shallow/flag2refine2.f90
+++ b/src/2d/shallow/flag2refine2.f90
@@ -177,27 +177,36 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
                     eta = q(1,i,j) + aux(1,i,j)
 
                     ! Check wave criteria
-		    !New method - level specific wave tolerance!
-		    do m=1,min(size(wave_tolerance),mxnest)
+		    !New method - level specific wave tolerance
+                    do m=1,min(size(wave_tolerance),mxnest)
                         if (abs(eta - sea_level) > wave_tolerance(m) .and. level <= m) then
-                            amrflags(i,j) = DOFLAG
-                            cycle x_loop
+                            ! Check to see if we are near shore
+                            if (q(1,i,j) < deep_depth) then
+                                amrflags(i,j) = DOFLAG
+                                cycle x_loop
+                            ! Check if we are allowed to flag in deep water
+                            ! anyway
+                            else if (level < max_level_deep) then
+                                amrflags(i,j) = DOFLAG
+                                cycle x_loop
+                            endif
                         endif
                     enddo
 		    
-		    !Old method!
-                    !if (abs(eta - sea_level) > wave_tolerance) then
-                    !    ! Check to see if we are near shore
-                    !    if (q(1,i,j) < deep_depth) then
-                    !        amrflags(i,j) = DOFLAG
-                    !        cycle x_loop
-                    !    ! Check if we are allowed to flag in deep water
-                    !    ! anyway
-                    !    else if (level < max_level_deep) then
-                    !        amrflags(i,j) = DOFLAG
-                    !        cycle x_loop
-                    !    endif
-                    !endif
+		    if (size(wave_tolerance) < mxnest-1) then
+                        if (abs(eta - sea_level) > wave_tolerance(size(wave_tolerance)) .and. level > size(wave_tolerance)) then
+                            ! Check to see if we are near shore
+                            if (q(1,i,j) < deep_depth) then
+                                amrflags(i,j) = DOFLAG
+                                cycle x_loop
+                            ! Check if we are allowed to flag in deep water
+                            ! anyway
+                            else if (level < max_level_deep) then
+                                amrflags(i,j) = DOFLAG
+                                cycle x_loop
+                            endif
+                        endif
+                    endif
 
                     ! Check speed criteria, note that it might be useful to
                     ! also have a per layer criteria since this is not

--- a/src/2d/shallow/flag2refine2.f90
+++ b/src/2d/shallow/flag2refine2.f90
@@ -177,18 +177,27 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
                     eta = q(1,i,j) + aux(1,i,j)
 
                     ! Check wave criteria
-                    if (abs(eta - sea_level) > wave_tolerance) then
-                        ! Check to see if we are near shore
-                        if (q(1,i,j) < deep_depth) then
-                            amrflags(i,j) = DOFLAG
-                            cycle x_loop
-                        ! Check if we are allowed to flag in deep water
-                        ! anyway
-                        else if (level < max_level_deep) then
+		    !New method - level specific wave tolerance!
+		    do m=1,min(size(wave_tolerance),mxnest)
+                        if (abs(eta - sea_level) > wave_tolerance(m) .and. level <= m) then
                             amrflags(i,j) = DOFLAG
                             cycle x_loop
                         endif
-                    endif
+                    enddo
+		    
+		    !Old method!
+                    !if (abs(eta - sea_level) > wave_tolerance) then
+                    !    ! Check to see if we are near shore
+                    !    if (q(1,i,j) < deep_depth) then
+                    !        amrflags(i,j) = DOFLAG
+                    !        cycle x_loop
+                    !    ! Check if we are allowed to flag in deep water
+                    !    ! anyway
+                    !    else if (level < max_level_deep) then
+                    !        amrflags(i,j) = DOFLAG
+                    !        cycle x_loop
+                    !    endif
+                    !endif
 
                     ! Check speed criteria, note that it might be useful to
                     ! also have a per layer criteria since this is not

--- a/src/2d/shallow/refinement_module.f90
+++ b/src/2d/shallow/refinement_module.f90
@@ -11,7 +11,7 @@ module refinement_module
     ! ========================================================================
     !  Refinement Criteria
     ! ========================================================================
-    real(kind=8) :: wave_tolerance
+    real(kind=8), allocatable :: wave_tolerance(:)
     real(kind=8), allocatable :: speed_tolerance(:)
     real(kind=8) :: deep_depth
     integer :: max_level_deep
@@ -59,7 +59,9 @@ contains
             endif
 
             ! Basic criteria
-            read(unit,*) wave_tolerance
+	    read(unit,'(a)') line
+            allocate(wave_tolerance(get_value_count(line)))
+            read(line,*) wave_tolerance
             read(unit,'(a)') line
             allocate(speed_tolerance(get_value_count(line)))
             read(line,*) speed_tolerance


### PR DESCRIPTION
Wave tolerance is now set to be level specific, very similar to the speed refinement. If the number of wave tolerance values are less than the max amr level specified, the last value of the wave tolerance is used for the remainder of the levels.  