### PR TITLE
WIP: Lower storage prepc 

### DIFF
--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -489,7 +489,7 @@ program amr2
         !call set_geo()                    ! sets basic parameters g and coord system
         call set_refinement()             ! sets refinement control parameters
         call read_dtopo_settings()        ! specifies file with dtopo from earthquake
-        call read_topo_settings()         ! specifies topography (bathymetry) files
+        call read_topo_settings(rest)     ! specifies topography (bathymetry) files
         call set_qinit()                  ! specifies file with dh if this used instead
         call set_fixed_grids()            ! Fixed grid settings
         call setup_variable_friction()    ! Variable friction parameter
@@ -524,7 +524,7 @@ program amr2
         call set_geo()                    ! sets basic parameters g and coord system
         call set_refinement()             ! sets refinement control parameters
         call read_dtopo_settings()        ! specifies file with dtopo from earthquake
-        call read_topo_settings()         ! specifies topography (bathymetry) files
+        call read_topo_settings(rest)     ! specifies topography (bathymetry) files
         call set_qinit()                  ! specifies file with dh if this used instead
         call set_fixed_grids()            ! Fixed grid settings
         call setup_variable_friction()    ! Variable friction parameter

--- a/src/2d/shallow/check.f
+++ b/src/2d/shallow/check.f
@@ -70,7 +70,7 @@ c
       write(chkunit) (alloc(i),i=1,lendim)
       write(chkunit) hxposs,hyposs,possk,icheck
       write(chkunit) lfree,lenf
-      write(chkunit) rnode,node,lstart,newstl,listsp,tol,
+      write(chkunit) rnode,node,lstart,newstl,listspStart,listsp,tol,
      1          ibuff,mstart,ndfree,ndfree_bnd,lfine,iorder,mxnest,
      2          intratx,intraty,kratio,iregsz,jregsz,
      2          iregst,jregst,iregend,jregend, 

--- a/src/2d/shallow/check.f
+++ b/src/2d/shallow/check.f
@@ -12,6 +12,7 @@ c     !use gauges_module, only: OUTGAUGEUNIT, num_gauges
       use gauges_module, only: num_gauges, gauges
       use gauges_module, only: print_gauges_and_reset_nextLoc
       use fgmax_module, only: FG_fgrids, FG_num_fgrids, fgrid
+      use topo_module, only:aux_finalized
 
       implicit double precision (a-h,o-z)
       integer tchkunit, ifg, ii
@@ -75,7 +76,7 @@ c
      2          intratx,intraty,kratio,iregsz,jregsz,
      2          iregst,jregst,iregend,jregend, 
      3          numgrids,kcheck,nsteps,
-     3          time,matlabu
+     3          time,matlabu,aux_finalized
       write(chkunit) avenumgrids, iregridcount,
      1               evol,rvol,rvoll,lentot,tmass0,cflmax,
      2               tvoll,tvollCPU,timeTick,timeTickCPU,

--- a/src/2d/shallow/restrt.f
+++ b/src/2d/shallow/restrt.f
@@ -7,6 +7,7 @@ c
       use amr_module
       use fgmax_module
       use gauges_module, only: gauges, num_gauges
+      use topo_module, only: aux_finalized
       implicit double precision (a-h,o-z)
       logical   ee
  
@@ -59,7 +60,7 @@ c     # need to allocate for dynamic memory:
      2       intrtx,intrty,intrtt,iregsz,jregsz,
      2       iregst,jregst,iregend,jregend,
      3       numgrids,kcheck1,nsteps,time,
-     3       matlabu
+     3       matlabu,aux_finalized
       read(rstunit) avenumgrids, iregridcount,
      1              evol,rvol,rvoll,lentot,tmass0,cflmax,
      2              tvoll,tvollCPU,timeTick,timeTickCPU,

--- a/src/2d/shallow/restrt.f
+++ b/src/2d/shallow/restrt.f
@@ -54,7 +54,7 @@ c     # need to allocate for dynamic memory:
       read(rstunit) (alloc(i),i=1,lendim)
       read(rstunit) hxposs,hyposs,possk,icheck
       read(rstunit) lfree,lenf
-      read(rstunit) rnode,node,lstart,newstl,listsp,tl,
+      read(rstunit) rnode,node,lstart,newstl,listspStart,listsp,tl,
      1       ibuf,mstart,ndfree,ndfree_bnd,lfine,iorder,mxnold,
      2       intrtx,intrty,intrtt,iregsz,jregsz,
      2       iregst,jregst,iregend,jregend,

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -83,7 +83,7 @@ contains
     ! Finest value of topography in a given region will be used for
     ! computation
     ! ========================================================================
-    subroutine read_topo_settings(file_name)
+    subroutine read_topo_settings(restart,file_name)
 
         use geoclaw_module
 
@@ -91,6 +91,7 @@ contains
 
         ! Input arguments
         character(len=*), intent(in), optional :: file_name
+        logical, intent(in) :: restart
 
         ! Locals
         integer, parameter :: iunit = 7
@@ -258,7 +259,10 @@ contains
                 aux_finalized = 2   !# indicates aux arrays properly set with dtopo
                 if (num_dtopo>0) then
                    topo_finalized = .false.
-                   aux_finalized = 0  !# will be incremented each time level 1 goes
+                   if (.not. restart) then ! rest is read in
+                      aux_finalized = 0  !# will be incremented each time level 1 goes
+                   endif
+
                    i0topo0(1) = 1
                    mtopo0size = dot_product(mtopo,topo0save)
                    allocate(topo0work(mtopo0size))

--- a/src/2d/shallow/upbnd.f
+++ b/src/2d/shallow/upbnd.f
@@ -10,8 +10,8 @@ c     1                  maxsp,iused,mptr)
       implicit double precision (a-h,o-z)
 
  
-       dimension val(nvar,mitot,mjtot),listbc(5,maxsp),
-     1           iused(mitot,mjtot)
+       dimension val(nvar,mitot,mjtot),iused(mitot,mjtot)
+       double precision listbc(5,maxsp)
 
 c  OLD INDEXING
 c      iaddaux(i,j) = locaux + i-1 +  mitot*(j-1) 


### PR DESCRIPTION
goes along with new version in amrclaw https://github.com/clawpack/amrclaw/pull/268  
This greatly reduces the length of the alloc array. RJL was running into excessive storage requirements with 2000 patches on finest level.  Also saved aux_finalized in topo_module to make restarts binary compatible with non-restarted runs.