### PR TITLE
warn instead of fail if etopo1 data can't be read from thredds server

### DIFF
--- a/tests/test_etopo1.py
+++ b/tests/test_etopo1.py
@@ -5,6 +5,7 @@ import os
 import numpy
 import nose
 import os
+import warnings
 from clawpack.geoclaw import topotools
 
 
@@ -21,11 +22,20 @@ def test_etopo1_topo(make_plot=False, save=False):
         import netCDF4
     except:
         raise nose.SkipTest("netCDF4 not installed, skipping test")
-        
-    topo1 = topotools.read_netcdf('etopo1', extent=extent, verbose=True)
 
-    topo10 = topotools.read_netcdf('etopo1', extent=extent, 
-                                   coarsen=10, verbose=True)
+    try:
+        topo1 = topotools.read_netcdf('etopo1', extent=extent, verbose=True)
+    except:
+        warnings.warn('Could not read etopo1 data, check if thredds server up')
+        raise nose.SkipTest("Reading etopo1 failed, skipping test")
+        
+
+    try:
+        topo10 = topotools.read_netcdf('etopo1', extent=extent, 
+                                       coarsen=10, verbose=True)
+    except:
+        warnings.warn('Could not read etopo1 data, check if thredds server up')
+        raise nose.SkipTest("Reading etopo1 failed, skipping test")
 
     testdata_path = os.path.join(os.path.dirname(__file__), 'data', 'etopo1_10min.asc')
     if save:
@@ -58,9 +68,13 @@ def test_etopo1_xarray():
     except:
         raise nose.SkipTest("xarray not installed, skipping test")
         
-    topo10,topo10_xarray = topotools.read_netcdf('etopo1', extent=extent, 
-                                                 return_xarray=True,
-                                                 coarsen=10, verbose=True)
+    try:
+        topo10,topo10_xarray = topotools.read_netcdf('etopo1', extent=extent, 
+                                                     return_xarray=True,
+                                                     coarsen=10, verbose=True)
+    except:
+        warnings.warn('Could not read etopo1 data, check if thredds server up')
+        raise nose.SkipTest("Reading etopo1 failed, skipping test")
 
     testdata_path = os.path.join(testdir, 'data', 'etopo1_10min.asc')
     topo10input = topotools.Topography()


### PR DESCRIPTION
The NOAA thredds server is sometimes down, making travis fail. 
This would issue a warning instead. 

@mandli: Look ok to do it this way?