### PR TITLE
Implement B-value from Holland 2008

### DIFF
--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -604,6 +604,9 @@ contains
 
     ! ==========================================================================
     !  Use the 2010 Holland model to set the storm fields
+    !  
+    !  As in the original publication, this implementation computes
+    !  cyclostrophic winds, i.e., it does not include the Coriolis force.
     ! ==========================================================================
     subroutine set_holland_2010_fields(maux, mbc, mx, my, xlower, ylower,    &
                                        dx, dy, t, aux, wind_index,           &
@@ -632,7 +635,7 @@ contains
         real(kind=8) :: x, y, r, theta, sloc(2), B
         real(kind=8) :: f, mwr, mws, Pc, dp, wind, tv(2), radius, mod_mws
         real(kind=8) :: rn, vn, xn, xx
-        real(kind=8) :: dg, edg, rg
+        real(kind=8) :: dg, rg
         integer :: i,j
 
         ! Holland 2010 does not require converting surface to gradient winds
@@ -650,17 +653,18 @@ contains
         B = get_holland_b(mod_mws / atmos_boundary_layer, dp)
 
         ! Additional Holland parameters needed
+        ! Since we don't have a second wind speed measurement, we assume that the
+        ! wind speed is 10 m/s at a radius of 500 km. For comparison: The original
+        ! publication assumed 17 m/s at a radius of 300 km.
+        vn = 10
         rn = 500000
         dg = (mwr/rn)**B
-        edg = exp(1.d0-dg)
-        rg = dg * edg/rho_air
-        vn = 10
+        rg = dg * exp(1.d0-dg)
         xn = log(vn/mws)/log(rg)
 
         ! Set fields
         do j=1-mbc,my+mbc
             y = ylower + (j-0.5d0) * dy     ! Degrees latitude
-            f = coriolis(y)
             do i=1-mbc,mx+mbc
                 x = xlower + (i-0.5d0) * dx   ! Degrees longitude
 
@@ -672,11 +676,10 @@ contains
                 ! # HOLLAND 2010 WIND SPEED CALCULATION
                 if (r <= mwr) then
                     xx = 0.5
-                    wind = mod_mws * ((mwr / r)**B * exp(1.d0 - (mwr / r)**B))**xx
                 else
                     xx = 0.5 + (r - mwr) * (xn - 0.5) / (rn - mwr)
-                    wind = mod_mws * ((mwr / r)**B * exp(1.d0 - (mwr / r)**B))**xx
                 endif
+                wind = mod_mws * ((mwr / r)**B * exp(1.d0 - (mwr / r)**B))**xx
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -438,7 +438,8 @@ contains
     ! 5. Apply distance ramp to limit scope
     ! ==========================================================================
     pure subroutine post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
-        wind_index, pressure_index, r, radius, tv, mod_mws, theta, convert_height)
+        wind_index, pressure_index, r, radius, tv, mod_mws, theta, convert_height, &
+        n_hemisphere)
 
         use geoclaw_module, only: Pa => ambient_pressure
 
@@ -448,7 +449,7 @@ contains
         real (kind=8), intent(in) :: tv(2), mod_mws, theta, r, radius
         integer, intent(in) :: wind_index, pressure_index
 
-        logical, intent(in) :: convert_height
+        logical, intent(in) :: convert_height, n_hemisphere
 
         real (kind=8) :: trans_speed_x, trans_speed_y, ramp
 
@@ -465,9 +466,10 @@ contains
         wind = wind * sampling_time
 
         ! Velocity components of storm (assumes perfect vortex shape)
-        ! including addition of translation speed
-        aux(wind_index,i,j)   = -wind * sin(theta) + trans_speed_x
-        aux(wind_index+1,i,j) =  wind * cos(theta) + trans_speed_y
+        ! including addition of translation speed, and adjustment of orientation
+        ! according to hemisphere (counter-clockwise on northern hemisphere).
+        aux(wind_index,i,j)   = wind * merge(-1, 1, n_hemisphere) * sin(theta) + trans_speed_x
+        aux(wind_index+1,i,j) = wind * merge(1, -1, n_hemisphere) * cos(theta) + trans_speed_y
 
         ! Apply distance ramp down(up) to fields to limit scope
         ramp = 0.5d0 * (1.d0 - tanh((r - radius) / RAMP_WIDTH))
