### PR TITLE
compare q(1,i,j) instead of q(1,i,j)*capa to dry_tolerance in update.f90

### DIFF
--- a/src/2d/shallow/multilayer/update.f90
+++ b/src/2d/shallow/multilayer/update.f90
@@ -149,7 +149,8 @@ subroutine update (level, nvar, naux)
                                     huf= alloc(iaddf(3*layer-1,iff+ico-1,jff+jco-1,locf,mi))*capa 
                                     hvf= alloc(iaddf(3*layer,iff+ico-1,jff+jco-1,locf,mi))*capa 
 
-                                    if (hf > dry_tolerance(layer)) then
+                                    if ( alloc(iaddf(3*layer-2,iff+ico-1,jff+jco-1,locf,mi))/rho(layer) &
+                                        > dry_tolerance(layer)) then
                                         etaf = hf + bf
                                         nwet(layer) = nwet(layer) + 1
                                     else

--- a/src/2d/shallow/update.f90
+++ b/src/2d/shallow/update.f90
@@ -138,7 +138,7 @@ subroutine update (level, nvar, naux)
                                 huf= alloc(iaddf(2,iff+ico-1,jff+jco-1,locf,mi))*capa 
                                 hvf= alloc(iaddf(3,iff+ico-1,jff+jco-1,locf,mi))*capa 
 
-                                if (hf > dry_tolerance) then
+                                if (alloc(iaddf(1,iff+ico-1,jff+jco-1,locf,mi)) > dry_tolerance) then
                                     etaf = hf + bf
                                     nwet = nwet + 1
                                 else


### PR DESCRIPTION
I would like to raise a discussion on this single line of code in update.f90.

I think here we should compare **q(1,i,j)** instead of **hf = q(1,i,j) * capa** to **dry_tolerance** in update.f90. 

One simple argument is that at all other places, **q(1,i,j)**  instead of **q(1,i,j) * capa** is compared to **dry_tolerance**.

Any thought?