### PR TITLE
Add meson.build.

### DIFF
--- a/src/python/geoclaw/meson.build
+++ b/src/python/geoclaw/meson.build
@@ -1,0 +1,28 @@
+package = 'clawpack.geoclaw'
+pkg_dir = join_paths(package.split('.'))
+
+python_sources = [
+  '__init__.py',
+  'data.py',
+  'dtopotools.py',
+  'etopotools.py',
+  'fgmax_tools.py',
+  'fgout_tools.py',
+  'geoplot.py',
+  'kmltools.py',
+  'marching_front.py',
+  'most2geoclaw.py',
+  'okada.py',
+  'plotfg.py',
+  'resolution.py',
+  'test.py',
+  'topotools.py',
+  'units.py',
+  'util.py',
+]
+
+py.install_sources(
+  python_sources,
+  subdir: pkg_dir,
+)
+


### PR DESCRIPTION
Only installs python files for now.

This is the first phase of switching to meson (away from distutils). This allows meson to install python files only. The second phase is to add compilation of the Fortran extensions (for Python).

For now, this will have no effect since the meson build is not enabled at the top level.