### PR TITLE
Fix fetch_noaa_tide_data() method to match current NOAA API formatting

### DIFF
--- a/src/python/geoclaw/util.py
+++ b/src/python/geoclaw/util.py
@@ -271,7 +271,7 @@ def fetch_noaa_tide_data(station, begin_date, end_date, time_zone='GMT',
 
     # fetch water levels and tide predictions
     date_time, water_level = fetch(
-        'water_level', 'Date Time, Water Level, Sigma, O, F, R, L, Quality',
+        'water_level', 'Date Time, Water Level, Sigma, O or I (for verified), F, R, L, Quality',
         col_idx, col_types)
     date_time2, prediction = fetch('predictions', 'Date Time, Prediction',
                                    col_idx, col_types)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -35,7 +35,7 @@ class TestFetchNoaaTideData:
                                  self.test_retrieve_and_cache.__name__)
 
         water_level_response = \
-            ('Date Time, Water Level, Sigma, O, F, R, L, Quality\n'
+            ('Date Time, Water Level, Sigma, O or I (for verified), F, R, L, Quality\n'
              '2000-10-30 12:00,1.001,0.001,0,0,0,0,v\n'
              '2000-10-30 12:06,1.002,0.002,0,0,0,0,v\n'
              '2000-10-30 12:12,1.003,0.003,0,0,0,0,v\n'

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -97,7 +97,7 @@ class TestFetchNoaaTideData:
 
         # missing first two entries
         water_level_response = \
-            ('Date Time, Water Level, Sigma, O, F, R, L, Quality\n'
+            ('Date Time, Water Level, Sigma, O or I (for verified), F, R, L, Quality\n'
              '2000-10-30 12:12,1.003,0.003,0,0,0,0,v\n'
              '2000-10-30 12:18,1.004,0.004,0,0,0,0,v\n'
              '2000-10-30 12:24,1.005,0.005,0,0,0,0,v\n')
@@ -127,7 +127,7 @@ class TestFetchNoaaTideData:
 
         # missing fist two water level values
         water_level_response = \
-            ('Date Time, Water Level, Sigma, O, F, R, L, Quality\n'
+            ('Date Time, Water Level, Sigma, O or I (for verified), F, R, L, Quality\n'
              '2000-10-30 12:00,,0.001,0,0,0,0,v\n'
              '2000-10-30 12:06,,0.002,0,0,0,0,v\n'
              '2000-10-30 12:12,1.003,0.003,0,0,0,0,v\n'


### PR DESCRIPTION
Previously, this method would expect different formatting from the NOAA API, leading to a Value Error being thrown.