### PR TITLE
make netcdf build on travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ __pycache__
 
 # ipython
 .ipynb_checkpoints
+
+# macOS
+*.DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,8 @@ before_script:
   - echo "PYTHONPATH="$PYTHONPATH
   - echo "CLAW="$CLAW
   - echo "FC="$FC
+  - ls /usr/local/lib
+  - ls /usr/share/lib
   - find ${HOME} -name netcdf.mod  
 script:
   - cd $CLAW/geoclaw

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - echo "PYTHONPATH="$PYTHONPATH
   - echo "CLAW="$CLAW
   - echo "FC="$FC
-  
+  - find ${HOME} --name netcdf.mod  
 script:
   - cd $CLAW/geoclaw
   - nosetests -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ install:
   - export CLAW=${PWD}
   - export FC=gfortran
   - export NETCDF4_DIR=/usr
-  - cd geoclaw
 
 before_script:
   # Print CPU info for debugging purposes:
@@ -35,8 +34,8 @@ before_script:
   - echo "PYTHONPATH="$PYTHONPATH
   - echo "CLAW="$CLAW
   - echo "FC="$FC
-  - ls /usr/lib
-  - find /usr -name netcdf*
+  - echo "NETCDF4_DIR="$NETCDF4_DIR
+
 script:
   - cd $CLAW/geoclaw
   - nosetests -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install:
   - export PYTHONPATH=${PWD}:$PYTHONPATH
   - export CLAW=${PWD}
   - export FC=gfortran
+  - export NETCDF4_DIR=/usr/local
   - cd geoclaw
   
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
   - 2.7
-  - 3.5
+  - 3.7
 env:
   - BUILD_TYPE="Release"
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - export PYTHONPATH=${PWD}:$PYTHONPATH
   - export CLAW=${PWD}
   - export FC=gfortran
-  - export NETCDF4_DIR=/usr/lib/x86_64-linux-gnu
+  - export NETCDF4_DIR=/usr
   - cd geoclaw
   
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,10 @@ python:
   - 3.7
 env:
   - BUILD_TYPE="Release"
-  
+
 before_install:
   - sudo apt-get update
-  - sudo apt-get install gfortran liblapack-pic liblapack-dev libnetcdf-dev libnetcdff-dev
+  - sudo apt-get install gfortran liblapack-pic liblapack-dev
   - pip install netCDF4
   - pip install xarray
   - pip install scipy
@@ -19,14 +19,14 @@ before_install:
   - ln -s ../ geoclaw
   # Print NumPy version being used
   - python -c "import numpy; print(numpy.__version__)"
-  
+
 install:
   - export PYTHONPATH=${PWD}:$PYTHONPATH
   - export CLAW=${PWD}
   - export FC=gfortran
   - export NETCDF4_DIR=/usr
   - cd geoclaw
-  
+
 before_script:
   # Print CPU info for debugging purposes:
   - cat /proc/cpuinfo
@@ -43,6 +43,6 @@ script:
 
 after_failure:
  - for failed_test_path in *_output ; do cat $failed_test_path/run_output.txt ; cat $failed_test_path/error_output.txt ; done
-  
+
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ before_script:
   - echo "CLAW="$CLAW
   - echo "FC="$FC
   - ls /usr/lib
-  - find / -name libnetcdf*  
 script:
   - cd $CLAW/geoclaw
   - nosetests -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
   - echo "CLAW="$CLAW
   - echo "FC="$FC
   - ls /usr/lib
-  - find ${HOME} -name netcdf.mod  
+  - find / -name libnetcdf*  
 script:
   - cd $CLAW/geoclaw
   - nosetests -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install gfortran liblapack-pic liblapack-dev
+  - sudo apt-get install gfortran liblapack-pic liblapack-dev libnetcdf-dev libnetcdff-dev
   - pip install netCDF4
   - pip install xarray
   - pip install scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,7 @@ before_script:
   - echo "CLAW="$CLAW
   - echo "FC="$FC
   - ls /usr/lib
+  - find /usr -name netcdf*
 script:
   - cd $CLAW/geoclaw
   - nosetests -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,7 @@ before_script:
   - echo "PYTHONPATH="$PYTHONPATH
   - echo "CLAW="$CLAW
   - echo "FC="$FC
-  - ls /usr/local/lib
-  - ls /usr/share/lib
+  - ls /usr/lib
   - find ${HOME} -name netcdf.mod  
 script:
   - cd $CLAW/geoclaw

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ before_script:
   - echo "PYTHONPATH="$PYTHONPATH
   - echo "CLAW="$CLAW
   - echo "FC="$FC
-  - find ${HOME} --name netcdf.mod  
+  - find ${HOME} -name netcdf.mod  
 script:
   - cd $CLAW/geoclaw
   - nosetests -sv

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
   
 before_install:
   - sudo apt-get update
