### PR TITLE
link more amrclaw modules/source

### DIFF
--- a/src/2d/shallow/Makefile.geoclaw
+++ b/src/2d/shallow/Makefile.geoclaw
@@ -6,7 +6,9 @@ GEOLIB:=$(CLAW)/geoclaw/src/2d/shallow
 #list of common sources for amr 2d codes
 COMMON_MODULES += \
  $(AMRLIB)/amr_module.f90 \
- $(AMRLIB)/regions_module.f90 
+ $(AMRLIB)/regions_module.f90 \
+ $(AMRLIB)/adjoint_module.f90 \
+ $(AMRLIB)/adjointsup_module.f90
 
 #list of common sources needed for geoclaw codes (subset of amr dependencies)
 COMMON_MODULES += \
@@ -24,7 +26,7 @@ COMMON_MODULES += \
  $(GEOLIB)/multilayer/multilayer_module.f90 \
  $(GEOLIB)/friction_module.f90
 
-# list of source files from AMR library. 
+# list of source files from AMR library.
 COMMON_SOURCES += \
   $(AMRLIB)/prefilp.f90 \
   $(AMRLIB)/trimbd.f90 \
@@ -32,6 +34,7 @@ COMMON_SOURCES += \
   $(AMRLIB)/intfil.f90 \
   $(AMRLIB)/flagregions2.f90  \
   $(AMRLIB)/quick_sort1.f \
+  $(AMRLIB)/quick_sort_reals.f \
   $(AMRLIB)/estdt.f \
   $(AMRLIB)/check4nans.f90 \
   $(AMRLIB)/init_iflags.f \
@@ -114,7 +117,7 @@ COMMON_SOURCES += \
   $(AMRLIB)/restrt_alloc.f90 \
   $(AMRLIB)/resize_alloc.f90
 
-# list of source files from GEOCLAW library. 
+# list of source files from GEOCLAW library.
 COMMON_SOURCES += \
   $(GEOLIB)/setprob.f90 \
   $(GEOLIB)/qinit.f90 \

--- a/src/2d/shallow/multilayer/Makefile.multilayer
+++ b/src/2d/shallow/multilayer/Makefile.multilayer
@@ -9,11 +9,11 @@ ifeq ($(UNAME), Darwin)
 else ifeq ($(UNAME), Linux)
   ifeq ($(FC), ifort)
     # Created using Intel MKL Link Line Advisor
-    # Please refer to 
+    # Please refer to
     # http://software.intel.com/en-us/articles/intel-mkl-link-line-advisor/
     # for other installation types
     FFLAGS += -I$(MKLROOT)/include
-    ifndef LFLAGS                                                                                                                                    
+    ifndef LFLAGS
       LFLAGS =  -Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_lp64.a $(MKLROOT)/lib/intel64/libmkl_core.a $(MKLROOT)/lib/intel64/libmkl_sequential.a -Wl,--end-group -lpthread -lm $(FFLAGS)
     else
       LFLAGS +=  -Wl,--start-group $(MKLROOT)/lib/intel64/libmkl_intel_ilp64.a $(MKLROOT)/lib/intel64/libmkl_core.a $(MKLROOT)/lib/intel64/libmkl_sequential.a -Wl,--end-group -lpthread -lm $(FFLAGS)
@@ -35,7 +35,9 @@ GEOLIB:=$(CLAW)/geoclaw/src/2d/shallow
 #list of common sources for amr 2d codes
 COMMON_MODULES += \
   $(AMRLIB)/amr_module.f90 \
-  $(AMRLIB)/regions_module.f90 
+  $(AMRLIB)/regions_module.f90 \
+  $(AMRLIB)/adjoint_module.f90 \
+  $(AMRLIB)/adjointsup_module.f90
 
 #list of common sources needed for geoclaw codes (subset of amr dependencies)
 COMMON_MODULES += \
@@ -53,7 +55,7 @@ COMMON_MODULES += \
   $(GEOLIB)/fgmax_module.f90 \
   $(GEOLIB)/friction_module.f90
 
-# list of source files from AMR library. 
+# list of source files from AMR library.
 COMMON_SOURCES += \
   $(AMRLIB)/prefilp.f90 \
   $(AMRLIB)/trimbd.f90 \
@@ -61,6 +63,7 @@ COMMON_SOURCES += \
   $(AMRLIB)/intfil.f90 \
   $(AMRLIB)/flagregions2.f90  \
   $(AMRLIB)/quick_sort1.f \
+  $(AMRLIB)/quick_sort_reals.f \
   $(AMRLIB)/estdt.f \
   $(AMRLIB)/check4nans.f90 \
   $(AMRLIB)/init_iflags.f \
@@ -143,7 +146,7 @@ COMMON_SOURCES += \
   $(AMRLIB)/restrt_alloc.f90 \
   $(AMRLIB)/resize_alloc.f90
 
-# list of source files from GEOCLAW library. 
+# list of source files from GEOCLAW library.
 COMMON_SOURCES += \
   $(GEOLIB)/setprob.f90 \
   $(GEOLIB)/qinit.f90 \


### PR DESCRIPTION
geoclaw tests were failing because a few AMRclaw modules were not linked. I'm not sure why these tests just started failing but perhaps because of some recent rearrangements in AMRclaw? Adding in these additional files into the Makefile that does the linking seems to solve the issue