### PR TITLE
Add sphere_source parameter

### DIFF
--- a/src/2d/shallow/geoclaw_module.f90
+++ b/src/2d/shallow/geoclaw_module.f90
@@ -30,7 +30,7 @@ module geoclaw_module
     real(kind=8) :: grav, rho_air, ambient_pressure, earth_radius, sea_level
     ! Water density can be an array to handle multiple layers
     real(kind=8), allocatable :: rho(:)
-    integer :: coordinate_system
+    integer :: coordinate_system, sphere_source
 
     ! Rotational velocity of Earth
     real(kind=8), parameter :: omega = 2.0d0 * pi / 86164.2d0
@@ -93,6 +93,7 @@ contains
             read(unit,*) ambient_pressure
             read(unit,*) earth_radius
             read(unit,*) coordinate_system
+            read(unit,*) sphere_source
             read(unit,*) sea_level
             read(unit,*)
             read(unit,*) coriolis_forcing

--- a/src/2d/shallow/src2.f90
+++ b/src/2d/shallow/src2.f90
@@ -40,9 +40,6 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     ! friction source term
     real(kind=8), parameter :: depth_tolerance = 1.0d-30
 
-    ! eventually move this to geoclaw_module and allow setting in setrun.py:
-    !integer :: sphere_source
-
     ! Physics
     ! Nominal density of water
     real(kind=8), parameter :: rho = 1025.d0
@@ -51,15 +48,10 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     ! Spherical geometry source term(s)
     !
     ! These should be included for shallow water on the sphere, 
-    ! at least in the mass term, but were only added in v5.9.0.
-    ! For now sphere_source is a local variable and is set to 0 for backward
-    ! compatibility.  To test adding source term(s), copy this routine
-    ! and modify sphere_source before recompiling.
-    !
-    ! (Plan for v5.10.1: move to geoclaw_module and allow setting in setrun.py,
-    ! and make sphere_source = 1 the default.)
-
-    !sphere_source = 0   ! for backward compatibility  ! now a setrun param
+    ! at least in the mass term, but were only added in v5.9.0 as an option.
+    ! rundata.geo_data.sphere_source can now be set in setrun.py
+    ! Set sphere_source = 0 to omit source terms for backward compatibility
+    ! sphere_source = 1 should become the default?
 
     if ((coordinate_system == 2) .and. (sphere_source > 0)) then
         ! add in spherical source term in mass equation 

--- a/src/2d/shallow/src2.f90
+++ b/src/2d/shallow/src2.f90
@@ -7,7 +7,7 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     use geoclaw_module, only: spherical_distance, coordinate_system
     use geoclaw_module, only: RAD2DEG, pi, dry_tolerance, DEG2RAD
     use geoclaw_module, only: rho_air
-    use geoclaw_module, only: earth_radius
+    use geoclaw_module, only: earth_radius, sphere_source
       
     use storm_module, only: wind_forcing, pressure_forcing, wind_drag
     use storm_module, only: wind_index, pressure_index
@@ -41,7 +41,7 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     real(kind=8), parameter :: depth_tolerance = 1.0d-30
 
     ! eventually move this to geoclaw_module and allow setting in setrun.py:
-    integer :: sphere_source
+    !integer :: sphere_source
 
     ! Physics
     ! Nominal density of water
@@ -59,7 +59,7 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     ! (Plan for v5.10.1: move to geoclaw_module and allow setting in setrun.py,
     ! and make sphere_source = 1 the default.)
 
-    sphere_source = 0   ! for backward compatibility
+    !sphere_source = 0   ! for backward compatibility  ! now a setrun param
 
     if ((coordinate_system == 2) .and. (sphere_source > 0)) then
         ! add in spherical source term in mass equation 

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -55,6 +55,7 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
         self.add_attribute('ambient_pressure', 101.3e3) # Nominal atmos pressure
         self.add_attribute('earth_radius',Rearth)
         self.add_attribute('coordinate_system',1)
+        self.add_attribute('sphere_source',0)  # should set to 1 by default?
         self.add_attribute('coriolis_forcing',True)
         self.add_attribute('theta_0',45.0)
         self.add_attribute('friction_forcing',True)
@@ -78,7 +79,10 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
         self.data_write('ambient_pressure',
                                 description="(Nominal atmospheric pressure Pa)")
         self.data_write('earth_radius', description="(Radius of the earth m)")
-        self.data_write('coordinate_system')
+        self.data_write('coordinate_system',
+                        description="(1=meters, 2=lon-lat)")
+        self.data_write('sphere_source',
+                        description="(0=none, 1=only in mass eqn, 2=all)")
         self.data_write('sea_level')
         self.data_write()
 


### PR DESCRIPTION
So that sphere source terms can be selected in setrun.py by setting
`rundata.geo_data.sphere_source`

Added to data.py, geoclaw_module.f90 and used in src2.f90.

For now set default to 0 for backward compatibility, but default
should eventually be 1 so that source term in mass is included.