### PR TITLE
improving timing with 8 byte integers

### DIFF
--- a/examples/tsunami/chile2010/setplot.py
+++ b/examples/tsunami/chile2010/setplot.py
@@ -160,6 +160,29 @@ def setplot(plotdata=None):
     plotaxes.afteraxes = add_zeroline
 
 
+    #-----------------------------------------
+    # Plots of timing (CPU and wall time):
+
+    def make_timing_plots(plotdata):
+        from clawpack.visclaw import plot_timing_stats
+        import os,sys
+        try:
+            timing_plotdir = plotdata.plotdir + '/_timing_figures'
+            os.system('mkdir -p %s' % timing_plotdir)
+            # adjust units for plots based on problem:
+            units = {'comptime':'seconds', 'simtime':'hours', 
+                     'cell':'millions'}
+            plot_timing_stats.make_plots(outdir=plotdata.outdir, 
+                                          make_pngs=True,
+                                          plotdir=timing_plotdir, 
+                                          units=units)
+        except:
+            print('*** Error making timing plots')
+
+    otherfigure = plotdata.new_otherfigure(name='timing plots',
+                    fname='_timing_figures/timing.html')
+    otherfigure.makefig = make_timing_plots
+
 
     #-----------------------------------------
     

--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -14,8 +14,9 @@ c
       integer omp_get_thread_num, omp_get_max_threads
       integer mythread/0/, maxthreads/1/
       integer listgrids(numgrids(level))
-      integer clock_start, clock_finish, clock_rate
-      integer clock_startStepgrid, clock_startBound,clock_finishBound
+      integer(kind=8) :: clock_start, clock_finish, clock_rate
+      integer(kind=8) :: clock_startStepgrid, clock_startBound,
+     &                   clock_finishBound
       real(kind=8) cpu_start, cpu_finish
       real(kind=8) cpu_startBound,cpu_finishBound
       real(kind=8) cpu_startStepgrid, cpu_finishStepgrid

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -620,6 +620,7 @@ program amr2
     ! Timing
     ! moved inside tick, so timers can be checkpoint for
     ! possible restart
+    ! call here only for timing debug info at end
     call system_clock(clock_start,clock_rate)
 
     if (output_t0) then
@@ -763,6 +764,8 @@ program amr2
     write(timing_unit,*)
 
     ! output clock_rate etc. useful in debugging or if negative time reported
+
+    call system_clock(clock_finish,clock_rate,count_max)
     format_string="('clock_rate = ',i10, ' per second,  count_max = ',i23)"
     !write(*,format_string) clock_rate, count_max
     write(timing_unit,format_string) clock_rate, count_max

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -116,7 +116,7 @@ program amr2
     logical :: vtime, rest, output_t0    
 
     ! Timing variables
-    integer(kind=8) :: clock_start, clock_finish, clock_rate, ttotal
+    integer(kind=8) :: clock_start, clock_finish, clock_rate, ttotal, count_max
     real(kind=8) :: ttotalcpu
     integer, parameter :: timing_unit = 48
     character(len=512) :: timing_line, timing_substr
@@ -642,7 +642,7 @@ program amr2
     
     
 
