### PR TITLE
Topo missing

### DIFF
--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -1,19 +1,4 @@
 ! ============================================================================
-!  Program:     topo_module
-!  File:        topo_mod.f90
-!  Created:     2010-04-22
-!  Author:      Kyle Mandli
-! ============================================================================
-!      Copyright (C) 2010-04-22 Kyle Mandli <mandli@amath.washington.edu>
-!
-!  Distributed under the terms of the Berkeley Software Distribution (BSD)
-!  license
-!                     http://www.opensource.org/licenses/
-!  this module has been significantly modified to accomodate the
-!  new method of moving topography.
-!  it now contains the previous dtopo module among other changes
-!  David George, Vancouver WA December 2013
-! ============================================================================
 !  Module for topography data
 ! ============================================================================
 module topo_module

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -539,8 +539,8 @@ contains
  602                format('WARNING... ',i6, &
                            ' missing data values in this topofile')
                     write(6,603) topo_missing
- 603                format('   These values have been set to ',f13.3, &
-                           ' in read_topo_file')
+ 603                format('   These values have been set to topo_missing = ',&
+                           f13.3, ' in read_topo_file')
                     if (topo_missing == 99999.d0) then
                         print *, 'ERROR... do not use this default value'
                         print *, 'Fix your topofile or set'

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -551,11 +551,19 @@ contains
 
                 ! Write a warning if we found and missing values
                 if (missing > 0)  then
-                    print *, '   WARNING...some missing data values this file'
-                    print *, '       ',missing,' missing data values'
-                    print *, '   These values have arbitrarily been set to ',&
-                        topo_missing
-                    print *, '   See read_topo_file in topo_module.f90'
+                    write(6,602) missing
+ 602                format('WARNING... ',i6, &
+                           ' missing data values in this topofile')
+                    write(6,603) topo_missing
+ 603                format('   These values have been set to ',f13.3, &
+                           ' in read_topo_file')
+                    if (topo_missing == 99999.d0) then
+                        print *, 'ERROR... do not use this default value'
+                        print *, 'Fix your topofile or set'
+                        print *, '  rundata.topo_data.topo_missing in setrun.py'
+                        stop
+                        endif
+                    print *, ' '
                 endif
 
                 close(unit=iunit)

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -437,7 +437,6 @@ contains
 
         ! Locals
         integer, parameter :: iunit = 19, miss_unit = 17
-        !real(kind=8), parameter :: topo_missing = -150.d0 ! now read in
         logical, parameter :: maketype2 = .false.
         integer :: i,j,num_points,missing,status,topo_start,n
         real(kind=8) :: no_data_value,x,y,z,topo_temp

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -79,6 +79,8 @@ module topo_module
     integer, allocatable :: i0topo0(:),topo0ID(:)
     integer :: mtopo0size,mtopo0files
 
+    real(kind=8) topo_missing
+
 contains
 
     ! ========================================================================
@@ -125,6 +127,9 @@ contains
             else
                 call opendatafile(iunit, 'topo.data')
             endif
+
+            ! Read in value to use in place of no_data_value in topofile
+            read(iunit,*) topo_missing
 
             ! Read in topography specification type
             read(iunit,"(i1)") test_topography
@@ -447,7 +452,7 @@ contains
 
         ! Locals
         integer, parameter :: iunit = 19, miss_unit = 17
-        real(kind=8), parameter :: topo_missing = -150.d0
+        !real(kind=8), parameter :: topo_missing = -150.d0 ! now read in
         logical, parameter :: maketype2 = .false.
         integer :: i,j,num_points,missing,status,topo_start,n
         real(kind=8) :: no_data_value,x,y,z,topo_temp

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -141,7 +141,7 @@ class TopographyData(clawpack.clawutil.data.ClawData):
         super(TopographyData,self).__init__()
 
         # Topography data
-        self.add_attribute('topo_missing',100.)
+        self.add_attribute('topo_missing',99999.)
         self.add_attribute('test_topography',0)
         self.add_attribute('topofiles',[])
         

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -141,6 +141,7 @@ class TopographyData(clawpack.clawutil.data.ClawData):
         super(TopographyData,self).__init__()
 
         # Topography data
+        self.add_attribute('topo_missing',100.)
         self.add_attribute('test_topography',0)
         self.add_attribute('topofiles',[])
         
@@ -162,6 +163,8 @@ class TopographyData(clawpack.clawutil.data.ClawData):
     def write(self,data_source='setrun.py', out_file='topo.data'): 
 
         self.open_data_file(out_file, data_source)
+        self.data_write(name='topo_missing',
+                        description='replace no_data_value in topofile')
         self.data_write(name='test_topography',description='(Type topography specification)')
         if self.test_topography == 0:
             ntopofiles = len(self.topofiles)


### PR DESCRIPTION
Missing data values in topofiles were set to -150, which was arbitrary and not a good value to use, see #327 

Now set to 99999. by default and this value can be set in `setrun.py`. If there are missing values and this default is being used then the code halts with an error like:

```
WARNING...      6 missing data values in this topofile
   These values have been set to topo_missing =     99999.000 in read_topo_file
 ERROR... do not use this default value
 Fix your topofile or set
   rundata.topo_data.topo_missing in setrun.py
```

This value is written to `topo.data` and expected by the Fortran code, so users need to remake data and `make new` to incorporate the changes.