### PR TITLE
Fix Floating Point Bug in Storm Track Time Comparison

### DIFF
--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -172,7 +172,10 @@ contains
             storm%central_pressure_change(storm%num_casts) = &
                 storm%central_pressure_change(storm%num_casts - 1)
 
-            if (t0 <= storm%track(1, 1) - TRACKING_TOLERANCE) then
+            print *, t0, storm%tracK(1, 1), TRACKING_TOLERANCE
+            print *, t0, storm%tracK(1, 1) - TRACKING_TOLERANCE
+            if (t0 - storm%tracK(1, 1) < -TRACKING_TOLERANCE) then
+            ! if (t0 <= storm%track(1, 1) - TRACKING_TOLERANCE) then
                 print *, "Start time", t0, " is outside of the tracking"
                 print *, "tolerance range with the track start"
                 print *, storm%track(1, 1), "."

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -172,10 +172,7 @@ contains
             storm%central_pressure_change(storm%num_casts) = &
                 storm%central_pressure_change(storm%num_casts - 1)
 
-            print *, t0, storm%tracK(1, 1), TRACKING_TOLERANCE
-            print *, t0, storm%tracK(1, 1) - TRACKING_TOLERANCE
             if (t0 - storm%tracK(1, 1) < -TRACKING_TOLERANCE) then
-            ! if (t0 <= storm%track(1, 1) - TRACKING_TOLERANCE) then
                 print *, "Start time", t0, " is outside of the tracking"
                 print *, "tolerance range with the track start"
                 print *, storm%track(1, 1), "."


### PR DESCRIPTION
GeoClaw currently does not allow `t0` to be before the available track time.  There is therefore a floating point comparison that checks to see if `t0 < track_t0`.  Before this was implemented with
```fortran
t0 <= storm%track(1, 1) - TRACKING_TOLERANCE
```
which usually works except when `t0` and `storm%track(1, 1)` get large enough (not even really that large).  Instead this PR changes this comparison to
```fortran
t0 - storm%tracK(1, 1) < -TRACKING_TOLERANCE
```
which is safer from a floating point case.