-  - sudo apt-get install gfortran liblapack-pic liblapack-dev
+  - sudo apt-get install gfortran liblapack-pic liblapack-dev libnetcdf-dev libnetcdff-dev
   - pip install netCDF4
   - pip install xarray
   - pip install scipy

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ install:
   - export PYTHONPATH=${PWD}:$PYTHONPATH
   - export CLAW=${PWD}
   - export FC=gfortran
-  - export NETCDF4_DIR=/usr/local
+  - export NETCDF4_DIR=/usr/lib/x86_64-linux-gnu
   - cd geoclaw
   
 before_script:

--- a/tests/netcdf_topo/regression_tests.py
+++ b/tests/netcdf_topo/regression_tests.py
@@ -32,8 +32,6 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
 
         super(NetCDFBowlSloshTest, self).__init__(methodName=methodName)
 
-        self.netcdf_passed = False
-
 
     def setUp(self):
 
@@ -96,14 +94,10 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
 
         except ImportError:
             # Assume that NetCDF is not installed and move on
-            self.netcdf_passed = False
-            self.success = True
             raise nose.SkipTest(build_failure_str)
 
         except RuntimeError as e:
             print(e.message)
-            self.netcdf_passed = False
-            self.success = True
             raise nose.SkipTest("NetCDF topography test skipped due to " +
                                 "runtime failure.")
         else:
@@ -132,7 +126,6 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
             if os.path.exists(obj_path):
                 os.remove(obj_path)
 
-            self.netcdf_passed = True
             super(NetCDFBowlSloshTest, self).build_executable()
 
 
@@ -141,19 +134,16 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
 
         """
 
-        # Check to see if NetCDF has been built
-        if self.netcdf_passed:
-            # Write out data files
-            self.load_rundata()
-            self.write_rundata_objects()
+        # Write out data files
+        self.load_rundata()
+        self.write_rundata_objects()
 
-            # Run code
-            self.run_code()
+        # Run code
+        self.run_code()
 
-            # Perform tests
-            self.check_gauges(save=save, gauge_id=1, indices=(2, 3),
-                              tolerance=1e-4)
-        self.success = True
+        # Perform tests
+        self.check_gauges(save=save, gauge_id=1, indices=(2, 3),
+                          tolerance=1e-4)
 
 
     def tearDown(self):

--- a/tests/netcdf_topo/regression_tests.py
+++ b/tests/netcdf_topo/regression_tests.py
@@ -22,7 +22,7 @@ import nose
 import clawpack.geoclaw.test as test
 import clawpack.geoclaw.topotools as topotools
 
-build_failure_str = ("NetCDF topography test skipped due to failure to build " 
+build_failure_str = ("NetCDF topography test skipped due to failure to build "
                      "test program.")
 class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
 
@@ -75,11 +75,11 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
         topo = topotools.Topography(topo_func=z)
         topo.x = numpy.linspace(-3.1, 3.1, 310)
         topo.y = numpy.linspace(-3.5,2.5, 300)
-        
+
         try:
             import netCDF4
             this_path = os.path.join(self.temp_path, 'bowl.nc')
-            
+
             # now mess with the order of the dimension IDs (lat, then lon)
             with netCDF4.Dataset(this_path,'w') as out:
                 lat = out.createDimension('lat',len(topo.y))
@@ -119,8 +119,7 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
         except subprocess.CalledProcessError:
 
             self.stdout.write(build_failure_str)
-            raise
-            #raise nose.SkipTest(build_failure_str)
+            raise nose.SkipTest(build_failure_str)
 
         else:
             # Force recompilation of topo_module to add NetCDF flags

--- a/tests/netcdf_topo/regression_tests.py
+++ b/tests/netcdf_topo/regression_tests.py
@@ -119,7 +119,8 @@ class NetCDFBowlSloshTest(test.GeoClawRegressionTest):
         except subprocess.CalledProcessError:
 
             self.stdout.write(build_failure_str)
-            raise nose.SkipTest(build_failure_str)
+            raise
+            #raise nose.SkipTest(build_failure_str)
 
         else:
             # Force recompilation of topo_module to add NetCDF flags


### PR DESCRIPTION
We were having some issues with netcdf in our build of clawpack and I realized that we have actually never been testing netcdf on travis. Previously, the netcdf tests would pass if netcdf-based builds failed. At some point, I changed this behavior to "Skip" but since that point, all travis builds have skipped. I installed the appropriate netcdf libraries and now that test is passing "for real".

I also bumped the python 3.x version to 3.7. We could test on 3.5 (and any other 3.x) as well if you think its useful?

Finally, I just added the macOS .DS_Store file to the gitignore since it was annoying me.