### PR TITLE
Include ghost cells when clipping netcdf and handle large topography

### DIFF
--- a/src/2d/shallow/set_eta_init.f90
+++ b/src/2d/shallow/set_eta_init.f90
@@ -30,8 +30,8 @@ subroutine set_eta_init(mbc,mx,my,xlow,ylow,dx,dy,t,veta)
     real(kind=8), intent(inout) :: veta(1-mbc:mx+mbc,1-mbc:my+mbc)
     
     ! Local
-    integer :: i,j,i1,i2,j1,j2,idtopo,jdtopo,kdtopo, &
-               index0_dtopowork,ij,m
+    integer :: i,j,i1,i2,j1,j2,idtopo,jdtopo,kdtopo,m
+    integer(kind=8) :: index0_dtopowork, ij
     real(kind=8) :: x,y
     real(kind=8) :: x1_lake,x2_lake,y1_lake,y2_lake, lake_level
 
@@ -94,7 +94,7 @@ subroutine set_eta_init(mbc,mx,my,xlow,ylow,dx,dy,t,veta)
             kdtopo = max(kdtopo,1)
           endif
 
-        index0_dtopowork = i0dtopo(m) + (kdtopo-1)*mxdtopo(m)*mydtopo(m)
+        index0_dtopowork = i0dtopo(m) + int(kdtopo-1, 8)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
         !write(6,*) '+++ index0_dtopowork = ',index0_dtopowork
 
         ! Adjust eta_init by dtopo on part of patch that overlaps dtopo.
@@ -111,7 +111,7 @@ subroutine set_eta_init(mbc,mx,my,xlow,ylow,dx,dy,t,veta)
                 idtopo = max(1, min(mxdtopo(m)-1, idtopo))
                 jdtopo = int(floor((yhidtopo(m)-y)/dydtopo(m))) + 1
                 jdtopo = max(1, min(mydtopo(m)-1, jdtopo))
-                ij = index0_dtopowork + (jdtopo-1)*mxdtopo(m) + idtopo-1
+                ij = index0_dtopowork + int(jdtopo-1, 8)*int(mxdtopo(m) + idtopo-1, 8)
 
                 veta(i,j) = veta(i,j) + dtopowork(ij)
 

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -14,14 +14,15 @@ module topo_module
     ! Topography file data
     integer :: test_topography
     character(len=150), allocatable :: topofname(:)
-    integer :: mtopofiles,mtoposize
+    integer :: mtopofiles
+    integer(kind=8) :: mtoposize
     real(kind=8), allocatable :: xlowtopo(:), ylowtopo(:), tlowtopo(:)
     real(kind=8), allocatable :: xhitopo(:), yhitopo(:), thitopo(:)
     real(kind=8), allocatable :: dxtopo(:), dytopo(:)
     real(kind=8), allocatable :: topotime(:)
-    integer, allocatable ::  mxtopo(:), mytopo(:)
+    integer(kind=8), allocatable :: mtopo(:), i0topo(:)
 
-    integer, allocatable :: i0topo(:), mtopo(:), mtopoorder(:)
+    integer, allocatable :: mxtopo(:), mytopo(:), mtopoorder(:)
     integer, allocatable :: itopotype(:)
     integer, allocatable :: topoID(:),topo0save(:)
     logical :: topo_finalized
@@ -49,10 +50,10 @@ module topo_module
     real(kind=8), allocatable :: dxdtopo(:),dydtopo(:),dtdtopo(:)
     real(kind=8), allocatable :: tdtopo1(:),tdtopo2(:),taudtopo(:)
 
-    integer, allocatable :: mxdtopo(:),mydtopo(:),mtdtopo(:),mdtopo(:)
-    integer, allocatable :: dtopotype(:)
-    integer, allocatable :: i0dtopo(:),mdtopoorder(:),kdtopo1(:),kdtopo2(:)
-    integer, allocatable :: index0_dtopowork1(:),index0_dtopowork2(:)
+    integer, allocatable :: mxdtopo(:), mydtopo(:), mtdtopo(:)
+    integer(kind=8), allocatable :: mdtopo(:), i0dtopo(:)
+    integer, allocatable :: dtopotype(:), mdtopoorder(:),kdtopo1(:),kdtopo2(:)
+    integer(kind=8), allocatable :: index0_dtopowork1(:),index0_dtopowork2(:)
 
     integer :: num_dtopo
     real(kind=8) dz
@@ -61,8 +62,10 @@ module topo_module
     ! Initial topography
     ! Work array for initial topography (only arrays where topo evolves)
     real(kind=8), allocatable :: topo0work(:)
-    integer, allocatable :: i0topo0(:),topo0ID(:)
-    integer :: mtopo0size,mtopo0files
+    integer, allocatable :: topo0ID(:)
+    integer(kind=8), allocatable :: i0topo0(:)
+    integer(kind=8) :: mtopo0size
+    integer :: mtopo0files
 
     real(kind=8) topo_missing
 
@@ -158,7 +161,7 @@ contains
                         mytopo(i),xlowtopo(i),ylowtopo(i),xhitopo(i),yhitopo(i), &
                         dxtopo(i),dytopo(i))
                     topoID(i) = i
-                    mtopo(i) = mxtopo(i)*mytopo(i)
+                    mtopo(i) = int(mxtopo(i), 8) * int(mytopo(i), 8)
                 enddo
 
                 ! adding extra topo arrays corresponding spatially to dtopo
@@ -176,7 +179,7 @@ contains
                    yhitopo(i) = yhidtopo(j)
                    dxtopo(i) = dxdtopo(j)
                    dytopo(i) = dydtopo(j)
-                   mtopo(i) = mxtopo(i)*mytopo(i)
+                   mtopo(i) = int(mxtopo(i), 8) * int(mytopo(i), 8)
                    topoID(i) = i
                    topotime(i) = -huge(1.0)
                    topo0save(i) = 1
@@ -335,18 +338,18 @@ contains
         !arguments
         integer, intent(in) :: mx,my
         real(kind=8), intent(in) :: dx,dy,xlow,yhi
-        real(kind=8), intent(inout) :: newtopo(1:mx*my)
+        real(kind=8), intent(inout) :: newtopo(1:int(mx, 8) * int(my, 8))
 
         !locals
-        integer :: i,j,ij,id,irank,itopo1,itopo2,jtopo1,jtopo2
-        integer :: ijll,ijlr,ijul,ijur
+        integer :: id,irank,itopo1,itopo2,jtopo1,jtopo2
+        integer(kind=8) :: i,j,ij,ijll,ijlr,ijul,ijur
         real(kind=8) :: x,y,xl,xr,yu,yl,zll,zlr,zul,zur,z,dxdy
 
-        do j=1,my
+        do j=1,int(my, 8)
                y = yhi - (j-1)*dy
-            do i=1,mx
+            do i=1,int(mx, 8)
                x = xlow + (i-1)*dx
