### PR TITLE
remove GIT_STATUS from test Makefiles

### DIFF
--- a/tests/chile2010_adjoint/Makefile
+++ b/tests/chile2010_adjoint/Makefile
@@ -20,7 +20,6 @@ PLOTDIR = _plots               # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
 RESTART ?= False                    # Should = clawdata.restart in setrun
-GIT_STATUS = True
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 

--- a/tests/chile2010_adjoint/adjoint/Makefile
+++ b/tests/chile2010_adjoint/adjoint/Makefile
@@ -21,7 +21,6 @@ PLOTDIR = _plots               # Directory for plots
 
 OVERWRITE ?= True                   # False ==> make a copy of OUTDIR first
 RESTART ?= False                    # Should = clawdata.restart in setrun
-GIT_STATUS = True
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 


### PR DESCRIPTION
This makes the test fail if run in a non-git version of the code,
e.g. obtained from a tar file.  

We should improve clawutil.claw_git_status.py
to not throw an error in this case eventually.
https://github.com/clawpack/clawutil/issues/135