### PR TITLE
fix ticklabel_format kwarg

### DIFF
--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -137,7 +137,7 @@ def plot_dZ_colors(x, y, dZ, axes=None, cmax_dZ=None, dZ_interval=None,
 
     y_ave = 0.5 * (y.min() + y.max())
     axes.set_aspect(1. / numpy.cos(y_ave * numpy.pi / 180.))
-    axes.ticklabel_format(format='plain', useOffset=False)
+    axes.ticklabel_format(style='plain', useOffset=False)
     axes.set_title('Seafloor deformation')
     for label in axes.get_xticklabels():
         label.set_rotation(20)
@@ -1003,7 +1003,7 @@ class Fault(object):
         else:
             slipax.set_title('Fault planes')
 
-        slipax.ticklabel_format(format='plain', useOffset=False)
+        slipax.ticklabel_format(style='plain', useOffset=False)
         for label in slipax.get_xticklabels():
             label.set_rotation(20)
         

--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -1098,7 +1098,7 @@ class Topography(object):
             axes = fig.add_subplot(111)
         
         # Turn off annoying offset
-        axes.ticklabel_format(format="plain", useOffset=False)
+        axes.ticklabel_format(style="plain", useOffset=False)
         for label in axes.get_xticklabels():
             label.set_rotation(20)
 


### PR DESCRIPTION
the kwarg is `style` not `format`, and matplotlib 3.1.1 throws an error
while older versions just ignored it.  Could omit this kwarg altogether.