### PR TITLE
remove unnecessary warning message

### DIFF
--- a/src/2d/shallow/fgmax_interpolate0.f90
+++ b/src/2d/shallow/fgmax_interpolate0.f90
@@ -166,11 +166,17 @@ subroutine fgmax_interpolate(mx,my,meqn,mbc,maux,q,aux,dx,dy, &
     
                 i = ik(k)
                 j = jk(k)
-                if ((i==mx+1) .or. (j==my+1)) then
-                    write(6,*) '**** Warning from fgmax_interpolate:'
-                    write(6,*) '**** Expected i <= mx, j<= my'
-                    write(6,*) 'i,j,mx,my: ',i,j,mx,my
-                    endif
+
+                ! Do not print the warning message below
+                ! It is possible that i==0 or mx+1, or j==0 or my+1
+                ! if the fg%x(k) or fg%y(k) was approx on the boundary of
+                ! the patch, but in this case it should be ok to use the
+                ! the ghost cell value. 
+                !if ((i==mx+1) .or. (j==my+1)) then
+                !    write(6,*) '**** Warning from fgmax_interpolate:'
+                !    write(6,*) '**** Expected i <= mx, j<= my'
+                !    write(6,*) 'i,j,mx,my: ',i,j,mx,my
+                !    endif
 
                 if ((values(mv,i,j)==FG_NOTSET)) then
                     fg_values(mv,k) = FG_NOTSET

--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -351,7 +351,7 @@ class DTopography(object):
             xvals = list(set(lastlines[:,1]))
             xvals.sort()
             mx = len(xvals)
-            my = len(lastlines) / mx
+            my = len(lastlines) // mx
             if verbose:
                 print("Read dtopo: mx=%s and my=%s, at %s times" % (mx,my,ntimes))
             X = numpy.reshape(lastlines[:,1],(my,mx))

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -634,7 +634,7 @@ class Topography(object):
                     if y != y0:
                         N[1] = n + 1
                         break
-                N[0] = data.shape[0] / N[1]
+                N[0] = data.shape[0] // N[1]
 
                 self._x = data[:N[1],0]
                 self._y = data[::N[1],1]


### PR DESCRIPTION
After checking again, I think `fgmax_interpolate0.f90` is correct and I have removed the warning message that raised concerns in https://groups.google.com/forum/#!topic/claw-users/r_eeWVx6tgw