-    call system_clock(clock_finish,clock_rate)
+    call system_clock(clock_finish,clock_rate,count_max)
     
     !output timing data
     open(timing_unit, file=timing_base_name//"txt", status='unknown',       &
@@ -652,7 +652,7 @@ program amr2
     format_string="('============================== Timing Data ==============================')"
     write(timing_unit,format_string)
     write(*,format_string)
-    
+
     write(*,*)
     write(timing_unit,*)
     
@@ -668,8 +668,6 @@ program amr2
     ttotalcpu=0.d0
     ttotal=0
 
-    call system_clock(clock_finish,clock_rate)  ! just to get clock_rate
-    write(*,*) "clock_rate ",clock_rate
 
     do level=1,mxnest
         format_string="(i3,'           ',1f15.3,'        ',1f15.3,'    ', e17.3)"
@@ -760,10 +758,21 @@ program amr2
     write(timing_unit, "('Note: timings are also recorded for each output step')")
     write(timing_unit, "('      in the file timing.csv.')")
     
-    
-    !end of timing data
+
     write(*,*)
     write(timing_unit,*)
+
+    ! output clock_rate etc. useful in debugging or if negative time reported
+    format_string="('clock_rate = ',i10, ' per second,  count_max = ',i23)"
+    !write(*,format_string) clock_rate, count_max
+    write(timing_unit,format_string) clock_rate, count_max
+
+    format_string="('clock_start = ',i20, ',  clock_finish = ',i20)"
+    !write(*,format_string) clock_start, clock_finish
+    write(timing_unit,format_string) clock_start, clock_finish
+    
+    
+    !end of timing data
     format_string="('=========================================================================')"
     write(timing_unit,format_string)
     write(*,format_string)

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -116,7 +116,7 @@ program amr2
     logical :: vtime, rest, output_t0    
 
     ! Timing variables
-    integer :: clock_start, clock_finish, clock_rate, ttotal
+    integer(kind=8) :: clock_start, clock_finish, clock_rate, ttotal
     real(kind=8) :: ttotalcpu
     integer, parameter :: timing_unit = 48
     character(len=512) :: timing_line, timing_substr

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -666,8 +666,13 @@ program amr2
     format_string="('Level           Wall Time (seconds)    CPU Time (seconds)   Total Cell Updates')"
     write(timing_unit,format_string)
     write(*,format_string)
-    ttotalcpu=0.d0
-    ttotal=0
+    if (rest) then
+        ttotalcpu=timeTickCPU
+        ttotal=timeTick
+      else
+        ttotalcpu=0.d0
+        ttotal=0
+      endif
 
 
     do level=1,mxnest

--- a/src/2d/shallow/gfixup.f
+++ b/src/2d/shallow/gfixup.f
@@ -15,7 +15,7 @@ c
       integer mythread/0/, maxthreads/1/
       integer newnumgrids(maxlv),listnewgrids(maxnumnewgrids)
 
-      integer clock_start, clock_finish, clock_rate
+      integer(kind=8) :: clock_start, clock_finish, clock_rate
       integer mbad
 c
 c ::::::::::::::::::::::::: GFIXUP ::::::::::::::::::::::::::::::::;

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -51,8 +51,6 @@ c          each step) to keep track of when that level should
 c          have its error estimated and finer levels should be regridded.
 c ::::::::::::::::::::::::::::::::::::;::::::::::::::::::::::::::
 c
-      call system_clock(tick_clock_start,tick_clock_rate)
-      call cpu_time(tick_cpu_start)
 
 
       ncycle         = nstart

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -19,8 +19,8 @@ c
 
       logical vtime,dumpout/.false./,dumpchk/.false./,rest,dump_final
       dimension dtnew(maxlv), ntogo(maxlv), tlevel(maxlv)
-      integer clock_start, clock_finish, clock_rate
-      integer tick_clock_finish, tick_clock_rate
+      integer(kind=8) :: clock_start, clock_finish, clock_rate
+      integer(kind=8) :: tick_clock_finish, tick_clock_rate
       character(len=128) :: time_format
       real(kind=8) cpu_start,cpu_finish
 

--- a/src/2d/shallow/valout.f90
+++ b/src/2d/shallow/valout.f90
@@ -49,8 +49,8 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
 #endif
 
     ! Timing
-    integer :: clock_start, clock_finish, clock_rate
-    integer    tick_clock_finish, tick_clock_rate, timeTick_int
+    integer(kind=8) :: clock_start, clock_finish, clock_rate
+    integer(kind=8) ::    tick_clock_finish, tick_clock_rate, timeTick_int
     real(kind=8) :: cpu_start, cpu_finish, t_CPU_overall, timeTick_overall
     character(len=128) :: console_format
     character(len=512) :: timing_line, timing_substr

--- a/src/2d/shallow/valout.f90
+++ b/src/2d/shallow/valout.f90
@@ -12,7 +12,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: node, rnode, ndilo, ndihi, ndjlo, ndjhi
     use amr_module, only: cornxlo, cornylo, levelptr, mxnest
     use amr_module, only: timeValout, timeValoutCPU, tvoll, tvollCPU, rvoll
-    use amr_module, only: timeTick, tick_clock_start, t0
+    use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
     use storm_module, only: storm_specification_type, output_storm_location
     use storm_module, only: output_storm_location
@@ -402,6 +402,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
         timeTick_overall = 0.d0
     else
         call cpu_time(t_CPU_overall)
+        ! if this is a restart, need to adjust add in time from previous run:
+        t_CPU_overall = t_CPU_overall + timeTickCPU
+
         call system_clock(tick_clock_finish,tick_clock_rate)
         timeTick_int = timeTick + tick_clock_finish - tick_clock_start
         timeTick_overall = real(timeTick_int, kind=8)/real(clock_rate,kind=8)


### PR DESCRIPTION
See https://github.com/clawpack/amrclaw/pull/250 for discussion of the changes in this PR.

The `chile2010` example also has a modified `setrun.py` to plot timing stats, using https://github.com/clawpack/visclaw/pull/247