### PR TITLE
kmltools -- increase number of digits printed

### DIFF
--- a/examples/tsunami/chile2010/README.rst
+++ b/examples/tsunami/chile2010/README.rst
@@ -25,15 +25,26 @@ A single gauge captures the sea surface elevation at the location of
 
 **Creating kml files to view on Google Earth**
 
+By default `make data` will create kml files showing the computational
+domain, the extents of the topofiles and dtopofiles used and the
+AMR regions specified, and the gauge location.  These can be viewed
+using Google Earth or other platforms supporting `kml`.  These are
+created by the line in `setrun.py` invoking
+`kmltools.make_input_data_kmls(rundata)`.
+
+Note that clicking on a rectangle or gauge in Google Earth displays
+information about it.  You may need to unselect some of the kml files under
+Places in order to click on ones underneath.
+
 `setplot_kml.py` is a version of the setplot file that produces `kml` files
-suitable for viewing on Google Earth or other platforms supporting `kml`.
+from the GeoClaw output for viewing the tsunami propagation.
 
 To use::
 
     make .output
     make plots SETPLOT_FILE=setplot_kml.py
 
-and then open `_output/Chile_2010.kmz` from Google Earth.  Note that this is
+and then open `_plots/Chile_2010.kmz` from Google Earth.  Note that this is
 a zipped directory containing a number of `kml` files and opening this way
 should open them all.  You can then select which ones to view (e.g. the
 simultion, the grid patches, regions specified in `setrun.py`, and/or gauges).

--- a/examples/tsunami/chile2010/setplot.py
+++ b/examples/tsunami/chile2010/setplot.py
@@ -41,6 +41,7 @@ def setplot(plotdata=None):
 
 
     plotdata.clearfigures()  # clear any old figures,axes,items data
+    plotdata.format = 'ascii'    # 'ascii' or 'binary' to match setrun.py
 
 
     # To plot gauge locations on pcolor or contour plot, use this as

--- a/examples/tsunami/chile2010/setrun.py
+++ b/examples/tsunami/chile2010/setrun.py
@@ -334,7 +334,7 @@ def setrun(claw_pkg='geoclaw'):
     rundata.regiondata.regions = []
     # to specify regions of refinement append lines of the form
     #  [minlevel,maxlevel,t1,t2,x1,x2,y1,y2]
-    rundata.regiondata.regions.append([3, 3, 0., 10000., -85,-72,-38,-25])
+    rundata.regiondata.regions.append([3, 3, 0., 1e9, -85.123456789,-72,-38,-25])
     rundata.regiondata.regions.append([3, 3, 8000., 26000., -90,-80,-30,-15])
 
     # ---------------
@@ -423,6 +423,8 @@ def setgeo(rundata):
 if __name__ == '__main__':
     # Set up run-time parameters and write all data files.
     import sys
+    from clawpack.geoclaw import kmltools
     rundata = setrun(*sys.argv[1:])
     rundata.write()
 
+    kmltools.make_input_data_kmls(rundata)

--- a/examples/tsunami/chile2010/setrun.py
+++ b/examples/tsunami/chile2010/setrun.py
@@ -334,7 +334,7 @@ def setrun(claw_pkg='geoclaw'):
     rundata.regiondata.regions = []
     # to specify regions of refinement append lines of the form
     #  [minlevel,maxlevel,t1,t2,x1,x2,y1,y2]
-    rundata.regiondata.regions.append([3, 3, 0., 1e9, -85.123456789,-72,-38,-25])
+    rundata.regiondata.regions.append([3, 3, 0., 10000., -85,-72,-38,-25])
     rundata.regiondata.regions.append([3, 3, 8000., 26000., -90,-80,-30,-15])
 
     # ---------------
@@ -424,6 +424,7 @@ if __name__ == '__main__':
     # Set up run-time parameters and write all data files.
     import sys
     from clawpack.geoclaw import kmltools
+
     rundata = setrun(*sys.argv[1:])
     rundata.write()
 

--- a/examples/tsunami/chile2010/setrun.py
+++ b/examples/tsunami/chile2010/setrun.py
@@ -143,7 +143,7 @@ def setrun(claw_pkg='geoclaw'):
         clawdata.output_t0 = True
         
 
-    clawdata.output_format = 'ascii'      # 'ascii' or 'netcdf' 
+    clawdata.output_format = 'ascii'      # 'ascii' or 'binary' 
 
     clawdata.output_q_components = 'all'   # need all
     clawdata.output_aux_components = 'none'  # eta=h+B is in q

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -31,14 +31,15 @@ from __future__ import absolute_import
 from __future__ import print_function
 from six.moves import range
 
