### PR TITLE
Update package dependencies for travis and tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,10 @@ env:
 before_install:
   - sudo apt-get update
   - sudo apt-get install gfortran liblapack-pic liblapack-dev
-  # Print NumPy version that is already installed by Travis CI:
-  - python -c "import numpy; print(numpy.__version__)"
-  # - pip install matplotlib
-  # - python -c "import matplotlib; print(matplotlib.__version__)"
   - pip install netCDF4
   - pip install xarray
   - pip install scipy
+  - pip install matplotlib
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   # - pip install matplotlib
   # - python -c "import matplotlib; print(matplotlib.__version__)"
   - pip install netCDF4
-  - pip install xarray==0.11.0
+  - pip install xarray>=0.12.0
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   # - python -c "import matplotlib; print(matplotlib.__version__)"
   - pip install netCDF4
   - pip install xarray
+  - pip install scipy
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   # - pip install matplotlib
   # - python -c "import matplotlib; print(matplotlib.__version__)"
   - pip install netCDF4
-  - pip install xarray>=0.12.0
+  - pip install xarray
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ before_install:
   - pip install netCDF4
   - pip install xarray
   - pip install scipy
-  - pip install matplotlib
   - git clone --branch=master --depth=100 --quiet git://github.com/clawpack/clawpack
   - cd clawpack
   - git submodule init

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ before_install:
   - git submodule update
   - rm -rf geoclaw
   - ln -s ../ geoclaw
+  # Print NumPy version being used
+  - python -c "import numpy; print(numpy.__version__)"
   
 install:
   - export PYTHONPATH=${PWD}:$PYTHONPATH

--- a/tests/old_topotools.py
+++ b/tests/old_topotools.py
@@ -96,11 +96,6 @@ skipfirstcols=0, skiplastcols=0):
 
 
 def topofile2griddata(inputfile, topotype=2):
-    
-    try:
-        import pylab
-    except ImportError:
-        raise nose.SkipTest("Skipping test since matplotlib was not found.")
 
     if topotype>1:
         (fin,topoheader)=topoheaderread(inputfile,closefile=False)


### PR DESCRIPTION
- pull latest xarray version on travis  now that latest is `>=0.12` and the bug we had with `0.11.3` no longer requires us to pin `xarray==0.11.0` (see #362 and #354)
- install `scipy` on travis so that no tests requiring `scipy` are skipped
- remove unneeded import of `pylab` package that causes `test_topotools.test_against_old()` to be skipped if `pylab` not installed. `pylab` is no longer needed for that test anyway.