### PR TITLE
Sift fault mu value

### DIFF
--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -1849,7 +1849,7 @@ class SiftFault(Fault):
                 subfault.width = float(tokens[9])
                 subfault.rake = float(tokens[10])
                 subfault.coordinate_specification = "noaa sift"
-                # subfault.mu = ??  ## currently using SubFault default
+                subfault.mu = 4.e11 # dynes/cm**2 = 4e10 Pa
                 subfault.convert_to_standard_units(self.input_units)
                 self.sift_subfaults[name] = subfault
 

--- a/tests/test_dtopotools.py
+++ b/tests/test_dtopotools.py
@@ -115,7 +115,7 @@ def test_read_sift_make_dtopo(save=False):
     sift_slip = {'acsza1':2, 'acszb1':3}
     fault = dtopotools.SiftFault(sift_slip)
 
-    assert abs(fault.Mw() - 7.3) < 1e-4, "*** Mw is wrong: %g" % fault.Mw()
+    assert abs(fault.Mw() - 7.966666666667) < 1e-4, "*** Mw is wrong: %g" % fault.Mw()
 
     xlower = 162.
     xupper = 168.
@@ -163,7 +163,7 @@ def test_SubdividedPlaneFault_make_dtopo(save=False):
     # print "new Mo = ",fault2.Mo()
     #fault2.plot_subfaults(slip_color=True)
 
-    assert abs(fault2.Mw() - 6.83402) < 1e-4, \
+    assert abs(fault2.Mw() - 7.500686667) < 1e-4, \
            "*** Mw is wrong: %g" % fault.Mw()
 
     xlower = 162.


### PR DESCRIPTION
The value of rigidity (mu) was not being set for SIFT faults.  Set it properly so Mw agrees with PMEL's version.