### PR TITLE
Correctly handle zero coordinate values in read_atcf

### DIFF
--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -357,11 +357,15 @@ class Storm(object):
             self.classification[i] = data[10]
 
             # Parse eye location - longitude/latitude order
-            if data[6][-1] == "N":
+            if data[6] == "0":
+                self.eye_location[i, 1] = 0.0
+            elif data[6][-1] == "N":
                 self.eye_location[i, 1] = float(data[6][0:-1]) / 10.0
             else:
                 self.eye_location[i, 1] = -float(data[6][0:-1]) / 10.0
-            if data[7][-1] == "E":
+            if data[7] == "0":
+                self.eye_location[i, 0] = 0.0
+            elif data[7][-1] == "E":
                 self.eye_location[i, 0] = float(data[7][0:-1]) / 10.0
             else:
                 self.eye_location[i, 0] = -float(data[7][0:-1]) / 10.0


### PR DESCRIPTION
In some ATCF files, such as https://ftp.nhc.noaa.gov/atcf/archive/2001/aal032001.dat.gz, zero coordinate values are sometimes stored as "0" instead of "0N" so that the previous parsing routine raised a ValueError ("could not convert string to float:").