### PR TITLE
improve getmaxspeed.f90 for dry cells

### DIFF
--- a/src/2d/shallow/getmaxspeed.f90
+++ b/src/2d/shallow/getmaxspeed.f90
@@ -28,7 +28,7 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
                     sig = sqrt(grav*val(1,i,j))
-                    sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
+                    sp_over_h = max((abs(u)+sig)/hxphys,(abs(v)+sig)/hyphys,sp_over_h)
                 endif
             end do
         end do

--- a/src/2d/shallow/getmaxspeed.f90
+++ b/src/2d/shallow/getmaxspeed.f90
@@ -27,12 +27,9 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                 if (val(1,i,j) > dry_tolerance) then
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
-                else
-                    u = 0.d0
-                    v = 0.d0
+                    sig = sqrt(grav*h)
+                    sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
                 endif
-                sig = sqrt(grav*val(1,i,j))
-                sp_over_h = max((abs(u)+sig)/hxphys,(abs(v)+sig)/hyphys,sp_over_h)
             end do
         end do
     else  ! speeds in cartesian coords, no metrics needed
@@ -41,12 +38,9 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                 if (val(1,i,j) > dry_tolerance) then
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
-                else
-                    u = 0.d0
-                    v = 0.d0
+                    sig = sqrt(grav*h)
+                    sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
                 endif
-                sig = sqrt(grav*val(1,i,j))
-                sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
             end do
         end do
     endif

--- a/src/2d/shallow/getmaxspeed.f90
+++ b/src/2d/shallow/getmaxspeed.f90
@@ -27,7 +27,7 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                 if (val(1,i,j) > dry_tolerance) then
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
-                    sig = sqrt(grav*h)
+                    sig = sqrt(grav*val(1,i,j))
                     sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
                 endif
             end do
@@ -38,7 +38,7 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                 if (val(1,i,j) > dry_tolerance) then
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
-                    sig = sqrt(grav*h)
+                    sig = sqrt(grav*val(1,i,j))
                     sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
                 endif
             end do


### PR DESCRIPTION
The subroutine `geoclaw/src/2d/shallow/getmaxspeed.f90` estimates the maximum wave speed on a patch, looping over all cells.  In dry cells it was doing a lot of arithmetic including sqrt's in order to do no update of the max value.  This routine is now simplified and should be faster on patches with lots of dry cells.

Also I noticed this on a problem where the depth `val(1,i,j)` was slightly negative and it was taking sqrt of a negative value, when it should have setting the wave speed to 0 in that cell.  I'm not sure how a negative value got in here since it should have been set to zero in `b4step`, but that's a different issue.  At any rate the new version won't have this potential problem.