### PR TITLE
Topo module variables removed from cellgridintegrate call sequence

### DIFF
--- a/src/2d/shallow/cellgridintegrate2.f
+++ b/src/2d/shallow/cellgridintegrate2.f
@@ -1,10 +1,8 @@
 c====================================================================
-      subroutine cellgridintegrate(topoint,xim,xcell,xip,yjm,ycell,yjp)
+      subroutine cellgridintegrate(topoint,xim,xip,yjm,yjp)
 c=====================================================================
 
-c *** Removed topo_module variables from calling sequence 
-
-c *** Note: xcell and ycell are no longer needed -- should be removed.
+c *** Note topo_module variables are no longer in the calling sequence 
 
       use topo_module, only: rectintegral,intersection, topowork
       use topo_module, only: xlowtopo,xhitopo,ylowtopo,yhitopo           
@@ -21,7 +19,7 @@ c     defined from data from multiple regular Cartesian grids
 c     (using the finest data available in any region)
 c
 c     The rectangle has coords:
-c     xim <= x <= xip, yjm <= y <= yjp, with center (x,y) = (xcell, ycell)
+c     xim <= x <= xip, yjm <= y <= yjp
 c
 c     The intersection (with one particular grid has coords:
 c     xintlo <= x <= xinthi, yintlo <= y <= yinthi

--- a/src/2d/shallow/cellgridintegrate2.f
+++ b/src/2d/shallow/cellgridintegrate2.f
@@ -1,32 +1,19 @@
 c====================================================================
-      subroutine cellgridintegrate(topoint,xim,xcell,xip,yjm,ycell,
-     &           yjp,xlowtopo,ylowtopo,xhitopo,yhitopo,dxtopo,dytopo,
-     &           mxtopo,mytopo,mtopo,i0topo,mtopoorder,
-     &           mtopofiles,mtoposize,topo)
+      subroutine cellgridintegrate(topoint,xim,xcell,xip,yjm,ycell,yjp)
 c=====================================================================
+
+c *** Removed topo_module variables from calling sequence 
 
 c *** Note: xcell and ycell are no longer needed -- should be removed.
 
-      use topo_module, only: rectintegral, intersection
-
+      use topo_module, only: rectintegral,intersection, topowork
+      use topo_module, only: xlowtopo,xhitopo,ylowtopo,yhitopo           
+      use topo_module, only: dxtopo,dytopo
+      use topo_module, only: mxtopo,mytopo,mtopoorder,i0topo,mtopofiles
+      
       implicit double precision (a-h,o-z)
 
-      dimension topo(mtoposize)
-
-      dimension xlowtopo(mtopofiles)
-      dimension ylowtopo(mtopofiles)
-      dimension xhitopo(mtopofiles)
-      dimension yhitopo(mtopofiles)
-      dimension dxtopo(mtopofiles)
-      dimension dytopo(mtopofiles)
-
-      dimension mxtopo(mtopofiles)
-      dimension mytopo(mtopofiles)
-
-      dimension mtopoorder(mtopofiles)
-      dimension i0topo(mtopofiles)
-      dimension mtopo(mtopofiles)
-
+      integer(kind=8) :: i0
 
 c     ##############################################################################
 c     cellgridintegrate integrates a unique surface, over a rectangular cell
@@ -65,7 +52,7 @@ c              !integrate surface and get out of here
                 topoint = topoint + topointegral(xmlo,xmhi,ymlo,
      &              ymhi,xlowtopo(mfid),ylowtopo(mfid),dxtopo(mfid),
      &              dytopo(mfid),mxtopo(mfid),mytopo(mfid),
-     &              topo(i0),im)
+     &              topowork(i0),im)
                return
             else
                go to 222

--- a/src/2d/shallow/setaux.f90
+++ b/src/2d/shallow/setaux.f90
@@ -161,11 +161,11 @@ subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux)
                         call wrap_coords(x,y,xperm,xper,xperp,yperm,yper, &
                                          yperp,dx,dy)
                         call cellgridintegrate(topo_integral,  &
-                                         xperm,xper,xperp,yperm,yper,yperp)
+                                               xperm,xperp,yperm,yperp)
                     endif
                 else
                     ! Cell does not extend outside of physical domain
-                    call cellgridintegrate(topo_integral,xm,x,xp,ym,y,yp)
+                    call cellgridintegrate(topo_integral,xm,xp,ym,yp)
                 endif
 
                 ! Correct for geometry

--- a/src/2d/shallow/setaux.f90
+++ b/src/2d/shallow/setaux.f90
@@ -161,17 +161,11 @@ subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux)
                         call wrap_coords(x,y,xperm,xper,xperp,yperm,yper, &
                                          yperp,dx,dy)
                         call cellgridintegrate(topo_integral,  &
-                            xperm,xper,xperp,yperm,yper,yperp, &
-                            xlowtopo,ylowtopo,xhitopo,yhitopo,dxtopo,dytopo, &
-                            mxtopo,mytopo,mtopo,i0topo,mtopoorder, &
-                            mtopofiles,mtoposize,topowork)
+                                         xperm,xper,xperp,yperm,yper,yperp)
                     endif
                 else
                     ! Cell does not extend outside of physical domain
-                    call cellgridintegrate(topo_integral,xm,x,xp,ym,y,yp, &
-                            xlowtopo,ylowtopo,xhitopo,yhitopo,dxtopo,dytopo, &
-                            mxtopo,mytopo,mtopo,i0topo,mtopoorder, &
-                            mtopofiles,mtoposize,topowork)
+                    call cellgridintegrate(topo_integral,xm,x,xp,ym,y,yp)
                 endif
 
                 ! Correct for geometry


### PR DESCRIPTION
WIP: Still need to test some more before merging.

Remove `topo_module` variables from calling sequence of `cellgridintegrate`
    
They don't need to be in the calling sequence since setaux already assumes they are in topo_module. 

Some integers were implicitly declared as (kind=4) whereas recent changes to topo_module.f90 in #540 declared them as (kind=8) to deal with larger topo files.  As a result the code dies when reading some large topo files when i0topo overflows 4 bytes and was set to 0 in `gridcellintegrate`.

@bolliger32: You might want to take a look and see if it still works for your big files.