### PR TITLE
Print gauges in a critical section, using a single unit number

### DIFF
--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -241,7 +241,7 @@ c        # now to make linear interpolation easier, since grid
 c        # now has boundary conditions filled in.
 
 c     should change the way print_gauges does io - right now is critical section
-c     NOW changed, mjb 2/6/2015.
+c     NOW changed, mjb 2/6/2015.  RJL Changed back to critical block 4/22
 c     NOTE that gauge subr called before stepgrid, so never get
 c     the very last gauge time at end of run.
 

--- a/src/2d/shallow/restrt.f
+++ b/src/2d/shallow/restrt.f
@@ -15,7 +15,7 @@ c
       dimension intrtx(maxlv),intrty(maxlv),intrtt(maxlv)
       type(fgrid), pointer :: fg
 
-      integer :: num_gauges_previous, i, ii
+      integer :: num_gauges_previous, i, ii, previous_gauge_num
 c
 c :::::::::::::::::::::::::::: RESTRT ::::::::::::::::::::::::::::::::
 c read back in the check point files written by subr. check.


### PR DESCRIPTION
I changed the `print_gauges_and_reset_nextLoc` function to print all gauge data using the same output file unit number `OUTGAUGEUNIT` rather than creating a unit number based on this base plus the OMP thread number.  And I put this code in an OMP critical block so that only one thread can be doing this at a time.

The other approach allows writing in parallel, in principle, but recently I've been having seg faults when using lots of threads that seems related to this. It also seems potentially bad practice since we don't know what unit numbers will be used for writing gauges, and we use other unit number for other purposes, so there are potentially conflicts.

I don't think this will introduce any bottlenecks.