-               ij = (j-1)*mx + i
+               ij = (j-1)*int(mx, 8) + i
                !find intersection starting from finest topo
                !all points must lie in some topo file therefore the
                !finest topo file for all dtopo points will be saved in topo0
@@ -424,16 +427,17 @@ contains
         ! Arguments
         integer, intent(in) :: mx,my,topo_type
         character(len=150), intent(in) :: fname
-        real(kind=8), intent(inout) :: topo(1:mx*my)
+        real(kind=8), intent(inout) :: topo(1:int(mx, 8)*int(my, 8))
         real(kind=8), intent(in) :: xll,yll
 
         ! Locals
         integer, parameter :: iunit = 19, miss_unit = 17
         logical, parameter :: maketype2 = .false.
-        integer :: i,j,missing,status,n
+        integer :: missing,status,n
         real(kind=8) :: no_data_value,x,y,topo_temp
         real(kind=8) :: values(10)
         character(len=80) :: str
+        integer(kind=8) :: i, j, mtot
 
         ! NetCDF Support
         character(len=10) :: direction, x_dim_name, x_var_name, y_dim_name, &
@@ -444,6 +448,8 @@ contains
         integer(kind=4) :: xstart(1), ystart(1), mx_tot, my_tot
         integer(kind=4) :: ios, nc_file, dim_ids(2), num_dims, &
             var_type, num_vars, num_dims_tot, z_dim_ids(2)
+
+        mtot = int(mx, 8) * int(my, 8)
 
         print *, ' '
         print *, 'Reading topography file  ', fname
@@ -456,10 +462,10 @@ contains
                 open(unit=iunit, file=fname, status='unknown',form='formatted')
                 i = 0
                 status = 0
-                do i=1,mx*my
+                do i=1,mtot
                     read(iunit,fmt=*,iostat=status) x,y,topo_temp
-                    if ((i > mx * my) .and. (status == 0)) then
-                        print *,'*** Error: i > mx*my = ',mx*my
+                    if ((i > mtot) .and. (status == 0)) then
+                        print *,'*** Error: i > mx*my = ',mtot
                         print *,'*** i, mx, my: ',i,mx,my
                         print *,'*** status = ',status
                         stop
@@ -497,7 +503,7 @@ contains
                 missing = 0
                 select case(abs(topo_type))
                     case(2)
-                        do i=1,mx*my
+                        do i=1,mtot
                             read(iunit,*) topo(i)
                             if (topo(i) == no_data_value) then
                                 missing = missing + 1
@@ -508,12 +514,12 @@ contains
                             endif
                         enddo
                     case(3)
-                        do j=1,my
-                            read(iunit,*) (topo((j-1)*mx + i),i=1,mx)
-                            do i=1,mx
-                                if (topo((j-1)*mx + i) == no_data_value) then
+                        do j=1,int(my, 8)
+                            read(iunit,*) (topo((j-1)*int(mx, 8) + i),i=1,mx)
+                            do i=1,int(mx, 8)
+                                if (topo((j-1)*int(mx, 8) + i) == no_data_value) then
                                     missing = missing + 1
-                                    topo((j-1)*mx + i) = topo_missing
+                                    topo((j-1)*int(mx, 8) + i) = topo_missing
                                     ! uncomment next line to print row j
                                     ! and element i that are missing.
                                     ! write(6,601) i,j
@@ -606,12 +612,12 @@ contains
 
                     ! check for lon/lat ordering of z variable
                     if (z_dim_ids(1) == x_dim_id) then
-                        do j = 0, my - 1
-                            topo(j * mx + 1:(j + 1) * mx) = nc_buffer(:, my - j)
+                        do j = 0, int(my, 8) - 1
+                            topo(j * int(mx, 8) + 1:(j + 1) * int(mx, 8)) = nc_buffer(:, my - j)
                         end do
                     else if (z_dim_ids(1) == y_dim_id) then
-                        do j = 0, my - 1
-                            topo(j * mx + 1:(j + 1) * mx) = nc_buffer(my - j, :)
+                        do j = 0, int(my, 8) - 1
+                            topo(j * int(mx, 8) + 1:(j + 1) * int(mx, 8)) = nc_buffer(my - j, :)
                         end do
                     end if
                     deallocate(nc_buffer)
@@ -657,7 +663,7 @@ contains
 
         ! Handle negative topo types
         if (topo_type < 0) then
-            forall(i=1:mx*my)
+            forall(i=1:mtot)
                 topo(i) = -topo(i)
             end forall
         endif
@@ -1039,7 +1045,7 @@ contains
 
         ! Locals
         integer, parameter :: iunit = 79
-        integer :: itopo,finer_than,rank
+        integer :: finer_than,rank
         real(kind=8) :: area_i,area_j
         integer :: i,j
 
@@ -1143,19 +1149,22 @@ contains
       ! Arguments
       integer, intent(in) :: mx,my,mt,dtopo_type
       character (len=150), intent(in) :: fname
-      real(kind=8), intent(inout) :: dtopo(1:mx*my*mt)
+      real(kind=8), intent(inout) :: dtopo(1:int(mx, 8)*int(my, 8)*int(mt, 8))
 
       ! Local
       integer, parameter :: iunit = 29
-      integer :: i,j,k,status
+      integer :: status
       real(kind=8) :: t,x,y
+      integer(kind=8) :: i, j, k, mtot
+
+      mtot = int(mx, 8) * int(my, 8)
 
       open(unit=iunit, file=fname, status = 'unknown',form='formatted')
 
       select case(abs(dtopo_type))
          case(1)
             ! ASCII file with 4 columns
-            do i = 1,mx*my*mt
+            do i = 1,mtot*mt
                read(iunit,fmt=*,iostat=status) t,x,y, dtopo(i)
             enddo
 
@@ -1165,7 +1174,7 @@ contains
                read(iunit,*)
             enddo
             ! read the data
-            do i = 1,mx*my*mt
+            do i = 1,mtot*mt
                read(iunit,*) dtopo(i)
             enddo
          case(3)
@@ -1173,9 +1182,9 @@ contains
             do i = 1,9
                read(iunit,*)
             enddo
-            do k = 1,mt
-               do j = 1,my
-                  read(iunit,*) (dtopo((k-1)*mx*my + (j-1)*mx + i) , i=1,mx)
+            do k = 1,int(mt, 8)
+               do j = 1,int(my, 8)
+                  read(iunit,*) (dtopo((k-1)*mtot + (j-1)*int(mx, 8) + i) , i=1,int(mx, 8))
                enddo
             enddo
       end select
@@ -1339,7 +1348,8 @@ recursive subroutine topoarea(x1,x2,y1,y2,m,area)
     ! local
     real(kind=8) :: xmlo,xmhi,ymlo,ymhi,x1m,x2m, &
         y1m,y2m, area1,area2,area_m