-def f2s(x, n=8):
+def f2s(x, num_digits=6):
     r"""
     Convert float to string in fixed point notation with at most
     n digits of precision and trailing zeros removed, for printing
     nicely in kml description boxes.
     """
-    format = '%' + '.%sf' % n
-    return (format % x).rstrip('0')
+    format = '%' + '.%sf' % num_digits
+    s = (format % x).rstrip('0')
+    return s
     
 def deg2dms(dy):
     r"""
@@ -288,8 +289,8 @@ def line2kml(xy,fname='line.kml',name='line',color='00FFFF',width=3,
     mapping['y2'] = y2
     mapping['elev'] = elev
     mapping['name'] = name
-    mapping['desc'] = "  x1 = %g, x2 = %g\n" % (x1,x2) \
-            + "  y1 = %g, y2 = %g" % (y1,y2)
+    mapping['desc'] = "  x1 = %s, x2 = %s\n" % (f2s(x1),f2s(x2)) \
+            + "  y1 = %s, y2 = %s" % (f2s(y1),f2s(y2))
     mapping['color'] = color
     mapping['width'] = width
 
@@ -341,8 +342,8 @@ def box2kml(xy,fname=None,name='box',color='FF0000',width=3,verbose=True):
     mapping['y2'] = y2
     mapping['elev'] = elev
     mapping['name'] = name
-    mapping['desc'] = "  x1 = %g, x2 = %g\n" % (x1,x2) \
-            + "  y1 = %g, y2 = %g" % (y1,y2)
+    mapping['desc'] = "  x1 = %s, x2 = %s\n" % (f2s(x1),f2s(x2)) \
+            + "  y1 = %s, y2 = %s" % (f2s(y1),f2s(y2))
     mapping['color'] = color
     mapping['width'] = width
 
@@ -401,10 +402,10 @@ def quad2kml(xy,fname=None,name='quad',color='FF0000',width=3,verbose=True):
     mapping['y4'] = y4
     mapping['elev'] = elev
     mapping['name'] = name
-    mapping['desc'] = "  x1 = %g, y1 = %g\n" % (x1,y1) \
-            + "  x2 = %g, y2 = %g" % (x2,y2) \
-            + "  x3 = %g, y3 = %g" % (x3,y3) \
-            + "  x4 = %g, y4 = %g" % (x4,y4)
+    mapping['desc'] = "  x1 = %s, y1 = %s\n" % (f2s(x1),f2s(y1)) \
+            + "  x2 = %s, y2 = %s" % (f2s(x2),f2s(y2)) \
+            + "  x3 = %s, y3 = %s" % (f2s(x3),f2s(y3)) \
+            + "  x4 = %s, y4 = %s" % (f2s(x4),f2s(y4))
     mapping['color'] = color
     mapping['width'] = 3
 
@@ -452,22 +453,22 @@ def poly2kml(xy,fname=None,name='poly',color='00FF00', width=3,
     mapping['y'] = y
     mapping['elev'] = elev
     mapping['name'] = name
-    d = "  x[0] = %g, y[0] = %g\n" % (x[0],y[0]) 
+    d = "  x[0] = %s, y[0] = %s\n" % (x[0],y[0]) 
     for j in range(1,len(x)):
-        d = d + "  x[%i] = %g, y[%i] = %g" % (j,x[j],j,y[j])
+        d = d + "  x[%i] = %s, y[%i] = %s" % (j,f2s(x[j]),j,f2s(y[j]))
     mapping['desc'] = d
     mapping['color'] = color
     mapping['width'] = width
 
     v = "\n"
     for j in range(len(x)):
-        v = v + "%g,%g,%g\n" % (x[j],y[j],elev)
-    v = v + "%g,%g,%g\n" % (x[0],y[0],elev)
+        v = v + "%s,%s,%s\n" % (f2s(x[j]),f2s(y[j]),f2s(elev))
+    v = v + "%s,%s,%s\n" % (f2s(x[0]),f2s(y[0]),f2s(elev))
     v.replace(' ','')
     
     region_text = kml_region(mapping, v)
     for j in range(1,len(x)):
-        d = d + "  x[%i] = %g, y[%i] = %g" % (j,x[j],j,y[j])
+        d = d + "  x[%i] = %s, y[%i] = %s" % (j,f2s(x[j]),j,f2s(y[j]))
 
     kml_text = kml_text + region_text + kml_footer()
     kml_file = open(fname,'w')
@@ -535,8 +536,8 @@ def gauges2kml(rundata=None, fname='gauges.kml', verbose=True):
         x1,y1 = gauge[1:3]
         gaugeno = gauge[0]
         if verbose:
-            print("Gauge %i: %10.6f  %10.6f  \n" % (gaugeno,x1,y1) \
-                    + "  t1 = %10.1f,  t2 = %10.1f" % (t1,t2))
+            print("Gauge %i: %s, %s  \n" % (gaugeno,f2s(x1),f2s(y1)) \
+                    + "  t1 = %s,  t2 = %s" % (f2s(t1),f2s(t2)))
         mapping = {}
         mapping['gaugeno'] = gaugeno
         mapping['t1'] = t1
@@ -545,8 +546,8 @@ def gauges2kml(rundata=None, fname='gauges.kml', verbose=True):
         mapping['y1'] = y1
         mapping['elev'] = elev
         mapping['name'] = 'Gauge %i' % rnum
-        description = "  t1 = %g, t2 = %g\n" % (t1,t2) \
-            + "  x1 = %g, y1 = %g\n" % (x1,y1)
+        description = "  t1 = %s, t2 = %s\n" % (f2s(t1),f2s(t2)) \
+            + "  x1 = %s, y1 = %s\n" % (f2s(x1),f2s(y1))
         mapping['desc'] = description
 
         gauge_text = kml_gauge(mapping)
@@ -581,21 +582,21 @@ def kml_region(mapping, vertex_text=None):
         if 'x3' in mapping:
             # quadrilateral with 4 corners specified
             vertex_text = """
