### PR TITLE
If no time offset is provided simply print none

### DIFF
--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -905,9 +905,9 @@ class Storm(object):
         num_casts = 0
         data_string = [""]
         if self.time_offset is None:
-            # Use the first time in sequence if not provided
-            self.time_offset = self.t[0]
-        data_string.append("%s\n\n" % self.time_offset.isoformat())
+	    data_string.append("None\n")
+	else:
+            data_string.append("%s\n\n" % self.time_offset.isoformat())
         for n in range(len(self.t)):
             # Remove duplicate times
             if n > 0:


### PR DESCRIPTION
This was breaking when looking at the first time as this was just a float, which of course has no `isoformat()` response to give.