-    integer :: mfid, indicator, i0
+    integer :: mfid, indicator
+    integer(kind=8) :: i0
     real(kind=8), external :: topointegral  
 
 
@@ -1416,7 +1426,8 @@ recursive subroutine rectintegral(x1,x2,y1,y2,m,integral)
     ! local
     real(kind=8) :: xmlo,xmhi,ymlo,ymhi,area,x1m,x2m, &
         y1m,y2m, int1,int2,int3
-    integer :: mfid, indicator, i0
+    integer :: mfid, indicator
+    integer(kind=8) :: i0
     real(kind=8), external :: topointegral  
 
 

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -3,7 +3,7 @@
 ! ============================================================================
 module topo_module
 
-    use amr_module, only: xlower,xupper,ylower,yupper
+    use amr_module, only: xlower,xupper,ylower,yupper,hxposs,hyposs,nghost
     implicit none
 
     logical, private :: module_setup = .false.
@@ -944,9 +944,9 @@ contains
                 dx = xlocs(2) - xlocs(1)
                 dy = ylocs(2) - ylocs(1)
                 
-                ! find which locs are within domain (with a dx/dy buffer around domain)
-                x_in_dom = (xlocs.gt.(xlower-dx)) .and. (xlocs.lt.(xupper+dx))
-                y_in_dom = (ylocs.gt.(ylower-dy)) .and. (ylocs.lt.(yupper+dy))
+                ! find which locs are within domain (with a dx/dy buffer around domain + ghost cells)
+                x_in_dom = (xlocs.gt.(xlower-dx-hxposs(1)*nghost)) .and. (xlocs.lt.(xupper+dx+hxposs(1)*nghost))
+                y_in_dom = (ylocs.gt.(ylower-dy-hyposs(1)*nghost)) .and. (ylocs.lt.(yupper+dy+hyposs(1)*nghost))
                 
                 xll = minval(xlocs, mask=x_in_dom)
                 yll = minval(ylocs, mask=y_in_dom)

--- a/src/2d/shallow/topo_update.f90
+++ b/src/2d/shallow/topo_update.f90
@@ -1,15 +1,15 @@
 !======================================================================
 subroutine topo_update(t)
-   !======================================================================
-   !
-   !  called to update topography grids to the current time t
-   !  topo arrays are modified directly from topo0 and dtopo
-   !
-   !  this routine replaces the old method implemented in movetopo
-   !  where dtopo modified aux arrays directly. Now aux values are
-   !  always determined from topography grids.
-   !
-   !                   David George, dgeorge@usgs.gov, December 20 2013
+!======================================================================
+!
+!  called to update topography grids to the current time t
+!  topo arrays are modified directly from topo0 and dtopo
+!
+!  this routine replaces the old method implemented in movetopo
+!  where dtopo modified aux arrays directly. Now aux values are
+!  always determined from topography grids.
+!
+!                   David George, dgeorge@usgs.gov, December 20 2013
 
 
    use topo_module
@@ -38,28 +38,28 @@ subroutine topo_update(t)
    do m=1,num_dtopo
       ! Find indices and times of dtopo arrays bracketing time t, and
       ! also taudtopo, the fraction of step between, used for interpolation.
-      ! Note that if t < t0dtopo(m) then index is set to 1 but later
+      ! Note that if t < t0dtopo(m) then index is set to 1 but later 
       ! this dtopo array is skipped altogether in this case and doesn't
       ! affect topography at time t.
       if (mtdtopo(m) == 1) then
