### PR TITLE
Bug fix for restart with fgmax grids and mxnest increase

### DIFF
--- a/src/2d/shallow/restrt.f
+++ b/src/2d/shallow/restrt.f
@@ -73,9 +73,10 @@ c     # need to allocate for dynamic memory:
         do ifg = 1, FG_num_fgrids
           fg => FG_fgrids(ifg)
           read(rstunit) fg%levelmax
-          read(rstunit) fg%auxdone(1:mxnest) 
+          read(rstunit) fg%auxdone(1:mxnold) 
           read(rstunit) fg%x,fg%y,fg%valuemax,fg%tmax,
-     &       fg%arrival_time,fg%aux(1:mxnold,:,:),fg%t_last_updated
+     &       fg%arrival_time,fg%aux(1:mxnold,:,:),
+     &       fg%t_last_updated(1:mxnold)
         end do
       else
         do ifg = 1, FG_num_fgrids


### PR DESCRIPTION
If a restart is done with more amr levels than the original run
then some fgmax arrays have to be read in with the old length mxnold
not the new number of levels mxnest.