### PR TITLE
Fix call to preinterpcopy; specify exceptions in test_etopo1

### DIFF
--- a/src/2d/shallow/filval.f90
+++ b/src/2d/shallow/filval.f90
@@ -151,7 +151,7 @@ subroutine filval(val, mitot, mjtot, dx, dy, level, time,  mic, &
           ! so only call intcopy (which copies soln) and not icall.
           if ((xperdom .and. sticksoutxfine)  .or. (yperdom.and.sticksoutyfine)) then
              call preintcopy(val,mitot,mjtot,nvar,ilo-nghost,ihi+nghost,  &
-                       jlo-nghost,jhi+nghost,level,1,1,fliparray)
+                       jlo-nghost,jhi+nghost,level,fliparray)
           else
              call intcopy(val,mitot,mjtot,nvar,ilo-nghost,ihi+nghost,  &
                           jlo-nghost,jhi+nghost,level,1,1)   

--- a/tests/test_etopo1.py
+++ b/tests/test_etopo1.py
@@ -20,20 +20,14 @@ def test_etopo1_topo(make_plot=False, save=False):
     
     try:
         import netCDF4
-    except:
+    except ImportError:
         raise nose.SkipTest("netCDF4 not installed, skipping test")
 
     try:
         topo1 = topotools.read_netcdf('etopo1', extent=extent, verbose=True)
-    except:
-        warnings.warn('Could not read etopo1 data, check if thredds server up')
-        raise nose.SkipTest("Reading etopo1 failed, skipping test")
-        
-
-    try:
         topo10 = topotools.read_netcdf('etopo1', extent=extent, 
                                        coarsen=10, verbose=True)
-    except:
+    except (OSError, RuntimeError):
         warnings.warn('Could not read etopo1 data, check if thredds server up')
         raise nose.SkipTest("Reading etopo1 failed, skipping test")
 
@@ -65,14 +59,14 @@ def test_etopo1_xarray():
 
     try:
         import xarray
-    except:
+    except ImportError:
         raise nose.SkipTest("xarray not installed, skipping test")
         
     try:
         topo10,topo10_xarray = topotools.read_netcdf('etopo1', extent=extent, 
                                                      return_xarray=True,
                                                      coarsen=10, verbose=True)
-    except:
+    except (OSError, RuntimeError):
         warnings.warn('Could not read etopo1 data, check if thredds server up')
         raise nose.SkipTest("Reading etopo1 failed, skipping test")
 


### PR DESCRIPTION
This PR fixes #476 . It also makes the try/except clause in the etopo test a bit more precise (i.e. it only allows OSError or RuntimeError exceptions) just to avoid skipping errors that aren't due to the THREDDS server.