### PR TITLE
topotools.Topography.__init__ now calls read() if path given.

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -417,7 +417,7 @@ class Topography(object):
         return self._delta
 
 
-    def __init__(self, path=None, topo_func=None, topo_type=None, 
+    def __init__(self, path=None, topo_type=None, topo_func=None, 
                        unstructured=False):
         r"""Topography initialization routine.
         
@@ -446,11 +446,9 @@ class Topography(object):
 
         self.coordinate_transform = lambda x,y: (x,y)
 
-        # RJL: should we read in by default if path is specified?
-        #      If not, why include all these parameters in __init__?
-        #if path:
-        #    self.read(path=path, topo_type=topo_type, unstructured=unstructured,
-        #     mask=mask, filter_region=filter_region)
+        if path:
+            self.read(path=path, topo_type=topo_type,
+                      unstructured=unstructured)
 
     def set_xyZ(self, X, Y, Z):
         r"""


### PR DESCRIPTION
The arguments were also re-ordered so `topo_type` follows `path`, since this is the most common use case (`topo_func` is now third). So you can do:

    topo = topotools.Topography(filename, 3)

to create a `Topography` object and read data from filename with `topo_type=3`.

Before, you had to do

    topo = topotools.Topography()
    topo.read(filename, 3)

Not a major change but after years of doing this, I'm tired of it.

This is also now consistent with `dtopotools`, where you can do something similar.