@@ -595,7 +597,7 @@ contains
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
-                    convert_height)
+                    convert_height, y >= 0)
 
             enddo
         enddo
@@ -683,7 +685,7 @@ contains
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
-                    convert_height)
+                    convert_height, y >= 0)
             enddo
         enddo
 
@@ -1209,8 +1211,8 @@ contains
                 trans_speed_x = tv(1) * mwr * r / (mwr**2.d0 + r**2.d0)
                 trans_speed_y = tv(2) * mwr * r / (mwr**2.d0 + r**2.d0)
                 
-                aux(wind_index,i,j)   = -wind * sin(theta) + trans_speed_x
-                aux(wind_index+1,i,j) =  wind * cos(theta) + trans_speed_y
+                aux(wind_index,i,j)   = wind * merge(-1, 1, y >= 0) * sin(theta) + trans_speed_x
+                aux(wind_index+1,i,j) = wind * merge(1, -1, y >= 0) * cos(theta) + trans_speed_y
             enddo
         enddo
 
@@ -1280,7 +1282,7 @@ contains
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                 wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
-                convert_height)
+                convert_height, y >= 0)
 
             enddo
         enddo
@@ -1363,7 +1365,7 @@ contains
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                 wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
-                convert_height)
+                convert_height, y >= 0)
 
             enddo
         enddo
@@ -1437,7 +1439,7 @@ contains
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
-                    convert_height)
+                    convert_height, y >= 0)
 
             enddo
         enddo
@@ -1530,7 +1532,7 @@ contains
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
-                    convert_height)
+                    convert_height, y >= 0)
 
             enddo
         enddo

--- a/src/2d/shallow/surge/storm_module.f90
+++ b/src/2d/shallow/surge/storm_module.f90
@@ -106,6 +106,7 @@ contains
 
         use model_storm_module, only: set_model_storm => set_storm
         use model_storm_module, only: set_holland_1980_fields
+        use model_storm_module, only: set_holland_2008_fields
         use model_storm_module, only: set_holland_2010_fields
         use model_storm_module, only: set_CLE_fields
         use model_storm_module, only: set_SLOSH_fields
@@ -197,10 +198,13 @@ contains
 
             ! Use parameterized storm model
             if (0 < storm_specification_type .and.              &
-                    storm_specification_type <=3) then
+                    storm_specification_type <= 3               &
+                .or. storm_specification_type == 8) then
                 select case(storm_specification_type)
                     case(1) ! Holland 1980 model
                         set_model_fields => set_holland_1980_fields
+                    case(8) ! Holland 2008 model
+                        set_model_fields => set_holland_2008_fields
                     case(2) ! Holland 2010 model
                         set_model_fields => set_holland_2010_fields
                     case(3) ! Chavas, Lin, Emanuel model

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -29,7 +29,7 @@ import numpy
 import clawpack.clawutil.data
 import warnings
 
-# Radius of earth in meters.  
+# Radius of earth in meters.
 # For consistency, should always use this value when needed, e.g.
 # in setrun.py or topotools:
 Rearth = 6367.5e3  # average of polar and equatorial radii
@@ -70,7 +70,7 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
 
         self.open_data_file(out_file, data_source)
 
