### PR TITLE
Variable max1d

### DIFF
--- a/examples/tsunami/chile2010/setrun.py
+++ b/examples/tsunami/chile2010/setrun.py
@@ -279,6 +279,9 @@ def setrun(claw_pkg='geoclaw'):
     # ---------------
     amrdata = rundata.amrdata
 
+    # maximum size of patches in each direction (matters in parallel):
+    amrdata.max1d = 60
+
     # max number of refinement levels:
     amrdata.amr_levels_max = 3
 

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -331,7 +331,6 @@ program amr2
     call opendatafile(inunit, amrfile)
 
     read(inunit,*) max1d  ! max size of each grid patch
-    write(6,*) '+++ max1d = ',max1d
 
     read(inunit,*) mxnest
     if (mxnest <= 0) then

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -330,6 +330,9 @@ program amr2
     !  Refinement Control
     call opendatafile(inunit, amrfile)
 
+    read(inunit,*) max1d  ! max size of each grid patch
+    write(6,*) '+++ max1d = ',max1d
+
     read(inunit,*) mxnest
     if (mxnest <= 0) then
         stop 'Error ***   mxnest (amrlevels_max) <= 0 not allowed'

--- a/src/2d/shallow/qad.f
+++ b/src/2d/shallow/qad.f
@@ -38,15 +38,15 @@ c      # in rp2, but shouldn't matter since wave is not used in qad
 c      # and for other arrays it is only the last parameter that is wrong
 c      #  ok as long as meqn, mwaves < maxvar
 
-       parameter (max1dp1 = max1d+1)
-       dimension ql(nvar,max1dp1),    qr(nvar,max1dp1)
-       dimension wave(nvar,mwaves,max1dp1), s(mwaves,max1dp1)
-       dimension amdq(nvar,max1dp1),  apdq(nvar,max1dp1)
-       dimension auxl(maxaux*max1dp1),  auxr(maxaux*max1dp1)
+       integer max1dp1
+       dimension ql(nvar,max1d+1),    qr(nvar,max1d+1)
+       dimension wave(nvar,mwaves,max1d+1), s(mwaves,max1d+1)
+       dimension amdq(nvar,max1d+1),  apdq(nvar,max1d+1)
+       dimension auxl(maxaux*(max1d+1)),  auxr(maxaux*(max1d+1))
 c
 c  WARNING: auxl,auxr dimensioned at max possible, but used as if
-c  they were dimensioned as the real maux by max1dp1. Would be better
-c  of course to dimension by maux by max1dp1 but this wont work if maux=0
+c  they were dimensioned as the real maux by max1d+1. Would be better
+c  of course to dimension by maux by max1d+1 but this wont work if maux=0
 c  So need to access using your own indexing into auxl,auxr.
        iaddaux(iaux,i) = iaux + maux*(i-1)
 
@@ -69,6 +69,7 @@ c       return
 
 c  ---------------------------------------------------------------
 
+       max1dp1 = max1d + 1
 
        if (qprint) write(dbugunit,*)" working on grid ",mptr
        tgrid = rnode(timemult, mptr)

--- a/src/2d/shallow/stepgrid.f
+++ b/src/2d/shallow/stepgrid.f
@@ -34,8 +34,6 @@ c :::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
       external rpn2,rpt2
 
 
-c      parameter (msize=max1d+4)
-c      parameter (mwork=msize*(maxvar*maxvar + 13*maxvar + 3*maxaux +2))
 
       dimension q(nvar,mitot,mjtot)
       dimension fp(nvar,mitot,mjtot),gp(nvar,mitot,mjtot)


### PR DESCRIPTION
Required to go with clawpack/amrclaw#253.

max1d is now a parameter that can optionally be set in setrun.py as `rundata.amrdata.max1d`. Otherwise it has the default value 60 from 2d amrclaw.  Shows up in `amr.data`.

Hoping this passes travis tests since https://github.com/clawpack/clawpack/pull/170 has been merged.