### PR TITLE
Require xarray version 0.11.0 so that travis tests do not fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   # - pip install matplotlib
   # - python -c "import matplotlib; print(matplotlib.__version__)"
   - pip install netCDF4
-  - pip install xarray
+  - pip install xarray==0.11.0
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init


### PR DESCRIPTION
Note that this was not reproducible on local setups and only
seemed to be happening with travis.