-{x1:.7f},{y1:.7f},{elev:.7f}
-{x2:.7f},{y2:.7f},{elev:.7f}
-{x3:.7f},{y3:.7f},{elev:.7f}
-{x4:.7f},{y4:.7f},{elev:.7f}
-{x1:.7f},{y1:.7f},{elev:.7f}
+{x1:.9f},{y1:.9f},{elev:.9f}
+{x2:.9f},{y2:.9f},{elev:.9f}
+{x3:.9f},{y3:.9f},{elev:.9f}
+{x4:.9f},{y4:.9f},{elev:.9f}
+{x1:.9f},{y1:.9f},{elev:.9f}
 """.format(**mapping).replace(' ','')
 
         else:
             # rectangle with 2 corners specified
             vertex_text = """
-{x1:.7f},{y1:.7f},{elev:.7f}
-{x2:.7f},{y1:.7f},{elev:.7f}
-{x2:.7f},{y2:.7f},{elev:.7f}
-{x1:.7f},{y2:.7f},{elev:.7f}
-{x1:.7f},{y1:.7f},{elev:.7f}
+{x1:.9f},{y1:.9f},{elev:.9f}
+{x2:.9f},{y1:.9f},{elev:.9f}
+{x2:.9f},{y2:.9f},{elev:.9f}
+{x1:.9f},{y2:.9f},{elev:.9f}
+{x1:.9f},{y1:.9f},{elev:.9f}
 """.format(**mapping).replace(' ','')
 
     mapping['vertices'] = vertex_text
@@ -628,8 +629,8 @@ def kml_line(mapping):
         mapping['color'] = 'FF' + mapping['color']
 
         line_text = """
-{x1:10.4f},{y1:10.4f},{elev:10.4f}
-{x2:10.4f},{y2:10.4f},{elev:10.4f}
+{x1:.9f},{y1:.9f},{elev:.9f}
+{x2:.9f},{y2:.9f},{elev:.9f}
 """.format(**mapping).replace(' ','')
 
     mapping['line'] = line_text
@@ -654,7 +655,7 @@ def kml_line(mapping):
     return kml_text
 
 def kml_gauge(mapping):
-    gauge_text = "{x1:10.4f},{y1:10.4f},{elev:10.4f}".format(**mapping).replace(' ','')
+    gauge_text = "{x1:.9f},{y1:.9f},{elev:.9f}".format(**mapping).replace(' ','')
 
     mapping['gauge'] = gauge_text
 

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -30,6 +30,16 @@ the full 8 digits if you want it transparent).
 from __future__ import absolute_import
 from __future__ import print_function
 from six.moves import range
+
+def f2s(x, n=8):
+    r"""
+    Convert float to string in fixed point notation with at most
+    n digits of precision and trailing zeros removed, for printing
+    nicely in kml description boxes.
+    """
+    format = '%' + '.%sf' % n
+    return (format % x).rstrip('0')
+    
 def deg2dms(dy):
     r"""
     Convert decimal degrees to tuple (degrees, minutes, seconds)
@@ -98,8 +108,8 @@ def regions2kml(rundata=None,fname='regions.kml',verbose=True,combined=True):
     clawdata = rundata.clawdata
     x1,y1 = clawdata.lower[0:]
     x2,y2 = clawdata.upper[0:]
-    description = "  x1 = %g, x2 = %g\n" % (x1,x2) \
-            + "  y1 = %g, y2 = %g\n" % (y1,y2)
+    description = "  x1 = %s, x2 = %s\n" % (f2s(x1),f2s(x2)) \
+            + "  y1 = %s, y2 = %s\n" % (f2s(y1),f2s(y2))
 
     mx,my = clawdata.num_cells[0:]
     dx = (x2-x1)/float(mx)
