### PR TITLE
bug in call to update_gauges?

### DIFF
--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -246,7 +246,7 @@ c     the very last gauge time at end of run.
 
       if (num_gauges > 0) then
            call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot),
-     .                       alloc(locaux:locnew+nvar*mitot*mjtot),
+     .                       alloc(locaux:locaux+naux*mitot*mjtot),
      .                       xlow,ylow,nvar,mitot,mjtot,naux,mptr)
            endif
 


### PR DESCRIPTION
This one line seems to have two bugs in it, can you take a look @mjberger or @mandli?

The corresponding line in `amrclaw/src/2d/advanc.f` also seems to have one of the bugs.  There it has
```
           call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot),
     .                       alloc(locaux:locaux+nvar*mitot*mjtot),
     .                       xlow,ylow,nvar,mitot,mjtot,naux,mptr)
```
and I think `nvar` should be `naux` on the second line?  Also the same problem in `1d` and `3d` amrclaw.

I came across this when reviewing #358 since I'd like to update that and try it out, and noticed there was a commit that partly fixed this line and then it was reverted in the second commit.  Not sure why but maybe @xinshengqin can comment.