-        self.data_write('gravity', 
+        self.data_write('gravity',
                                description="(gravitational acceleration m/s^2)")
         self.data_write('rho', description="(Density of water kg/m^3)")
         self.data_write('rho_air',description="(Density of air kg/m^3)")
@@ -100,7 +100,7 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
         self.data_write()
 
         self.data_write('dry_tolerance')
- 
+
         self.close_data_file()
 
 
@@ -152,13 +152,13 @@ class TopographyData(clawpack.clawutil.data.ClawData):
         self.add_attribute('topo_missing',99999.)
         self.add_attribute('test_topography',0)
         self.add_attribute('topofiles',[])
-        
+
         # Jump discontinuity
         self.add_attribute('topo_location',-50e3)
         self.add_attribute('topo_left',-4000.0)
         self.add_attribute('topo_right',-200.0)
         self.add_attribute('topo_angle',0.0)
-        
+
         # Simple oceanic shelf
         self.add_attribute('x0',350e3)
         self.add_attribute('x1',450e3)
@@ -168,7 +168,7 @@ class TopographyData(clawpack.clawutil.data.ClawData):
         self.add_attribute('beach_slope',0.008)
 
 
-    def write(self,data_source='setrun.py', out_file='topo.data'): 
+    def write(self,data_source='setrun.py', out_file='topo.data'):
 
         self.open_data_file(out_file, data_source)
         self.data_write(name='topo_missing',
@@ -198,7 +198,7 @@ class TopographyData(clawpack.clawutil.data.ClawData):
             self.data_write(name='topo_location',description='(Bathymetry jump location)')
             self.data_write(name='topo_left',description='(Depth to left of bathy_location)')
             self.data_write(name='topo_right',description='(Depth to right of bathy_location)')
-        elif self.test_topography == 2 or self.test_topography == 3: 
+        elif self.test_topography == 2 or self.test_topography == 3:
             self.data_write(name='x0',description='(Location of basin end)')
             self.data_write(name='x1',description='(Location of shelf slope end)')
             self.data_write(name='x2',description='(Location of beach slope)')
@@ -218,7 +218,7 @@ class FixedGridData(clawpack.clawutil.data.ClawData):
     def __init__(self):
 
         super(FixedGridData,self).__init__()
-        
+
         # Fixed Grids
         self.add_attribute('fixedgrids',[])
 
@@ -238,7 +238,7 @@ class FGmaxData(clawpack.clawutil.data.ClawData):
     def __init__(self):
 
         super(FGmaxData,self).__init__()
-        
+
         # File name for fgmax points and parameters:
         self.add_attribute('fgmax_files',[])
         self.add_attribute('num_fgmax_val',1)
@@ -280,7 +280,7 @@ class FGmaxData(clawpack.clawutil.data.ClawData):
             if fg.fgno in fgno_list:
                 msg = 'Trying to set fgmax grid number to fgno = %i' % fg.fgno \
                       + '\n             but this fgno was already used' \
-                      + '\n             Set unique fgno for each fgmax grid' 
+                      + '\n             Set unique fgno for each fgmax grid'
                 raise ValueError(msg)
 
             fgno_list.append(fg.fgno)
@@ -294,7 +294,7 @@ class DTopoData(clawpack.clawutil.data.ClawData):
     def __init__(self):
 
         super(DTopoData,self).__init__()
-        
+
         # Moving topograhpy
         self.add_attribute('dtopofiles',[])
         self.add_attribute('dt_max_dtopo', 1.e99)
@@ -336,7 +336,7 @@ class DTopoData(clawpack.clawutil.data.ClawData):
         with open(os.path.abspath(path), 'r') as data_file:
 
             file_name = None
-            
+
             # Forward to first parameter
             for line in data_file:
 
@@ -370,12 +370,12 @@ class DTopoData(clawpack.clawutil.data.ClawData):
 
 
 class ForceDry(clawpack.clawutil.data.ClawData):
-    
+
     def __init__(self):
         r"""
         A single force_dry array and associated data
         """
-        
+
         super(ForceDry,self).__init__()
         self.add_attribute('tend',None)
         self.add_attribute('fname','')
@@ -386,12 +386,12 @@ class QinitData(clawpack.clawutil.data.ClawData):
     def __init__(self):
 
         super(QinitData,self).__init__()
-        
+
         # Qinit data
         self.add_attribute('qinit_type',0)
-        self.add_attribute('qinitfiles',[])   
-        self.add_attribute('variable_eta_init',False)   
-        self.add_attribute('force_dry_list',[])   
+        self.add_attribute('qinitfiles',[])
+        self.add_attribute('variable_eta_init',False)
+        self.add_attribute('force_dry_list',[])
         self.add_attribute('num_force_dry',0)
 
     def write(self,data_source='setrun.py', out_file='qinit.data'):
@@ -431,7 +431,7 @@ class QinitData(clawpack.clawutil.data.ClawData):
         self.data_write('num_force_dry')
 
         for force_dry in self.force_dry_list:
-            
+
             # if path is relative in setrun, assume it's relative to the
             # same directory that out_file comes from
             fname = os.path.abspath(os.path.join(os.path.dirname(out_file),\
@@ -439,7 +439,7 @@ class QinitData(clawpack.clawutil.data.ClawData):
             self._out_file.write("\n'%s' \n" % fname)
             self._out_file.write("%.3f \n" % force_dry.tend)
 
-    
+
         self.close_data_file()
 
 
@@ -451,14 +451,15 @@ class SurgeData(clawpack.clawutil.data.ClawData):
     storm_spec_dict_mapping = {"HWRF":-1,
                                None: 0,
                                'holland80': 1,
+                               'holland08': 8,
                                'holland10': 2,
-                               'CLE': 3,  
-                               'SLOSH': 4,                     
-                               'rankine': 5,           
-                               'modified-rankine': 6, 
-                               'DeMaria': 7     
+                               'CLE': 3,
+                               'SLOSH': 4,
+                               'rankine': 5,
+                               'modified-rankine': 6,
+                               'DeMaria': 7
                               }
-    storm_spec_not_implemented = ['CLE'] 
+    storm_spec_not_implemented = ['CLE']
 
     def __init__(self):
         super(SurgeData,self).__init__()
@@ -476,13 +477,13 @@ class SurgeData(clawpack.clawutil.data.ClawData):
         # AMR parameters
         self.add_attribute('wind_refine',[20.0,40.0,60.0])
         self.add_attribute('R_refine',[60.0e3,40e3,20e3])
-        
+
         # Storm parameters
         self.add_attribute('storm_type', None)  # Backwards compatibility
         self.add_attribute('storm_specification_type', 0) # Type of parameterized storm
         self.add_attribute("storm_file", None) # File(s) containing data
 
-        
+
     def write(self,out_file='surge.data',data_source="setrun.py"):
         """Write out the data file to the path given"""
 
@@ -499,7 +500,7 @@ class SurgeData(clawpack.clawutil.data.ClawData):
                         description="(Index into aux array - fortran indexing)")
         self.data_write("pressure_index", value=self.pressure_index +  1,
                         description="(Index into aux array - fortran indexing)")
-        self.data_write("display_landfall_time", 
+        self.data_write("display_landfall_time",
                         description='(Display time relative to landfall)')
         self.data_write()
 
@@ -530,11 +531,11 @@ class SurgeData(clawpack.clawutil.data.ClawData):
             if self.storm_specification_type in         \
                     self.storm_spec_dict_mapping.keys():
                 if self.storm_specification_type in     \
-                    self.storm_spec_not_implemented: 
-                    raise NotImplementedError("%s has not been implemented." 
-                                %self.storm_specification_type) 
-                
-                else: 
+                    self.storm_spec_not_implemented:
+                    raise NotImplementedError("%s has not been implemented."
+                                %self.storm_specification_type)
+
+                else:
                     self.data_write("storm_specification_type",
                                 self.storm_spec_dict_mapping[
                                         self.storm_specification_type],


### PR DESCRIPTION
This PR implements the B-value computation for TC surface wind fields according to Holland 2008 (https://dx.doi.org/10.1175/2008MWR2395.1), the B-value that is recommended in Holland et al. 2010 (see discussion in #512). Furthermore, this PR comes with a new wind field model that combines the original Holland 1980 formula with the updated B-value from Holland 2008, corresponding to the wind field model used in TCE-DAT (https://essd.copernicus.org/articles/10/185/2018/).

This PR includes the changes introduced in #513 and #519 and should ideally be reviewed after those two have been merged.