### PR TITLE
remove tick_clock_start declaration from tick.f

### DIFF
--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -20,7 +20,7 @@ c
       logical vtime,dumpout/.false./,dumpchk/.false./,rest,dump_final
       dimension dtnew(maxlv), ntogo(maxlv), tlevel(maxlv)
       integer clock_start, clock_finish, clock_rate
-      integer tick_clock_start, tick_clock_finish, tick_clock_rate
+      integer tick_clock_finish, tick_clock_rate
       character(len=128) :: time_format
       real(kind=8) cpu_start,cpu_finish
 


### PR DESCRIPTION
It is now declared in amrclaw/src/2d/amr_module.f90

Addresses #316.