### PR TITLE
Fix fgmax_finalize.f90 to construct proper filename

### DIFF
--- a/src/2d/shallow/fgmax_finalize.f90
+++ b/src/2d/shallow/fgmax_finalize.f90
@@ -29,8 +29,7 @@ subroutine fgmax_finalize()
 
         fg => FG_fgrids(ifg)   
 
-        !ifg1 = ifg
-        ifg1 = fg%fgno  ! use the fgno specified, not 1,2,...
+        ifg1 = fg%fgno  ! use the fgno specified for filename, not ifg
         do ipos=4,1,-1
             idigit = mod(ifg1,10)
             cfgno(ipos:ipos) = char(ichar('0') + idigit)

--- a/src/2d/shallow/fgmax_finalize.f90
+++ b/src/2d/shallow/fgmax_finalize.f90
@@ -29,7 +29,8 @@ subroutine fgmax_finalize()
 
         fg => FG_fgrids(ifg)   
 
-        ifg1 = ifg
+        !ifg1 = ifg
+        ifg1 = fg%fgno  ! use the fgno specified, not 1,2,...
         do ipos=4,1,-1
             idigit = mod(ifg1,10)
             cfgno(ipos:ipos) = char(ichar('0') + idigit)


### PR DESCRIPTION
Filename for fgmax output file should be based on `fg.fgno` since that is specified by the user, rather than just numbering them sequentially.