### PR TITLE
Fixed orientation issue / rake is required to be set in set_corners()

### DIFF
--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -1590,19 +1590,16 @@ class SubFault(object):
             
             #Compute strike
             strike_deg = rad2deg(numpy.arctan(-b/a))
-            print('+++ initial strike_deg = %g' % strike_deg)
             
             #Compute dip
             beta = deg2rad(strike_deg + 90)
             m = numpy.array([sin(beta),cos(beta),0]) #Points in dip direction
             n = numpy.array([a,b,c]) #Normal to the plane
-            #dip_deg = abs(rad2deg(numpy.arcsin(m.dot(n)/(norm(m)*norm(n)))))
 
             if abs(c) < 1e-8:
                 dip_deg = 90.   # vertical fault
             else:
                 dip_deg = rad2deg(numpy.arcsin(m.dot(n)/(norm(m)*norm(n))))
-            print('+++ initial dip_deg = %g' % dip_deg)
             
             # dip should be between 0 and 90. If negative, reverse strike:
             if dip_deg < 0:

--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -1552,9 +1552,8 @@ class SubFault(object):
 
             x0 = numpy.array(self.corners)
             x = x0.copy()
-            x = numpy.array(x0)
             
-            x[:,2] = - numpy.abs(x[:,2]) # set depth to be always negative(lazy)
+            x[:,2] = - numpy.abs(x[:,2]) # set depth to be always negative
 
             if 0:
                 # old coordinate transform
@@ -1581,6 +1580,7 @@ class SubFault(object):
             normal = cross(v1,v2)
             if normal[2] < 0:
                 normal = -normal
+                self._corners.reverse()
             strikev = cross(normal,e3)   # vector in strike direction
 
             a = normal[0]

--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -1529,12 +1529,12 @@ class SubFault(object):
         Calculate geometry for triangular subfaults
 
         - Uses *corners* to calculate *centers*, *longitude*, *latitude*,
-          *depth*, *strike*, *dip*, *rake*, *length*, *width*.
+          *depth*, *strike*, *dip*, *length*, *width*.
 
         - sets *coordinate_specification* as "triangular"
 
         - Note that calculate_geometry() computes 
-          long/lat/strik/dip/rake/length/width to calculate centers/corners
+          long/lat/strike/dip/length/width to calculate centers/corners
         
         """
 
@@ -1649,7 +1649,7 @@ class SubFault(object):
             raise ValueError("Invalid coordinate specification %s." \
                                                 % self.coordinate_specification)
 
-    def set_corners(self,corners,rake,projection_zone=None):
+    def set_corners(self,corners,projection_zone=None):
         r"""
         Set three corners for a triangular fault.
         :Inputs: 
@@ -1664,7 +1664,6 @@ class SubFault(object):
                 [corners[0],corners[1],corners[2]]
             self._projection_zone = projection_zone
             self.coordinate_specification = 'triangular'
-            self.rake = rake
             self.calculate_geometry_triangles()
         else:
             raise ValueError("Expected input of length 3")


### PR DESCRIPTION
@rjleveque Thanks for the comments from [github.com/rjleveque/geoclaw/pull/3](https://github.com/rjleveque/geoclaw/pull/3). I've made some fixes in this PR.

[1-3] I think I mistakenly did a double-negative. I defined a logical ``self._fix_orientation``: when it switches on (the orientation is clock-wise), I multiply a negative sign to fix the sign error. I agree that the data user input should be preserved, probably can confuse the user.

[4-5] I removed the optional ``rake=90.`` argument to ``self.calculate_geometry_triangles()`` and also made the ``rake`` input required for ``self.set_corners()``, as suggested. (I think in the past I looked through all the triangular subfaults in CSZ and seeing them all having rake of 90 degrees I assumed that 90 degrees was the default for most cases.)

[6] I am not sure where to specify that the user needs to install ``utm`` and ``pyproj`` ... and yes, I think the discrepancy should be due to the various differences in transforming from long-lat to meters - there is actually a subtle issue here: for the triangular case, the method needs the deformations originating from each of the corners of the triangle to cancel exactly. 