### PR TITLE
etopotools -- corners from file

### DIFF
--- a/src/python/geoclaw/etopotools.py
+++ b/src/python/geoclaw/etopotools.py
@@ -58,6 +58,11 @@ def etopo1_download(xlimits, ylimits, dx=0.0166666666667, dy=None, \
     if dy is None:
         dy = dx
 
+    arcminute = 1/60.
+    if abs(dx-arcminute)>1e-8 or abs(dy-arcminute)>1e-8:
+        print('*** Warning: data may not be properly subsampled at')
+        print('*** resolutions other than 1 arcminute, dx=dy=1/60.')
+
     x1,x2 = xlimits
     y1,y2 = ylimits
 

--- a/src/python/geoclaw/etopotools.py
+++ b/src/python/geoclaw/etopotools.py
@@ -105,12 +105,12 @@ def etopo1_download(xlimits, ylimits, dx=0.0166666666667, dy=None, \
             x2file = float(lines[3].split()[1])
             lines[2] = 'xllcorner    %1.12f\n' % x1file
             lines[3] = 'yllcorner    %1.12f\n' % x2file
-            lines = lines[:5] + ['nodata_value    -99999\n'] + lines[5:]
+            if 'nodata_value' not in lines[5]:
+                lines = lines[:5] + ['nodata_value    -99999\n'] + lines[5:]
+                print("Added nodata_value line")
             f = open(file_path,'w')
             f.writelines(lines)
             f.close()
-            #print("Shifted xllcorner and yllcorner to cell centers")
-            print("Added nodata_value line")
         print("Created file: ",file_path)
 
     if return_topo:

--- a/src/python/geoclaw/etopotools.py
+++ b/src/python/geoclaw/etopotools.py
@@ -9,6 +9,7 @@ See http://www.ngdc.noaa.gov/mgg/global/global.html
 
 from __future__ import absolute_import
 from __future__ import print_function
+
 def etopo1_download(xlimits, ylimits, dx=0.0166666666667, dy=None, \
         output_dir='.', file_name=None, force=False, verbose=True, \
         return_topo=False):
@@ -100,14 +101,16 @@ def etopo1_download(xlimits, ylimits, dx=0.0166666666667, dy=None, \
         if lines[2].split()[0] != 'xllcorner':
             print("*** Error downloading, check the file!")
         else:
-            lines[2] = 'xllcorner    %1.12f\n' % x1
-            lines[3] = 'yllcorner    %1.12f\n' % y1
+            x1file = float(lines[2].split()[1])
+            x2file = float(lines[3].split()[1])
+            lines[2] = 'xllcorner    %1.12f\n' % x1file
+            lines[3] = 'yllcorner    %1.12f\n' % x2file
             lines = lines[:5] + ['nodata_value    -99999\n'] + lines[5:]
             f = open(file_path,'w')
             f.writelines(lines)
             f.close()
-            print("Shifted xllcorner and yllcorner to cell centers")
-            print("   and added nodata_value line")
+            #print("Shifted xllcorner and yllcorner to cell centers")
+            print("Added nodata_value line")
         print("Created file: ",file_path)
 
     if return_topo:


### PR DESCRIPTION
The etopo1 file downloaded will in general have different `xllcorner, yllcorner` than the values requested by the user in `xlimits, ylimits` and the topofile written out should have the values downloaded, not those requested.

*Note:*

- It was recently noticed that this does not always download the right thing if a resolution is requested that is coarser than 1 arcminute, as illustrated in [this notebook](http://depts.washington.edu/ptha/etopo_registration_tests.html)  
- This seems to be a problem with the NCEI server, but they are no longer supporting this approach so any bugs probably won't be fixed.  I added a warning message if the user requests something other than `dx=dy=1/60.`
- There is now a much better way to do download etopo1 data, by opening a remote NetCDF file and downloading the data from that directly.  I am working on a new version that will be in a different PR. For now it's good to merge in these fixes.