### PR TITLE
Fix force_dry_init indexes and tests

### DIFF
--- a/src/2d/shallow/filpatch.f90
+++ b/src/2d/shallow/filpatch.f90
@@ -59,7 +59,6 @@ recursive subroutine filrecur(level,nvar,valbig,aux,naux,t,mx,my, &
 
     real(kind=8) :: eta1old, eta2old
     real(kind=8) :: veta_init_c
-    real(kind=8) :: x,y
     integer :: ii,jj
 
     ! Scratch arrays for interpolation
@@ -327,20 +326,17 @@ recursive subroutine filrecur(level,nvar,valbig,aux,naux,t,mx,my, &
                                                              + eta2 * slope(2,i_coarse,j_coarse)
                     h_fine = max(eta_fine - aux(1,i_fine + nrowst - 1, j_fine + ncolst - 1), 0.d0)
 
-                    if (variable_eta_init) &
+                    if (variable_eta_init) then
                         veta_init_c = vetac(ivetac(i_coarse,j_coarse))
                         ! else it has been set to the constant sea_level
+                    endif
 
-                    x = xlow_fine + (i_fine-0.5d0)*dx_fine
-                    y = ylow_fine + (j_fine-0.5d0)*dy_fine
-
-                    if (use_force_dry_this_level .and. &
-                            (((eta_coarse(i_coarse,j_coarse) == veta_init_c) &
-                            .and. (h_fine > 0)) &
-                            .or. (t <= tend_force_dry))) then
+                    if (use_force_dry_this_level &
+                            .and. (h_fine > 0) &
+                            .and. (t <= tend_force_dry)) then
                         ! check if in force_dry region
-                        ii = int((x - xlow_fdry + 1d-7) / dx_fdry) + 1
-                        jj = int((y - ylow_fdry + 1d-7) / dy_fdry) + 1
+                        ii = int((xcent_fine - xlow_fdry + 1d-7) / dx_fdry) + 1
+                        jj = int((ycent_fine - ylow_fdry + 1d-7) / dy_fdry) + 1
                         jj = my_fdry - jj  ! since index 1 corresponds to north edge
                         if ((ii>=1) .and. (ii<=mx_fdry) .and. &
                             (jj>=1) .and. (jj<=my_fdry)) then

--- a/src/2d/shallow/filval.f90
+++ b/src/2d/shallow/filval.f90
@@ -224,14 +224,13 @@ subroutine filval(val, mitot, mjtot, dx, dy, level, time,  mic, &
                        val(1,ifine,jfine) = max(0.d0, val(1,ifine,jfine)  &
                                                - aux(1,ifine,jfine))
                                                
-                       x = xleft + (ifine-0.5d0)*dx
-                       y = ybot + (jfine-0.5d0)*dy
+                       x = xleft + (ifine-0.5d0)*dx - nghost*dx
+                       y = ybot + (jfine-0.5d0)*dy - nghost*dy
 
                        ! Check cells newly initialized to wet using force_dry:
                        if (use_force_dry_this_level .and. &
-                               (((coarseval(2) == vetac(i,j)) &
-                               .and. (val(1,ifine,jfine) > 0)) &
-                               .or. (time <= tend_force_dry))) then
+                                (val(1,ifine,jfine) > 0) .and. &
+                                (time <= tend_force_dry)) then
                            ! check if in force_dry region
                            ii = int((x - xlow_fdry + 1d-7) / dx_fdry) + 1
                            jj = int((y - ylow_fdry + 1d-7) / dy_fdry) + 1

--- a/src/2d/shallow/qinit.f90
+++ b/src/2d/shallow/qinit.f90
@@ -1,13 +1,14 @@
 
 subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
     
+    use geoclaw_module, only: sea_level
+    use amr_module, only: t0
     use qinit_module, only: qinit_type,add_perturbation
+    use qinit_module, only: variable_eta_init
     use qinit_module, only: force_dry,use_force_dry,mx_fdry, my_fdry
     use qinit_module, only: xlow_fdry, ylow_fdry, xhi_fdry, yhi_fdry
     use qinit_module, only: dx_fdry, dy_fdry
-    use geoclaw_module, only: sea_level
-    use amr_module, only: t0
-    use qinit_module, only: variable_eta_init
+    use qinit_module, only: tend_force_dry
     
     implicit none
     
@@ -37,7 +38,7 @@ subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
         q(1,i,j) = max(0.d0, veta(i,j) - aux(1,i,j))
     end forall
 
-    if (use_force_dry) then
+    if (use_force_dry .and. (t0 <= tend_force_dry)) then
      ! only use the force_dry if it specified on a grid that matches the 
      ! resolution of this patch, since we only check the cell center:
      ddxy = max(abs(dx-dx_fdry), abs(dy-dy_fdry))


### PR DESCRIPTION
This fixes a couple bugs in the `force_dry_init` array capability added in v5.7.0, see http://www.clawpack.org/force_dry.html

Array indexes were calculated improperly in `filval` due to not including ghost cells in the calculation, possibly leading to one or two cells near shore that should have been filled with water but are mistakenly forced to be dry initially.  In some cases this results in a significant wave being generated as water rushes into the dry cells from neighboring wet cells, so the shoreline appears to radiate nonphysical waves.  This showed up in some gauge results in narrow waterways and bays that had highly-oscillatory behavior before the tsunami should have arrived.

There was also some unintended logic with .or. rather than .and. in testing if `(t <= tend_force_dry)`.  After that time, this array should be ignored.  

There was also some logic to try to apply these arrays only in cells where new grid patches were generated, not in previously existing grids.  This wasn't working properly and probably is not needed, but should perhaps be rethought at some point.