### PR TITLE
flagregions.f90 never used, remove from Makefile.geoclaw

### DIFF
--- a/src/2d/shallow/Makefile.geoclaw
+++ b/src/2d/shallow/Makefile.geoclaw
@@ -47,7 +47,6 @@ COMMON_SOURCES += \
   $(AMRLIB)/prepbigstep.f \
   $(AMRLIB)/bufnst2.f \
   $(AMRLIB)/flagger.f \
-  $(AMRLIB)/flagregions.f90 \
   $(AMRLIB)/errf1.f \
   $(AMRLIB)/fixcapaq.f \
   $(AMRLIB)/flglvl2.f \


### PR DESCRIPTION
`flagregions2.f90` is also in `Makefile.geoclaw` and is the one actually used.  `flagregions` is a left-over.

Bigger question to discuss: where should we flag regions in geoclaw, see #298.
