### PR TITLE
Grid registration - handle xllcorner,yllcorner properly

### DIFF
--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -723,6 +723,7 @@ contains
         character(len=10) :: x_dim_name, x_var_name, y_dim_name, y_var_name, z_var_name
         integer(kind=4) :: x_var_id, y_var_id, z_var_id
         logical :: verbose
+        logical :: xll_registered, yll_registered
         ! character(len=10) :: x_dim_name, y_dim_name, z_dim_name
         ! character(len=10) :: x_var_name, y_var_name, z_var_name
         ! integer :: ios, root_id, x_var_id, y_var_id, z_var_id, var_ids(10)
@@ -794,10 +795,14 @@ contains
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)
                 xll = values(1)
+                xll_registered = ((index(str, 'xllcorner') > 0) .or. &
+                          (index(str, 'XLLCORNER') > 0))
 
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)
                 yll = values(1)
+                yll_registered = ((index(str, 'yllcorner') > 0) .or. &
+                          (index(str, 'YLLCORNER') > 0))
 
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)
@@ -811,6 +816,19 @@ contains
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)
                 nodata_value = values(1)
+
+                if (xll_registered) then
+                    xll = xll + 0.5d0*dx
+                    write(6,*) '*** in file: ',trim(fname)
+                    write(6,*) '    Shifting xllcorner by 0.5*dx to cell center'
+                    endif 
+
+                if (yll_registered) then
+                    yll = yll + 0.5d0*dy
+                    write(6,*) '*** in file: ',trim(fname)
+                    write(6,*) '    Shifting yllcorner by 0.5*dy to cell center'
+                    endif 
+
 
                 xhi = xll + (mx-1)*dx
                 yhi = yll + (my-1)*dy

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -693,7 +693,7 @@ contains
 #endif
 
         use geoclaw_module
-        use utility_module, only: parse_values
+        use utility_module, only: parse_values, to_lower
 
         implicit none
 
@@ -795,14 +795,14 @@ contains
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)
                 xll = values(1)
-                xll_registered = ((index(str, 'xllcorner') > 0) .or. &
-                          (index(str, 'XLLCORNER') > 0))
+                str = to_lower(str)  ! convert to lower case
+                xll_registered = (index(str, 'xllcorner') > 0)
 
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)
                 yll = values(1)
-                yll_registered = ((index(str, 'yllcorner') > 0) .or. &
-                          (index(str, 'YLLCORNER') > 0))
+                str = to_lower(str)  ! convert to lower case
+                yll_registered = (index(str, 'yllcorner') > 0)
 
                 read(iunit,'(a)') str
                 call parse_values(str, n, values)

--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -1134,7 +1134,8 @@ class SubFault(object):
       Each will be a tuple *(x, y, depth)*.
     
 
-    Top edge    Bottom edge
+    Top edge    Bottom edge ::
+
       a ----------- b          ^ 
       |             |          |         ^
       |             |          |         |

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -676,7 +676,7 @@ def kml_timespan(t1,t2,event_time=None,tz=None,tscale=1):
     event_time : Start of event in UTC :  [Y,M,D,H,M,S], e.g. [2010,2,27,3,34,0]
     tz         : time zone offset to UTC.  e.g. +3 for Chile; -9 for Japan.
 
-    Time span element looks like :
+    Time span element looks like ::
 
         <TimeSpan>
           <begin>2010-02-27T06:34:00+03:00</begin>

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -92,9 +92,7 @@ def create_topo_func(loc,verbose=False):
      - *loc* (list) - Create a topography file with the profile denoted by the
        tuples inside of loc.  A sample set of points are shown below.  Note 
        that the first value of the list is the x location and the second is 
-       the height of the topography.
-
-       **This figure doesn't show up properly in Sphinx docs...**
+       the height of the topography::
 
         z (m)
         ^                                                  o loc[5]  o
@@ -865,8 +863,8 @@ class Topography(object):
              'geoclaw' or 'default'  ==> write value then label 
                                      with grid_registration == 'lower' as default
              'arcgis' or 'asc' ==> write label then value  
-                                     with grid_registration == 'llcorner' as default
-                        (needed for .asc files in ArcGIS)
+                                   with grid_registration == 'llcorner' as default
+                                   (needed for .asc files in ArcGIS)
          - *Z_format* (str) - string format to use for Z values
            The default format "%15.7e" gives at least millimeter precision
            for topography with abs(Z) < 10000 and results in

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -812,17 +812,21 @@ class Topography(object):
                 x = numpy.linspace(xll, xll+(num_cells[0]-1)*dx, num_cells[0])
                 y = numpy.linspace(yll, yll+(num_cells[1]-1)*dy, num_cells[1])
                 if self.grid_registration in ['lower', 'llcenter']:
-                    # extent gives cell center / data locations:
+                    # x,y are cell center / data locations:
                     self._x = x
                     self._y = y
                 elif self.grid_registration == 'llcorner':
-                    # extent gives lower left corner:
+                    # x,y are lower left corners:
                     # data points are offset by dx/2, dy/2
                     self._x = x + dx/2.
                     self._y = y + dy/2.
                 else:
