### PR TITLE
Output gauge number rather than index

### DIFF
--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -288,10 +288,11 @@ contains
             end do 
         end do
 
-
         do i = 1, num_gauges
-          if (mbestsrc(i) .eq. 0) &
-              print *, "ERROR in setting grid src for gauge data", i
+            if (mbestsrc(i) .eq. 0) then
+                print *, "ERROR in setting grid src for gauge data",      &
+                         gauges(i)%gauge_num
+            end if
         end do
 
         ! Sort the source arrays for easy testing during integration

--- a/src/2d/shallow/multilayer/gauges_module.f90
+++ b/src/2d/shallow/multilayer/gauges_module.f90
@@ -292,10 +292,11 @@ contains
             end do 
         end do
 
-
         do i = 1, num_gauges
-          if (mbestsrc(i) .eq. 0) &
-              print *, "ERROR in setting grid src for gauge data", i
+            if (mbestsrc(i) .eq. 0) then
+                print *, "ERROR in setting grid src for gauge data",      &
+                         gauges(i)%gauge_num
+            end if
         end do
 
         ! Sort the source arrays for easy testing during integration


### PR DESCRIPTION
This is just a minor tweak that causes and error from `setbestsrc` to output the gauge number rather than the index of the gauge which is not so helpful.