### PR TITLE
Fixed error in strike direction in triangular subfaults

### DIFF
--- a/src/python/geoclaw/dtopotools.py
+++ b/src/python/geoclaw/dtopotools.py
@@ -1543,7 +1543,9 @@ class SubFault(object):
                 dip_deg = 90.   # vertical fault
             else:
                 dip_deg = rad2deg(numpy.arcsin(m.dot(n)/(norm(m)*norm(n))))
-            
+                # use "right hand rule" convention for dip direction
+                dip_deg = -dip_deg
+                
             # dip should be between 0 and 90. If negative, reverse strike:
             if dip_deg < 0:
                 strike_deg = strike_deg - 180.


### PR DESCRIPTION
The sign change is critical. The dip direction has to be both "down-dip" and clockwise or to the "right" of the strike direction. Without the sign change (current version) the dip direction is up-dip.  Not resolving this ambiguity correctly essentially flips the polarity in the resulting dtopo for each subfault. 