### PR TITLE
update chile2010/setplot_kml.py

### DIFF
--- a/examples/tsunami/chile2010/setplot_kml.py
+++ b/examples/tsunami/chile2010/setplot_kml.py
@@ -73,6 +73,7 @@ def setplot(plotdata):
 
     plotfigure.use_for_kml = True
     plotfigure.kml_use_for_initial_view = True
+    plotfigure.kml_show_figure = True
 
     # These override any axes limits set below in plotaxes
     plotfigure.kml_xlimits = [-120,-60]
@@ -108,6 +109,7 @@ def setplot(plotdata):
 
     plotfigure.use_for_kml = True
     plotfigure.kml_use_for_initial_view = False  # Use large plot for view
+    plotfigure.kml_show_figure = True
 
     # Set Google Earth bounding box and figure size
     plotfigure.kml_xlimits = [-84,-74]


### PR DESCRIPTION
to show tsunami plots by default when loading kmz into Google Earth.

As suggested in #329.