### PR TITLE
remove unneeded addition to python path in a setplot

### DIFF
--- a/examples/tsunami/eta_init_force_dry/setplot.py
+++ b/examples/tsunami/eta_init_force_dry/setplot.py
@@ -16,11 +16,6 @@ from clawpack.geoclaw import topotools
 from six.moves import range
 import os,sys
 
-
-new_code = '../../new_python'
-print('Adding %s to path' % new_code)
-sys.path.insert(0, new_code)
-
 cmax = 0.5
 cmin = -cmax
 


### PR DESCRIPTION
Left over from an earlier test version before things were merged into geoclaw.