### PR TITLE
change InputError to ValueError

### DIFF
--- a/src/python/geoclaw/fgout_tools.py
+++ b/src/python/geoclaw/fgout_tools.py
@@ -591,7 +591,7 @@ def make_fgout_fcn_xyt(fgout1, fgout2, qoi, method_xy='nearest',
         elif bounds_error:
             errmsg = '*** argument t=%g should be between t1=%g and t2=%g' \
                      % (t,t1,t2)
-            raise InputError(errmsg)
+            raise ValueError(errmsg)
         else:
             qout = fill_value * ones(xa.shape)
             return qout


### PR DESCRIPTION
I mis-remembered the name of the standard exception, `InputError` is not defined.