### PR TITLE
Multilayer gauge fix

### DIFF
--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -464,6 +464,11 @@ program amr2
 
         ! moved upt before restrt or won't properly initialize 
         call set_fgmax()   
+        
+        ! need these before set_gauges so num_out_vars set right for gauges
+        call set_geo()                    ! sets basic parameters g and coord system
+        call set_multilayer()             ! Set multilayer SWE parameters
+        
         ! Set gauge output, note that restrt might reset x,y for lagrangian:
         call set_gauges(rest, nvar, naux) 
 
@@ -475,18 +480,19 @@ program amr2
         print *, 'Restarting from previous run'
         print *, '   at time = ',time
         print *, ' '
+
         ! Call user routine to set up problem parameters:
         call setprob()
 
         ! Non-user defined setup routine
-        call set_geo()                    ! sets basic parameters g and coord system
+        !call set_geo()                    ! sets basic parameters g and coord system
         call set_refinement()             ! sets refinement control parameters
         call read_dtopo_settings()        ! specifies file with dtopo from earthquake
         call read_topo_settings()         ! specifies topography (bathymetry) files
         call set_qinit()                  ! specifies file with dh if this used instead
         call set_fixed_grids()            ! Fixed grid settings
         call setup_variable_friction()    ! Variable friction parameter
-        call set_multilayer()             ! Set multilayer SWE parameters
+        !call set_multilayer()             ! Set multilayer SWE parameters
         call set_storm()                  ! Set storm parameters
         call set_regions()                ! Set refinement regions
         call read_adjoint_data()          ! Read adjoint solution

--- a/src/2d/shallow/multilayer/gauges_module.f90
+++ b/src/2d/shallow/multilayer/gauges_module.f90
@@ -65,6 +65,13 @@ module gauges_module
         ! Last time recorded
         real(kind=8) :: last_time
 
+        ! Last time and final (x,y) written to file 
+        ! (only needed for lagrangian gauges, for checkpointing)
+        ! lagrangian gauges not yet supported in multilayer,
+        ! but these variables still needed for checkpt, restart
+        real(kind=8) :: t_last_written, x_last_written, y_last_written
+
+
         ! Output settings
         integer :: file_format, gtype
         real(kind=8) :: min_time_increment
@@ -93,6 +100,7 @@ contains
 
         use utility_module, only: get_value_count
 
+        use amr_module, only: NEEDS_TO_BE_SET
         use multilayer_module, only: num_layers
 
         implicit none
@@ -129,8 +137,16 @@ contains
             do i=1,num_gauges
                 read(UNIT, *) gauges(i)%gauge_num, gauges(i)%x, gauges(i)%y, &
                               gauges(i)%t_start, gauges(i)%t_end
+                ! note that for lagrangian gauges, the x,y values read here 
+                ! might be overwritten if this is a restart
                 gauges(i)%buffer_index = 1
                 gauges(i)%last_time = gauges(i)%t_start
+                ! keep track of last position for lagrangian gauges,
+                ! initialize here in case checkpoint happens before 
+                ! ever writing this gauge:
+                gauges(i)%t_last_written = NEEDS_TO_BE_SET
+                gauges(i)%x_last_written = gauges(i)%x
+                gauges(i)%y_last_written = gauges(i)%y
             enddo
 
             ! Read in output formats
@@ -638,6 +654,16 @@ contains
             open(unit=myunit, file=gauges(gauge_num)%file_name, status='old', &
                               position='append', form='formatted')
           
+            !if (gauges(gauge_num)%gtype == 2) then
+                ! keep track of last x,y location written to gauge file
+                ! in case we are at a checkpoint time
+            j = gauges(gauge_num)%buffer_index - 1
+            if (j > 0) then
+                gauges(gauge_num)%t_last_written = gauges(gauge_num)%data(1, j)
+                gauges(gauge_num)%x_last_written = gauges(gauge_num)%data(3, j)
+                gauges(gauge_num)%y_last_written = gauges(gauge_num)%data(4, j)
+            endif
+
             ! Loop through gauge's buffer writing out all available data.  Also
             ! reset buffer_index back to beginning of buffer since we are emptying
             ! the buffer here

--- a/tests/multilayer/Makefile
+++ b/tests/multilayer/Makefile
@@ -18,8 +18,6 @@ OUTDIR = _output               # Directory for output
 SETPLOT_FILE = setplot.py      # File containing function to set plots
 PLOTDIR = _plots               # Directory for plots
 
-RESTART = False
-
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 
 # Compiler flags can be specified here or set as an environment variable


### PR DESCRIPTION
Lagrangian gauges aren't yet handled in multilayer code but some variables need to be added to the `gauge_type`. 

There aren't used unless doing a restart, but the latest gfortran caught this and `tests/multilayer` didn't pass.

I also decided to check that restarting works and it didn't because of another issue: In `amr2.f90` it is now necessary to call `set_geo` and `set_multilayer` before `set_gauges` so the number of layers is set.

At some point, need to investigate whether other `set_*` routines should best be called before or after `restrt`, depending on whether the user should be allowed to modify various things in the restart from the original run.

But I think things are working again as in v5.6.1.
