### PR TITLE
Interpolation in fill_rad_w_other_source

### DIFF
--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1386,6 +1386,9 @@ def fill_rad_w_other_source(t, storm_targ, storm_fill, var):
 
         #remove duplicates
         fill_da = fill_da.groupby('t').first()
+	
+	# remove NaNs
+        fill_da = fill_da.dropna('t')
 
         # interpolate to point
         fill_interp = fill_da.interp({'t':t}).item()

--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1324,7 +1324,7 @@ def cle_2015(storm, r, t):
 
 # =============================================================================
 # Radius fill functions
-def fill_rad_w_other_source(t, storm_targ, storm_fill, var):
+def fill_rad_w_other_source(t, storm_targ, storm_fill, var, interp_kwargs={}):
     r"""Fill in storm radius variable (*max_wind_radius* or \
     *storm_radius*) with values from another source. i.e.
     if you have missing radii in IBTrACS, you can fill with ATCF.
@@ -1346,6 +1346,8 @@ def fill_rad_w_other_source(t, storm_targ, storm_fill, var):
     - *storm_fill* (:py:class:`clawpack.geoclaw.storm.Storm`) storm
         that has non-missing values you want to use to fill *storm_targ*
     - *var* (str) Either 'max_wind_radius' or 'storm_radius'
+    - *interp_kwargs* (dict) Additional keywords passed to scipy's
+        interpolator.
 
     :Returns:
     - (float) value to use to fill this time point in *storm_targ*. -1
@@ -1386,12 +1388,12 @@ def fill_rad_w_other_source(t, storm_targ, storm_fill, var):
 
         #remove duplicates
         fill_da = fill_da.groupby('t').first()
-	
-	# remove NaNs
+
+        # remove NaNs
         fill_da = fill_da.dropna('t')
 
         # interpolate to point
-        fill_interp = fill_da.interp({'t':t}).item()
+        fill_interp = fill_da.interp(t=[t], kwargs=interp_kwargs).item()
 
         # try replacing with storm_fill
         # (assuming atcf has more data points than ibtracs)
@@ -1405,7 +1407,8 @@ def fill_rad_w_other_source(t, storm_targ, storm_fill, var):
     targ_da = targ_da.where(targ_da>0,numpy.nan)
     if targ_da.notnull().any():
         targ_da = targ_da.groupby('t').first()
-        targ_interp = targ_da.interp({'t':t}).item()
+        targ_da = targ_da.dropna('t')
+        targ_interp = targ_da.interp(t=[t], kwargs=interp_kwargs).item()
         if not numpy.isnan(targ_interp):
             return targ_interp
         


### PR DESCRIPTION
The utility function `fill_rad_w_other_source` fills in missing wind radius data, amongst others, using interpolation. This PR makes sure that no NaNs are present in the interpolation step. Furthermore, it adds an optional parameter (`interp_kwargs`) to `fill_rad_w_other_source` that is passed on to xarray's `DataArray.interp(...)` where it is used as keyword arguments to scipy's interpolator. A typical use case would be to specify `{ 'fill_value': 'extrapolate' }`.