### PR TITLE
Use where instead of find in some places

### DIFF
--- a/examples/tsunami/bowl-slosh-netcdf/setplot.py
+++ b/examples/tsunami/bowl-slosh-netcdf/setplot.py
@@ -123,7 +123,7 @@ def setplot(plotdata=None):
         # Return x value and surface eta at this point, along y=0
         from pylab import ravel
         x = current_data.x
-        y = current_data.y
+        y = ravel(current_data.y)
         dy = current_data.dy
         q = current_data.q
 

--- a/examples/tsunami/bowl-slosh/setplot.py
+++ b/examples/tsunami/bowl-slosh/setplot.py
@@ -127,7 +127,7 @@ def setplot(plotdata=None):
         dy = current_data.dy
         q = current_data.q
 
-        ij = where((y <= dy/2.) & (y > -dy/2.))[0]
+        ij = where((y <= dy/2.) & (y > -dy/2.))
         x_slice = ravel(x)[ij]
         eta_slice = ravel(q[3,:,:])[ij]
         return x_slice, eta_slice

--- a/examples/tsunami/bowl-slosh/setplot.py
+++ b/examples/tsunami/bowl-slosh/setplot.py
@@ -121,13 +121,13 @@ def setplot(plotdata=None):
 
     def xsec(current_data):
         # Return x value and surface eta at this point, along y=0
-        from pylab import find,ravel
+        from pylab import where,ravel
         x = current_data.x
-        y = current_data.y
+        y = ravel(current_data.y)
         dy = current_data.dy
         q = current_data.q
 
-        ij = find((y <= dy/2.) & (y > -dy/2.))
+        ij = where((y <= dy/2.) & (y > -dy/2.))[0]
         x_slice = ravel(x)[ij]
         eta_slice = ravel(q[3,:,:])[ij]
         return x_slice, eta_slice

--- a/tests/bowl_slosh/setplot.py
+++ b/tests/bowl_slosh/setplot.py
@@ -96,10 +96,9 @@ def setplot(plotdata):
     plotaxes.ylimits = [-0.15,0.3]
     plotaxes.title = 'Cross section at y=0'
     def plot_topo_xsec(current_data):
-        from pylab import plot, hold, cos,sin,where,legend,nan
+        from pylab import plot, cos,sin,where,legend,nan
         t = current_data.t
 
-        hold(True)
         x = linspace(-2,2,201)
         y = 0.
         B = h0*(x**2 + y**2)/a**2 - h0
@@ -111,20 +110,19 @@ def setplot(plotdata):
         ## plot([0],[-1],'bo',label="Level 2")  # but will produced desired legend
         plot([0],[-1],'bo',label="Computed")  ## need to fix plotstyle
         legend()
-        hold(False)
     plotaxes.afteraxes = plot_topo_xsec
 
     plotitem = plotaxes.new_plotitem(plot_type='1d_from_2d_data')
 
     def xsec(current_data):
         # Return x value and surface eta at this point, along y=0
-        from pylab import find,ravel
+        from pylab import where,ravel
         x = current_data.x
-        y = current_data.y
+        y = ravel(current_data.y)
         dy = current_data.dy
         q = current_data.q
 
-        ij = find((y <= dy/2.) & (y > -dy/2.))
+        ij = where((y <= dy/2.) & (y > -dy/2.))[0]
         x_slice = ravel(x)[ij]
         eta_slice = ravel(q[3,:,:])[ij]
         return x_slice, eta_slice

--- a/tests/bowl_slosh/setplot.py
+++ b/tests/bowl_slosh/setplot.py
@@ -122,7 +122,7 @@ def setplot(plotdata):
         dy = current_data.dy
         q = current_data.q
 
-        ij = where((y <= dy/2.) & (y > -dy/2.))[0]
+        ij = where((y <= dy/2.) & (y > -dy/2.))
         x_slice = ravel(x)[ij]
         eta_slice = ravel(q[3,:,:])[ij]
         return x_slice, eta_slice

--- a/tests/dtopo1/setplot.py
+++ b/tests/dtopo1/setplot.py
@@ -108,13 +108,13 @@ def setplot(plotdata):
 
     def xsec(current_data):
         # Return x value and surface eta at this point, along y=0
-        from pylab import find,ravel
+        from pylab import where,ravel
         x = current_data.x
-        y = current_data.y
+        y = ravel(current_data.y)
         dy = current_data.dy
         q = current_data.q
 
-        ij = find((y <= y0+dy/2.+1e-8) & (y > y0-dy/2.))
+        ij = where((y <= y0+dy/2.+1e-8) & (y > y0-dy/2.))[0]
         x_slice = ravel(x)[ij]
         eta_slice = ravel(q[3,:,:])[ij]
         return x_slice, eta_slice
@@ -125,16 +125,16 @@ def setplot(plotdata):
     plotitem.amr_show = [1]  # plot on all levels
 
     def add_dtopo_plot(current_data):
-        from pylab import find, plot, legend
+        from pylab import where, plot, legend
         for dtopo in [dtopo1,dtopo2]:
-            j = max(find(dtopo.y <= y0))
+            j = max(where(dtopo.y <= y0)[0])
             j1 = min(j+1, len(dtopo.y)-1)
             beta = (y0 - dtopo.y[j])/(dtopo.y[1] - dtopo.y[0])
     
             t = current_data.t
-            itlist = find(dtopo.times <= t)
+            itlist = where(dtopo.times <= t)[0]
             if len(itlist) > 0:
-                it = max(find(dtopo.times <= t))
+                it = max(where(dtopo.times <= t)[0])
                 #print "+++ t, it, dtopo.times[it]: ",t, it, dtopo.times[it]
                 dz = dtopo.dZ[it,:,:]
                 dzj = dz[j,:]


### PR DESCRIPTION
Since `matplotlib.find` is deprecated, use `where` instead in some `setplot.py` files.

Also a missing `ravel` in a couple files for plotting the bowl-slosh surface.