-         ! Special case: instantaneous displacement at one instant in time
-         kdtopo1(m) = 1
-         kdtopo2(m) = 1
-         tdtopo1(m) = t
-         tdtopo2(m) = t
-         taudtopo(m) = 0.d0
-      else
-         kdtopo1(m) = int(floor((t-t0dtopo(m))/dtdtopo(m)))+1
-         kdtopo2(m) = int(ceiling((t-t0dtopo(m))/dtdtopo(m)))+1
-         kdtopo1(m) = min(kdtopo1(m),mtdtopo(m))
-         kdtopo2(m) = min(kdtopo2(m),mtdtopo(m))
-         kdtopo1(m) = max(kdtopo1(m),1)
-         kdtopo2(m) = max(kdtopo2(m),1)
-         tdtopo1(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo1(m)-1,kind=8) ! <= t
-         tdtopo2(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo2(m)-1,kind=8) ! >= t
-         taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
-         taudtopo(m) = max(taudtopo(m),0.d0)
-      endif
+          ! Special case: instantaneous displacement at one instant in time
+          kdtopo1(m) = 1
+          kdtopo2(m) = 1
+          tdtopo1(m) = t
+          tdtopo2(m) = t
+          taudtopo(m) = 0.d0
+        else
+          kdtopo1(m) = int(floor((t-t0dtopo(m))/dtdtopo(m)))+1
+          kdtopo2(m) = int(ceiling((t-t0dtopo(m))/dtdtopo(m)))+1
+          kdtopo1(m) = min(kdtopo1(m),mtdtopo(m))
+          kdtopo2(m) = min(kdtopo2(m),mtdtopo(m))
+          kdtopo1(m) = max(kdtopo1(m),1)
+          kdtopo2(m) = max(kdtopo2(m),1)
+          tdtopo1(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo1(m)-1,kind=8) ! <= t
+          tdtopo2(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo2(m)-1,kind=8) ! >= t
+          taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
+          taudtopo(m) = max(taudtopo(m),0.d0)
+        endif
       index0_dtopowork1(m) = i0dtopo(m) + (int(kdtopo1(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
       index0_dtopowork2(m) = i0dtopo(m) + (int(kdtopo2(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
    enddo
@@ -68,16 +68,16 @@ subroutine topo_update(t)
    !first set topofiles aligned exactly with corresponding dtopo
    !do i= mtopofiles - num_dtopo + 1, mtopofiles !topofile
    !   m = i - mtopofiles + num_dtopo !corresponding dtopofile
-   !interpolate in time directly for matching nodes
+      !interpolate in time directly for matching nodes
    !   if (t<t0dtopo(m).or.topotime(i)>tfdtopo(m)) then
-   !dtopo has not started or topo has already been set from final dz
+         !dtopo has not started or topo has already been set from final dz
    !      cycle
    !   endif
    !   topowork(i0topo(i):i0topo(i) + mtopo(i)-1) = &
    !            topo0work(i0topo0(i):i0topo0(i) + mtopo(i)-1) &!initial topo
    !            + taudtopo(m)*dtopowork(index0_dtopowork1(m):index0_dtopowork1(m) + mtopo(i)-1) &
    !            + (1.0-taudtopo(m))*dtopowork(index0_dtopowork2(m):index0_dtopowork2(m) + mtopo(i)-1)
-   !set time-stamp
+      !set time-stamp
    !   topotime(i) = t
    !enddo
 
@@ -107,9 +107,9 @@ subroutine topo_update(t)
             do irank = 1,num_dtopo
                m = mdtopoorder(irank)
                if ( (x>xhidtopo(m)).or.(x<xlowdtopo(m)).or. &
-                  (y>yhidtopo(m)).or.(y<ylowdtopo(m))) then
-                  !no intersection of point with this dtopo
-                  cycle
+                          (y>yhidtopo(m)).or.(y<ylowdtopo(m))) then
+                     !no intersection of point with this dtopo
+                     cycle
                endif
 
                !if (t<t0dtopo(m).or.topotime(mt)>tfdtopo(m)) then
@@ -180,4 +180,3 @@ subroutine topo_update(t)
 
 
 end subroutine topo_update
-

--- a/src/2d/shallow/topo_update.f90
+++ b/src/2d/shallow/topo_update.f90
@@ -1,182 +1,183 @@
 !======================================================================
 subroutine topo_update(t)
-!======================================================================
-!
-!  called to update topography grids to the current time t
-!  topo arrays are modified directly from topo0 and dtopo
-!
-!  this routine replaces the old method implemented in movetopo
-!  where dtopo modified aux arrays directly. Now aux values are
-!  always determined from topography grids.
-!
-!                   David George, dgeorge@usgs.gov, December 20 2013
-
-
-   use topo_module
-
-   implicit none
-
-   !arguments
-   real(kind=8), intent(in) ::t
-
-   !locals
-   integer :: i,j,m,mt
-   integer :: ij,ij0,irank,idtopo1,idtopo2,jdtopo1,jdtopo2
-   integer :: ijll,ijlr,ijul,ijur
-   real(kind=8) :: x,y,xl,xr,yu,yl,zll,zlr,zul,zur,dz12,dz1,dz2,dztotal
-
-   if (t<minval(t0dtopo).or.topo_finalized.eqv..true.) then
-      return
-   endif
-
-   if (minval(topotime)>=maxval(tfdtopo)) then
-      topo_finalized = .true.
-      return
-   endif
-
-   !first find t related values to avoid calculation for every i,j
-   do m=1,num_dtopo
-      ! Find indices and times of dtopo arrays bracketing time t, and
-      ! also taudtopo, the fraction of step between, used for interpolation.
-      ! Note that if t < t0dtopo(m) then index is set to 1 but later 
-      ! this dtopo array is skipped altogether in this case and doesn't
-      ! affect topography at time t.
-      if (mtdtopo(m) == 1) then
-          ! Special case: instantaneous displacement at one instant in time
-          kdtopo1(m) = 1
-          kdtopo2(m) = 1
-          tdtopo1(m) = t
-          tdtopo2(m) = t
-          taudtopo(m) = 0.d0
-        else
-          kdtopo1(m) = int(floor((t-t0dtopo(m))/dtdtopo(m)))+1
-          kdtopo2(m) = int(ceiling((t-t0dtopo(m))/dtdtopo(m)))+1
-          kdtopo1(m) = min(kdtopo1(m),mtdtopo(m))
-          kdtopo2(m) = min(kdtopo2(m),mtdtopo(m))
-          kdtopo1(m) = max(kdtopo1(m),1)
-          kdtopo2(m) = max(kdtopo2(m),1)
-          tdtopo1(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo1(m)-1,kind=8) ! <= t
-          tdtopo2(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo2(m)-1,kind=8) ! >= t
-          taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
-          taudtopo(m) = max(taudtopo(m),0.d0)
-        endif
-      index0_dtopowork1(m) = i0dtopo(m) + (kdtopo1(m)-1)*mxdtopo(m)*mydtopo(m)
-      index0_dtopowork2(m) = i0dtopo(m) + (kdtopo2(m)-1)*mxdtopo(m)*mydtopo(m)
-   enddo
-
-
-   !first set topofiles aligned exactly with corresponding dtopo
-   !do i= mtopofiles - num_dtopo + 1, mtopofiles !topofile
-   !   m = i - mtopofiles + num_dtopo !corresponding dtopofile
-      !interpolate in time directly for matching nodes
-   !   if (t<t0dtopo(m).or.topotime(i)>tfdtopo(m)) then
-         !dtopo has not started or topo has already been set from final dz
-   !      cycle
-   !   endif
-   !   topowork(i0topo(i):i0topo(i) + mtopo(i)-1) = &
-   !            topo0work(i0topo0(i):i0topo0(i) + mtopo(i)-1) &!initial topo
-   !            + taudtopo(m)*dtopowork(index0_dtopowork1(m):index0_dtopowork1(m) + mtopo(i)-1) &
-   !            + (1.0-taudtopo(m))*dtopowork(index0_dtopowork2(m):index0_dtopowork2(m) + mtopo(i)-1)
-      !set time-stamp
-   !   topotime(i) = t
-   !enddo
-
-
-   !set non-dtopo associated topofiles
-   !rather, set all topofiles
-   do mt=1,mtopofiles
-      if (topo0save(mt)<=0) then
-         !no intersection or dtopo area already covered by finer topo files
-         !shouldn't ever need to alter this topofile
-         topotime(mt)=t
-         cycle
+   !======================================================================
+   !
+   !  called to update topography grids to the current time t
+   !  topo arrays are modified directly from topo0 and dtopo
+   !
+   !  this routine replaces the old method implemented in movetopo
+   !  where dtopo modified aux arrays directly. Now aux values are
+   !  always determined from topography grids.
+   !
+   !                   David George, dgeorge@usgs.gov, December 20 2013
+   
+   
+      use topo_module
+   
+      implicit none
+   
+      !arguments
+      real(kind=8), intent(in) ::t
+   
+      !locals
+      integer :: m,mt
+      integer :: irank,idtopo1,idtopo2,jdtopo1,jdtopo2
+      integer(kind=8) :: ij,ij0,i,j,ijll,ijlr,ijul,ijur
+      real(kind=8) :: x,y,xl,xr,yu,yl,zll,zlr,zul,zur,dz12,dz1,dz2,dztotal
+   
+      if (t<minval(t0dtopo).or.topo_finalized.eqv..true.) then
+         return
       endif
-      if (topotime(mt)==t) then
-         !topofile is already at correct time
-         !this should catch the files set in the first loop above for topo/dtopo files
-         cycle
+   
+      if (minval(topotime)>=maxval(tfdtopo)) then
+         topo_finalized = .true.
+         return
       endif
-
-      do j=1,mytopo(mt)
-         y = yhitopo(mt) - real(j-1,kind=8)*dytopo(mt)
-         do i=1,mxtopo(mt)
-            ij = i0topo(mt) + (j-1)*mxtopo(mt) + i -1
-            ij0 = i0topo0(mt) + (j-1)*mxtopo(mt) + i -1
-            x = xlowtopo(mt) +  real(i-1,kind=8)*dxtopo(mt)
-            dztotal = 0.0
-            do irank = 1,num_dtopo
-               m = mdtopoorder(irank)
-               if ( (x>xhidtopo(m)).or.(x<xlowdtopo(m)).or. &
-                          (y>yhidtopo(m)).or.(y<ylowdtopo(m))) then
-                     !no intersection of point with this dtopo
-                     cycle
-               endif
-
-               !if (t<t0dtopo(m).or.topotime(mt)>tfdtopo(m)) then
-               if (t<t0dtopo(m)) then
-                  !this dtopo does not take place yet or topo has already been set for final dz from this dtopo
-                  !this is important to skip, because of limits set above that would use the initial dz even when t<t0dtopo. this should be revisited
-                  !intersection might be with another dtopo with different time bands
-                  cycle
-               endif
-               !find indices for bilinear dtopo
-               !dtopo arrays are in form of DEM...high y values first
-               !note for xy points lying on nodes all indices will be equal
-
-               ! rewritten to avoid roundoff pushing outside of proper range:
-               ! note above is no longer true but interp should be fine
-               idtopo1 = int(floor((x-xlowdtopo(m))/dxdtopo(m)))+1
-               idtopo1 = max(1, min(mxdtopo(m)-1, idtopo1))
-               idtopo2 = idtopo1+1
-               jdtopo1 = int(floor((yhidtopo(m)-y)/dydtopo(m))) + 1
-               jdtopo1 = max(1, min(mydtopo(m)-1, jdtopo1))
-               jdtopo2 = jdtopo1+1
-
-               !indices for dtopo work array
-               ijll = index0_dtopowork1(m) + (jdtopo2-1)*mxdtopo(m) + idtopo1 -1
-               ijlr = index0_dtopowork1(m) + (jdtopo2-1)*mxdtopo(m) + idtopo2 -1
-               ijul = index0_dtopowork1(m) + (jdtopo1-1)*mxdtopo(m) + idtopo1 -1
-               ijur = index0_dtopowork1(m) + (jdtopo1-1)*mxdtopo(m) + idtopo2 -1
-
-               !find x,y,z values for bilinear
-               !z may be from only 1 or 2 nodes for coincidently aligned grids
-               !bilinear should still evaluate correctly
-               zll = dtopowork(ijll)
-               zlr = dtopowork(ijlr)
-               zul = dtopowork(ijul)
-               zur = dtopowork(ijur)
-               xl = xlowdtopo(m) + real(idtopo1-1,kind=8)*dxdtopo(m)
-               xr = xl + dxdtopo(m)
-               yu = yhidtopo(m) - real(jdtopo1-1,kind=8)*dydtopo(m)
-               yl = yu - dydtopo(m)
-
-               !bilinear value at (x,y) of dtopo cell at t=tdtopo1
-               dz1 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
-
-               !indices for work array at later time
-               ijll = index0_dtopowork2(m) + (jdtopo2-1)*mxdtopo(m) + idtopo1 -1
-               ijlr = index0_dtopowork2(m) + (jdtopo2-1)*mxdtopo(m) + idtopo2 -1
-               ijul = index0_dtopowork2(m) + (jdtopo1-1)*mxdtopo(m) + idtopo1 -1
-               ijur = index0_dtopowork2(m) + (jdtopo1-1)*mxdtopo(m) + idtopo2 -1
-               zll = dtopowork(ijll)
-               zlr = dtopowork(ijlr)
-               zul = dtopowork(ijul)
-               zur = dtopowork(ijur)
-               !bilinear value of at (x,y) of dtopo cell at t=tdtopo2
-               dz2 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
-               dz12 = taudtopo(m)*dz1 + (1.0-taudtopo(m))*dz2
-               dz12 = dz12/(dxdtopo(m)*dydtopo(m))
-               !found value from finest dtopo, move to next point
-               !exit
-               !rather, don't exit, add dtopo
-               dztotal = dztotal + dz12
-            enddo
-            !set topo value from ALL dtopo
-            topowork(ij) = topo0work(ij0) + dztotal
-         enddo
+   
+      !first find t related values to avoid calculation for every i,j
+      do m=1,num_dtopo
+         ! Find indices and times of dtopo arrays bracketing time t, and
+         ! also taudtopo, the fraction of step between, used for interpolation.
+         ! Note that if t < t0dtopo(m) then index is set to 1 but later 
+         ! this dtopo array is skipped altogether in this case and doesn't
+         ! affect topography at time t.
+         if (mtdtopo(m) == 1) then
+             ! Special case: instantaneous displacement at one instant in time
+             kdtopo1(m) = 1
+             kdtopo2(m) = 1
+             tdtopo1(m) = t
+             tdtopo2(m) = t
+             taudtopo(m) = 0.d0
+           else
+             kdtopo1(m) = int(floor((t-t0dtopo(m))/dtdtopo(m)))+1
+             kdtopo2(m) = int(ceiling((t-t0dtopo(m))/dtdtopo(m)))+1
+             kdtopo1(m) = min(kdtopo1(m),mtdtopo(m))
+             kdtopo2(m) = min(kdtopo2(m),mtdtopo(m))
+             kdtopo1(m) = max(kdtopo1(m),1)
+             kdtopo2(m) = max(kdtopo2(m),1)
+             tdtopo1(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo1(m)-1,kind=8) ! <= t
+             tdtopo2(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo2(m)-1,kind=8) ! >= t
+             taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
+             taudtopo(m) = max(taudtopo(m),0.d0)
+           endif
+         index0_dtopowork1(m) = i0dtopo(m) + (int(kdtopo1(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
+         index0_dtopowork2(m) = i0dtopo(m) + (int(kdtopo2(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
       enddo
-      topotime(mt) = t
-   enddo
-
-
-end subroutine topo_update
+   
+   
+      !first set topofiles aligned exactly with corresponding dtopo
+      !do i= mtopofiles - num_dtopo + 1, mtopofiles !topofile
+      !   m = i - mtopofiles + num_dtopo !corresponding dtopofile
+         !interpolate in time directly for matching nodes
+      !   if (t<t0dtopo(m).or.topotime(i)>tfdtopo(m)) then
+            !dtopo has not started or topo has already been set from final dz
+      !      cycle
+      !   endif
+      !   topowork(i0topo(i):i0topo(i) + mtopo(i)-1) = &
+      !            topo0work(i0topo0(i):i0topo0(i) + mtopo(i)-1) &!initial topo
+      !            + taudtopo(m)*dtopowork(index0_dtopowork1(m):index0_dtopowork1(m) + mtopo(i)-1) &
+      !            + (1.0-taudtopo(m))*dtopowork(index0_dtopowork2(m):index0_dtopowork2(m) + mtopo(i)-1)
+         !set time-stamp
+      !   topotime(i) = t
+      !enddo
+   
+   
+      !set non-dtopo associated topofiles
+      !rather, set all topofiles
+      do mt=1,mtopofiles
+         if (topo0save(mt)<=0) then
+            !no intersection or dtopo area already covered by finer topo files
+            !shouldn't ever need to alter this topofile
+            topotime(mt)=t
+            cycle
+         endif
+         if (topotime(mt)==t) then
+            !topofile is already at correct time
+            !this should catch the files set in the first loop above for topo/dtopo files
+            cycle
+         endif
+   
+         do j=1,int(mytopo(mt), 8)
+            y = yhitopo(mt) - real(j-1,kind=8)*dytopo(mt)
+            do i=1,int(mxtopo(mt), 8)
+               ij = i0topo(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
+               ij0 = i0topo0(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
+               x = xlowtopo(mt) +  real(i-1,kind=8)*dxtopo(mt)
+               dztotal = 0.0
+               do irank = 1,num_dtopo
+                  m = mdtopoorder(irank)
+                  if ( (x>xhidtopo(m)).or.(x<xlowdtopo(m)).or. &
+                             (y>yhidtopo(m)).or.(y<ylowdtopo(m))) then
+                        !no intersection of point with this dtopo
+                        cycle
+                  endif
+   
+                  !if (t<t0dtopo(m).or.topotime(mt)>tfdtopo(m)) then
+                  if (t<t0dtopo(m)) then
+                     !this dtopo does not take place yet or topo has already been set for final dz from this dtopo
+                     !this is important to skip, because of limits set above that would use the initial dz even when t<t0dtopo. this should be revisited
+                     !intersection might be with another dtopo with different time bands
+                     cycle
+                  endif
+                  !find indices for bilinear dtopo
+                  !dtopo arrays are in form of DEM...high y values first
+                  !note for xy points lying on nodes all indices will be equal
+   
+                  ! rewritten to avoid roundoff pushing outside of proper range:
+                  ! note above is no longer true but interp should be fine
+                  idtopo1 = int(floor((x-xlowdtopo(m))/dxdtopo(m)))+1
+                  idtopo1 = max(1, min(mxdtopo(m)-1, idtopo1))
+                  idtopo2 = idtopo1+1
+                  jdtopo1 = int(floor((yhidtopo(m)-y)/dydtopo(m))) + 1
+                  jdtopo1 = max(1, min(mydtopo(m)-1, jdtopo1))
+                  jdtopo2 = jdtopo1+1
+   
+                  !indices for dtopo work array
+                  ijll = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+                  ijlr = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+                  ijul = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+                  ijur = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+   
+                  !find x,y,z values for bilinear
+                  !z may be from only 1 or 2 nodes for coincidently aligned grids
+                  !bilinear should still evaluate correctly
+                  zll = dtopowork(ijll)
+                  zlr = dtopowork(ijlr)
+                  zul = dtopowork(ijul)
+                  zur = dtopowork(ijur)
+                  xl = xlowdtopo(m) + real(idtopo1-1,kind=8)*dxdtopo(m)
+                  xr = xl + dxdtopo(m)
+                  yu = yhidtopo(m) - real(jdtopo1-1,kind=8)*dydtopo(m)
+                  yl = yu - dydtopo(m)
+   
+                  !bilinear value at (x,y) of dtopo cell at t=tdtopo1
+                  dz1 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
+   
+                  !indices for work array at later time
+                  ijll = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+                  ijlr = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+                  ijul = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+                  ijur = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+                  zll = dtopowork(ijll)
+                  zlr = dtopowork(ijlr)
+                  zul = dtopowork(ijul)
+                  zur = dtopowork(ijur)
+                  !bilinear value of at (x,y) of dtopo cell at t=tdtopo2
+                  dz2 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
+                  dz12 = taudtopo(m)*dz1 + (1.0-taudtopo(m))*dz2
+                  dz12 = dz12/(dxdtopo(m)*dydtopo(m))
+                  !found value from finest dtopo, move to next point
+                  !exit
+                  !rather, don't exit, add dtopo
+                  dztotal = dztotal + dz12
+               enddo
+               !set topo value from ALL dtopo
+               topowork(ij) = topo0work(ij0) + dztotal
+            enddo
+         enddo
+         topotime(mt) = t
+      enddo
+   
+   
+   end subroutine topo_update
+   

--- a/src/2d/shallow/topo_update.f90
+++ b/src/2d/shallow/topo_update.f90
@@ -10,174 +10,174 @@ subroutine topo_update(t)
    !  always determined from topography grids.
    !
    !                   David George, dgeorge@usgs.gov, December 20 2013
-   
-   
-      use topo_module
-   
-      implicit none
-   
-      !arguments
-      real(kind=8), intent(in) ::t
-   
-      !locals
-      integer :: m,mt
-      integer :: irank,idtopo1,idtopo2,jdtopo1,jdtopo2
-      integer(kind=8) :: ij,ij0,i,j,ijll,ijlr,ijul,ijur
-      real(kind=8) :: x,y,xl,xr,yu,yl,zll,zlr,zul,zur,dz12,dz1,dz2,dztotal
-   
-      if (t<minval(t0dtopo).or.topo_finalized.eqv..true.) then
-         return
+
+
+   use topo_module
+
+   implicit none
+
+   !arguments
+   real(kind=8), intent(in) ::t
+
+   !locals
+   integer :: m,mt
+   integer :: irank,idtopo1,idtopo2,jdtopo1,jdtopo2
+   integer(kind=8) :: ij,ij0,i,j,ijll,ijlr,ijul,ijur
+   real(kind=8) :: x,y,xl,xr,yu,yl,zll,zlr,zul,zur,dz12,dz1,dz2,dztotal
+
+   if (t<minval(t0dtopo).or.topo_finalized.eqv..true.) then
+      return
+   endif
+
+   if (minval(topotime)>=maxval(tfdtopo)) then
+      topo_finalized = .true.
+      return
+   endif
+
+   !first find t related values to avoid calculation for every i,j
+   do m=1,num_dtopo
+      ! Find indices and times of dtopo arrays bracketing time t, and
+      ! also taudtopo, the fraction of step between, used for interpolation.
+      ! Note that if t < t0dtopo(m) then index is set to 1 but later
+      ! this dtopo array is skipped altogether in this case and doesn't
+      ! affect topography at time t.
+      if (mtdtopo(m) == 1) then
+         ! Special case: instantaneous displacement at one instant in time
+         kdtopo1(m) = 1
+         kdtopo2(m) = 1
+         tdtopo1(m) = t
+         tdtopo2(m) = t
+         taudtopo(m) = 0.d0
+      else
+         kdtopo1(m) = int(floor((t-t0dtopo(m))/dtdtopo(m)))+1
+         kdtopo2(m) = int(ceiling((t-t0dtopo(m))/dtdtopo(m)))+1
+         kdtopo1(m) = min(kdtopo1(m),mtdtopo(m))
+         kdtopo2(m) = min(kdtopo2(m),mtdtopo(m))
+         kdtopo1(m) = max(kdtopo1(m),1)
+         kdtopo2(m) = max(kdtopo2(m),1)
+         tdtopo1(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo1(m)-1,kind=8) ! <= t
+         tdtopo2(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo2(m)-1,kind=8) ! >= t
+         taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
+         taudtopo(m) = max(taudtopo(m),0.d0)
       endif
-   
-      if (minval(topotime)>=maxval(tfdtopo)) then
-         topo_finalized = .true.
-         return
+      index0_dtopowork1(m) = i0dtopo(m) + (int(kdtopo1(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
+      index0_dtopowork2(m) = i0dtopo(m) + (int(kdtopo2(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
+   enddo
+
+
+   !first set topofiles aligned exactly with corresponding dtopo
+   !do i= mtopofiles - num_dtopo + 1, mtopofiles !topofile
+   !   m = i - mtopofiles + num_dtopo !corresponding dtopofile
+   !interpolate in time directly for matching nodes
+   !   if (t<t0dtopo(m).or.topotime(i)>tfdtopo(m)) then
+   !dtopo has not started or topo has already been set from final dz
+   !      cycle
+   !   endif
+   !   topowork(i0topo(i):i0topo(i) + mtopo(i)-1) = &
+   !            topo0work(i0topo0(i):i0topo0(i) + mtopo(i)-1) &!initial topo
+   !            + taudtopo(m)*dtopowork(index0_dtopowork1(m):index0_dtopowork1(m) + mtopo(i)-1) &
+   !            + (1.0-taudtopo(m))*dtopowork(index0_dtopowork2(m):index0_dtopowork2(m) + mtopo(i)-1)
+   !set time-stamp
+   !   topotime(i) = t
+   !enddo
+
+
+   !set non-dtopo associated topofiles
+   !rather, set all topofiles
+   do mt=1,mtopofiles
+      if (topo0save(mt)<=0) then
+         !no intersection or dtopo area already covered by finer topo files
+         !shouldn't ever need to alter this topofile
+         topotime(mt)=t
+         cycle
       endif
-   
-      !first find t related values to avoid calculation for every i,j
-      do m=1,num_dtopo
-         ! Find indices and times of dtopo arrays bracketing time t, and
-         ! also taudtopo, the fraction of step between, used for interpolation.
-         ! Note that if t < t0dtopo(m) then index is set to 1 but later 
-         ! this dtopo array is skipped altogether in this case and doesn't
-         ! affect topography at time t.
-         if (mtdtopo(m) == 1) then
-             ! Special case: instantaneous displacement at one instant in time
-             kdtopo1(m) = 1
-             kdtopo2(m) = 1
-             tdtopo1(m) = t
-             tdtopo2(m) = t
-             taudtopo(m) = 0.d0
-           else
-             kdtopo1(m) = int(floor((t-t0dtopo(m))/dtdtopo(m)))+1
-             kdtopo2(m) = int(ceiling((t-t0dtopo(m))/dtdtopo(m)))+1
-             kdtopo1(m) = min(kdtopo1(m),mtdtopo(m))
-             kdtopo2(m) = min(kdtopo2(m),mtdtopo(m))
-             kdtopo1(m) = max(kdtopo1(m),1)
-             kdtopo2(m) = max(kdtopo2(m),1)
-             tdtopo1(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo1(m)-1,kind=8) ! <= t
-             tdtopo2(m) = t0dtopo(m)+ dtdtopo(m)*real(kdtopo2(m)-1,kind=8) ! >= t
-             taudtopo(m) = 1.d0-max(0.d0,((t-tdtopo1(m))/dtdtopo(m)))
-             taudtopo(m) = max(taudtopo(m),0.d0)
-           endif
-         index0_dtopowork1(m) = i0dtopo(m) + (int(kdtopo1(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
-         index0_dtopowork2(m) = i0dtopo(m) + (int(kdtopo2(m), 8)-1)*int(mxdtopo(m), 8)*int(mydtopo(m), 8)
-      enddo
-   
-   
-      !first set topofiles aligned exactly with corresponding dtopo
-      !do i= mtopofiles - num_dtopo + 1, mtopofiles !topofile
-      !   m = i - mtopofiles + num_dtopo !corresponding dtopofile
-         !interpolate in time directly for matching nodes
-      !   if (t<t0dtopo(m).or.topotime(i)>tfdtopo(m)) then
-            !dtopo has not started or topo has already been set from final dz
-      !      cycle
-      !   endif
-      !   topowork(i0topo(i):i0topo(i) + mtopo(i)-1) = &
-      !            topo0work(i0topo0(i):i0topo0(i) + mtopo(i)-1) &!initial topo
-      !            + taudtopo(m)*dtopowork(index0_dtopowork1(m):index0_dtopowork1(m) + mtopo(i)-1) &
-      !            + (1.0-taudtopo(m))*dtopowork(index0_dtopowork2(m):index0_dtopowork2(m) + mtopo(i)-1)
-         !set time-stamp
-      !   topotime(i) = t
-      !enddo
-   
-   
-      !set non-dtopo associated topofiles
-      !rather, set all topofiles
-      do mt=1,mtopofiles
-         if (topo0save(mt)<=0) then
-            !no intersection or dtopo area already covered by finer topo files
-            !shouldn't ever need to alter this topofile
-            topotime(mt)=t
-            cycle
-         endif
-         if (topotime(mt)==t) then
-            !topofile is already at correct time
-            !this should catch the files set in the first loop above for topo/dtopo files
-            cycle
-         endif
-   
-         do j=1,int(mytopo(mt), 8)
-            y = yhitopo(mt) - real(j-1,kind=8)*dytopo(mt)
-            do i=1,int(mxtopo(mt), 8)
-               ij = i0topo(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
-               ij0 = i0topo0(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
-               x = xlowtopo(mt) +  real(i-1,kind=8)*dxtopo(mt)
-               dztotal = 0.0
-               do irank = 1,num_dtopo
-                  m = mdtopoorder(irank)
-                  if ( (x>xhidtopo(m)).or.(x<xlowdtopo(m)).or. &
-                             (y>yhidtopo(m)).or.(y<ylowdtopo(m))) then
-                        !no intersection of point with this dtopo
-                        cycle
-                  endif
-   
-                  !if (t<t0dtopo(m).or.topotime(mt)>tfdtopo(m)) then
-                  if (t<t0dtopo(m)) then
-                     !this dtopo does not take place yet or topo has already been set for final dz from this dtopo
-                     !this is important to skip, because of limits set above that would use the initial dz even when t<t0dtopo. this should be revisited
-                     !intersection might be with another dtopo with different time bands
-                     cycle
-                  endif
-                  !find indices for bilinear dtopo
-                  !dtopo arrays are in form of DEM...high y values first
-                  !note for xy points lying on nodes all indices will be equal
-   
-                  ! rewritten to avoid roundoff pushing outside of proper range:
-                  ! note above is no longer true but interp should be fine
-                  idtopo1 = int(floor((x-xlowdtopo(m))/dxdtopo(m)))+1
-                  idtopo1 = max(1, min(mxdtopo(m)-1, idtopo1))
-                  idtopo2 = idtopo1+1
-                  jdtopo1 = int(floor((yhidtopo(m)-y)/dydtopo(m))) + 1
-                  jdtopo1 = max(1, min(mydtopo(m)-1, jdtopo1))
-                  jdtopo2 = jdtopo1+1
-   
-                  !indices for dtopo work array
-                  ijll = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
-                  ijlr = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
-                  ijul = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
-                  ijur = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
-   
-                  !find x,y,z values for bilinear
-                  !z may be from only 1 or 2 nodes for coincidently aligned grids
-                  !bilinear should still evaluate correctly
-                  zll = dtopowork(ijll)
-                  zlr = dtopowork(ijlr)
-                  zul = dtopowork(ijul)
-                  zur = dtopowork(ijur)
-                  xl = xlowdtopo(m) + real(idtopo1-1,kind=8)*dxdtopo(m)
-                  xr = xl + dxdtopo(m)
-                  yu = yhidtopo(m) - real(jdtopo1-1,kind=8)*dydtopo(m)
-                  yl = yu - dydtopo(m)
-   
-                  !bilinear value at (x,y) of dtopo cell at t=tdtopo1
-                  dz1 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
-   
-                  !indices for work array at later time
-                  ijll = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
-                  ijlr = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
-                  ijul = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
-                  ijur = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
-                  zll = dtopowork(ijll)
-                  zlr = dtopowork(ijlr)
-                  zul = dtopowork(ijul)
-                  zur = dtopowork(ijur)
-                  !bilinear value of at (x,y) of dtopo cell at t=tdtopo2
-                  dz2 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
-                  dz12 = taudtopo(m)*dz1 + (1.0-taudtopo(m))*dz2
-                  dz12 = dz12/(dxdtopo(m)*dydtopo(m))
-                  !found value from finest dtopo, move to next point
-                  !exit
-                  !rather, don't exit, add dtopo
-                  dztotal = dztotal + dz12
-               enddo
-               !set topo value from ALL dtopo
-               topowork(ij) = topo0work(ij0) + dztotal
+      if (topotime(mt)==t) then
+         !topofile is already at correct time
+         !this should catch the files set in the first loop above for topo/dtopo files
+         cycle
+      endif
+
+      do j=1,int(mytopo(mt), 8)
+         y = yhitopo(mt) - real(j-1,kind=8)*dytopo(mt)
+         do i=1,int(mxtopo(mt), 8)
+            ij = i0topo(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
+            ij0 = i0topo0(mt) + (j-1)*int(mxtopo(mt), 8) + i -1
+            x = xlowtopo(mt) +  real(i-1,kind=8)*dxtopo(mt)
+            dztotal = 0.0
+            do irank = 1,num_dtopo
+               m = mdtopoorder(irank)
+               if ( (x>xhidtopo(m)).or.(x<xlowdtopo(m)).or. &
+                  (y>yhidtopo(m)).or.(y<ylowdtopo(m))) then
+                  !no intersection of point with this dtopo
+                  cycle
+               endif
+
+               !if (t<t0dtopo(m).or.topotime(mt)>tfdtopo(m)) then
+               if (t<t0dtopo(m)) then
+                  !this dtopo does not take place yet or topo has already been set for final dz from this dtopo
+                  !this is important to skip, because of limits set above that would use the initial dz even when t<t0dtopo. this should be revisited
+                  !intersection might be with another dtopo with different time bands
+                  cycle
+               endif
+               !find indices for bilinear dtopo
+               !dtopo arrays are in form of DEM...high y values first
+               !note for xy points lying on nodes all indices will be equal
+
+               ! rewritten to avoid roundoff pushing outside of proper range:
+               ! note above is no longer true but interp should be fine
+               idtopo1 = int(floor((x-xlowdtopo(m))/dxdtopo(m)))+1
+               idtopo1 = max(1, min(mxdtopo(m)-1, idtopo1))
+               idtopo2 = idtopo1+1
+               jdtopo1 = int(floor((yhidtopo(m)-y)/dydtopo(m))) + 1
+               jdtopo1 = max(1, min(mydtopo(m)-1, jdtopo1))
+               jdtopo2 = jdtopo1+1
+
+               !indices for dtopo work array
+               ijll = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijlr = index0_dtopowork1(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+               ijul = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijur = index0_dtopowork1(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+
+               !find x,y,z values for bilinear
+               !z may be from only 1 or 2 nodes for coincidently aligned grids
+               !bilinear should still evaluate correctly
+               zll = dtopowork(ijll)
+               zlr = dtopowork(ijlr)
+               zul = dtopowork(ijul)
+               zur = dtopowork(ijur)
+               xl = xlowdtopo(m) + real(idtopo1-1,kind=8)*dxdtopo(m)
+               xr = xl + dxdtopo(m)
+               yu = yhidtopo(m) - real(jdtopo1-1,kind=8)*dydtopo(m)
+               yl = yu - dydtopo(m)
+
+               !bilinear value at (x,y) of dtopo cell at t=tdtopo1
+               dz1 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
+
+               !indices for work array at later time
+               ijll = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijlr = index0_dtopowork2(m) + int(jdtopo2-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+               ijul = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo1, 8) -1
+               ijur = index0_dtopowork2(m) + int(jdtopo1-1, 8)*int(mxdtopo(m), 8) + int(idtopo2, 8) -1
+               zll = dtopowork(ijll)
+               zlr = dtopowork(ijlr)
+               zul = dtopowork(ijul)
+               zur = dtopowork(ijur)
+               !bilinear value of at (x,y) of dtopo cell at t=tdtopo2
+               dz2 = zll*(xr-x)*(yu-y) + zlr*(x-xl)*(yu-y) + zul*(xr-x)*(y-yl) + zur*(x-xl)*(y-yl)
+               dz12 = taudtopo(m)*dz1 + (1.0-taudtopo(m))*dz2
+               dz12 = dz12/(dxdtopo(m)*dydtopo(m))
+               !found value from finest dtopo, move to next point
+               !exit
+               !rather, don't exit, add dtopo
+               dztotal = dztotal + dz12
             enddo
+            !set topo value from ALL dtopo
+            topowork(ij) = topo0work(ij0) + dztotal
          enddo
-         topotime(mt) = t
       enddo
-   
-   
-   end subroutine topo_update
-   
+      topotime(mt) = t
+   enddo
+
+
+end subroutine topo_update
+


### PR DESCRIPTION
Addresses #539. Also addresses one other issue. Previously, the total number of grid cells in your supplied topography was limited to a 4-byte integer's values (2\**31 -1). This was violated, for example, when using a large chunk of a global 15-arcsecond DEM (which has occasionally been necessary when running a global model to avoid model instability due to boundary fluxes). This PR changes that limit to a 8-byte integer (2\**63 - 1).