### PR TITLE
Clean up model_storm_module and bound azimuthal wind at 0

### DIFF
--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -391,9 +391,11 @@ contains
 
     ! 2. Convert wind speed at 10 m to top of atmospheric boundary layer
     ! ==========================================================================
-    subroutine adjust_max_wind(tv, mws, mod_mws)
+    pure subroutine adjust_max_wind(tv, mws, mod_mws)
 
-        real (kind=8), intent(inout) :: tv(2), mws
+        real (kind=8), intent(inout) :: tv(2)
+        
+        real (kind=8), intent(in) :: mws
 
         real (kind=8), intent(out) :: mod_mws
 
@@ -432,7 +434,7 @@ contains
 
     ! 5. Apply distance ramp to limit scope
     ! ==========================================================================
-    subroutine post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
+    pure subroutine post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
         wind_index, pressure_index, r, radius, tv, mod_mws, theta, Pa)
 
         integer, intent(in) :: maux, mbc, mx, my, i, j


### PR DESCRIPTION
The main change from this PR is to close #465 by clipping azimuthal wind speed at 0 (no negative values). In addition, I cleaned up the model_storm_module file a bit by pulling out common pre- and post-processing functionality into separate subroutines (including this bounding at 0 function). I noticed a few errors in some of the wind models that I noted in #466 but didn't address as my knowledge of these wind models is limited