### PR TITLE
print more digits in gauge locations

### DIFF
--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -204,7 +204,7 @@ contains
 
                     ! Write header
                     header_1 = "('# gauge_id= ',i5,' " //                   &
-                               "location=( ',1e15.7,' ',1e15.7,' ) " //     &
+                               "location=( ',1e17.10,' ',1e17.10,' ) " //   &
                                "num_var= ',i2)"
                     write(OUTGAUGEUNIT, header_1) gauges(i)%gauge_num,      &
                                                   gauges(i)%x,              &


### PR DESCRIPTION
Needed for precise positioning of longitude,latitude in geoclaw.
Previous format could be off by 5 meters.  Change from 7 to 10 digits, which may
be overkill, but agrees with number of digits printed in gauges.data file
used as input.