@@ -189,7 +199,7 @@ def regions2kml(rundata=None,fname='regions.kml',verbose=True,combined=True):
                     % (rnum,x1,x2,y1,y2))
             print("           minlevel = %i,  maxlevel = %i" \
                     % (minlevel,maxlevel) \
-                    + "  t1 = %10.1f,  t2 = %10.1f" % (t1,t2))
+                    + "  t1 = %s,  t2 = %s" % (f2s(t1),f2s(t2)))
         mapping = {}
         mapping['minlevel'] = minlevel
         mapping['maxlevel'] = maxlevel
@@ -202,9 +212,9 @@ def regions2kml(rundata=None,fname='regions.kml',verbose=True,combined=True):
         mapping['elev'] = elev
         mapping['name'] = 'Region %i' % rnum
         description = "minlevel = %i, maxlevel = %i\n" % (minlevel,maxlevel) \
-            + "  t1 = %g, t2 = %g\n" % (t1,t2) \
-            + "  x1 = %g, x2 = %g\n" % (x1,x2) \
-            + "  y1 = %g, y2 = %g\n\n" % (y1,y2)
+            + "  t1 = %s, t2 = %s\n" % (f2s(t1),f2s(t2)) \
+            + "  x1 = %s, x2 = %s\n" % (f2s(x1),f2s(x2)) \
+            + "  y1 = %s, y2 = %s\n\n" % (f2s(y1),f2s(y2))
         if len(dy_levels) >= minlevel:
             dy = dy_levels[minlevel-1]
             dy_deg,dy_min,dy_sec = deg2dms(dy)
@@ -571,21 +581,21 @@ def kml_region(mapping, vertex_text=None):
         if 'x3' in mapping:
             # quadrilateral with 4 corners specified
             vertex_text = """
-{x1:10.4f},{y1:10.4f},{elev:10.4f}
-{x2:10.4f},{y2:10.4f},{elev:10.4f}
-{x3:10.4f},{y3:10.4f},{elev:10.4f}
-{x4:10.4f},{y4:10.4f},{elev:10.4f}
-{x1:10.4f},{y1:10.4f},{elev:10.4f}
+{x1:.7f},{y1:.7f},{elev:.7f}
+{x2:.7f},{y2:.7f},{elev:.7f}
+{x3:.7f},{y3:.7f},{elev:.7f}
+{x4:.7f},{y4:.7f},{elev:.7f}
+{x1:.7f},{y1:.7f},{elev:.7f}
 """.format(**mapping).replace(' ','')
 
         else:
             # rectangle with 2 corners specified
             vertex_text = """
-{x1:10.4f},{y1:10.4f},{elev:10.4f}
-{x2:10.4f},{y1:10.4f},{elev:10.4f}
-{x2:10.4f},{y2:10.4f},{elev:10.4f}
-{x1:10.4f},{y2:10.4f},{elev:10.4f}
-{x1:10.4f},{y1:10.4f},{elev:10.4f}
+{x1:.7f},{y1:.7f},{elev:.7f}
+{x2:.7f},{y1:.7f},{elev:.7f}
+{x2:.7f},{y2:.7f},{elev:.7f}
+{x1:.7f},{y2:.7f},{elev:.7f}
+{x1:.7f},{y1:.7f},{elev:.7f}
 """.format(**mapping).replace(' ','')
 
     mapping['vertices'] = vertex_text

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -34,8 +34,8 @@ from six.moves import range
 def f2s(x, num_digits=6):
     r"""
     Convert float to string in fixed point notation with at most
-    n digits of precision and trailing zeros removed, for printing
-    nicely in kml description boxes.
+    *num_digits* digits of precision and trailing zeros removed, 
+    for printing nicely in kml description boxes.
     """
     format = '%' + '.%sf' % num_digits
     s = (format % x).rstrip('0')


### PR DESCRIPTION
This increases the number of digits put into kml files showing gauges, and extent of topo, dtopo, regions, both in the number used to position and in the text box descriptions (using a function `f2s` that converts floats to strings with trailing zeros removed but with more digits than the `%g` format - maybe there's a better way to do this?). 

I modified the chile2010 example to make these kml files by default since this is generally very useful to make sure things are placed where expected.  I added some description to the `README.rst`.

In testing this, I also tried 
```
make plots SETPLOT_FILE=setplot_kml.py
```
and discovered that it seems to still make the png files properly (by unzipping Chile2010.kmz) and opening one) but when the kmz file is opened in my current version of Google Earth the tsunami does not show up, nor does the gauge plot.  Maybe @donnaaboise or someone more familiar with GE rendering wants to take a look at this?