-                    raise IOError('Unrecognized grid_registration: %s' \
+                    # assume that x,y are cell center / data locations:
+                    self._x = x
+                    self._y = y
+                    print('*** Warning: Unrecognized grid_registration: %s' \
                                     % self.grid_registration)
+                    print('    Assuming x,y at grid points')
                 
                 # set extent based on data locations (not lower corner for 'llcorner')
                 self._extent = [self._x[0],self._x[-1],self._y[0],self._y[-1]]

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -777,14 +777,17 @@ class Topography(object):
 
                 xline = topo_file.readline().split()
                 xll = float(xline[value_index])
-                x_registration = xline[label_index][1:]  # drop 'x' character
+                # drop 'x' character and convert remaining string to lower case:
+                x_registration = xline[label_index][1:].lower()
 
                 yline = topo_file.readline().split()
                 yll = float(yline[value_index])
-                y_registration = yline[label_index][1:]  # drop 'y' character
-
+                # drop 'y' character and convert remaining string to lower case:
+                y_registration = yline[label_index][1:].lower()
+                
                 if x_registration == y_registration:
                     self.grid_registration = x_registration
+                    # expect registration in ['llcorner', 'llcenter', 'lower']
                 else:
                     raise IOError("x_registration and y_registration don't " \
                         + "match: %s,%s" % (x_registration, y_registration))
@@ -823,6 +826,8 @@ class Topography(object):
                     # data points are offset by dx/2, dy/2
                     self._x = x + dx/2.
                     self._y = y + dy/2.
+                    print('*** Note: since grid registration is llcorner,')
+                    print('    will shift x,y values by (dx/2, dy/2) to cell centers')
                 else:
                     # assume that x,y are cell center / data locations:
                     self._x = x
@@ -833,10 +838,6 @@ class Topography(object):
                 
                 # set extent based on data locations (not lower corner for 'llcorner')
                 self._extent = [self._x[0],self._x[-1],self._y[0],self._y[-1]]
-    
-                if self.grid_registration == 'llcorner':
-                    print('*** Note: since grid registration is llcorner,')
-                    print('    will shift x,y values by (dx/2, dy/2) to cell centers')
 
         else:
             raise IOError("Cannot read header for topo_type %s" % self.topo_type)

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -283,7 +283,8 @@ class Topography(object):
     :Examples:
 
         >>> import clawpack.geoclaw.topotools as topo
-        >>> topo_file = topo.Topography('./topo.tt3', topo_type=3)
+        >>> topo_file = topo.Topography()
+        >>> topo_file.read('./topo.tt3', topo_type=3)
         >>> topo_file.plot()
 
     """
@@ -471,7 +472,9 @@ class Topography(object):
                 # RJL: why do we expect 1d z?
                 if self._z is None:
                 # Try to read the data, may not have done this yet
-                    self.read(path=self.path, mask=mask)
+                    if self.topo_type is None:
+                        raise ValueError("topo_type must be specified")
+                    self.read(path=self.path, topo_type=self.topo_type, mask=mask)
                     if self._Z is not None:
                         # We are done, the read function did our work
                         return

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -473,6 +473,8 @@ class Topography(object):
                 if self._z is None:
                 # Try to read the data, may not have done this yet
                     if self.topo_type is None:
+                        self.topo_type = determine_topo_type(self.path)
+                    if self.topo_type is None:
                         raise ValueError("topo_type must be specified")
                     self.read(path=self.path, topo_type=self.topo_type, mask=mask)
                     if self._Z is not None:
@@ -603,7 +605,8 @@ class Topography(object):
                 # Try to look at suffix for type
                 self.topo_type = determine_topo_type(self.path)
                 if self.topo_type is None:
-                    self.topo_type = 3
+                    #self.topo_type = 3
+                    raise ValueError("topo_type must be specified")
 
         if self.unstructured:
             # Read in the data as series of tuples


### PR DESCRIPTION
This is to deal with the issue that we always interpreted DEM files incorrectly if the header specifies `xllcorner, yllcorner`, see #276 and https://groups.google.com/forum/#!topic/claw-users/a0sK7dwETvE

This changes how the data is interpreted when DEMs of this form are read in to either the Fortran code (changes to `topo_module.f90`) or into Python using `topotools.py`, and therefore will change the computed results in these cases.

I am working on some documentation that explains all this better, comments welcome on the drafts at

 - http://depts.washington.edu/clawpack/sampledocs/v5.5.0alpha/topo.html
 - http://depts.washington.edu/clawpack/sampledocs/v5.5.0alpha/grid_registration.html

It would be good if someone experiments with this before we merge it.

Note: the chile2010 example uses a very old etopo file that specifies `xll,yll` in the header, which gets interpreted as would `xllcenter,yllcenter` in the new version, i.e. the same way it was interpreted in the old version.  So results for this test problem (and the unit tests in `geoclaw/tests`) do not change.  The chile2010 example should be updated and improved as a separate issue.