### PR TITLE
compute new ntogo in tick.f rather than incrementing by 1

### DIFF
--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -435,9 +435,6 @@ c                   adjust time steps for this and finer levels
                      write(6,*) "**** ntogo = ",ntogo(level)
                      write(6,1006) intratx(level-1),intraty(level-1),
      &                             kratio(level-1),level
- 602                 format("**** Writing checkpoint file at t = ",
-     &                      d16.6)
-                     write(6,602) time
  603                 format("**** Writing extra output frames for ",
      &                      "debugging at level-1 =",i3,
      &                      " and level =",i3)

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -391,15 +391,22 @@ c                same level goes again. check for ok time step
                     print *,"    old ntogo dt",ntogo(level),possk(level)
 
 c                   adjust time steps for this and finer levels
-                    ntogo(level) = ntogo(level) + 1
-                    possk(level) = (tlevel(level-1)-tlevel(level))/
-     .                             ntogo(level)
+
+                    ! try computing ntogo properly (worked better in BoussDev)
+                    ! (old way was to repeatedly increment by 1)
+                    new_ntogo = ceiling(((tlevel(level-1)
+     &                              -tlevel(level)) / dtnew(level)))
+                    new_ntogo = min(new_ntogo, ntogo(level)+10)
+                    ntogo(level) = new_ntogo
+                    possk(level) = (tlevel(level-1)-tlevel(level))
+     &                             / ntogo(level)
+                    write(*,*) "    NEW ntogo dt ",ntogo(level),
+     &                         possk(level)
                     if (varRefTime) then
-                       kratio(level-1) = ceiling(possk(level-1) /
-     .                                           possk(level))
+                      kratio(level-1) = ceiling(possk(level-1)
+     &                                  / possk(level))
                     endif
-                    print *,"    new ntogo dt ",ntogo(level),
-     &                      possk(level)
+
                     go to 106
                  endif
                  if (ntogo(level) .gt. 100) then

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -531,7 +531,7 @@ c             ! use same alg. as when setting refinement when first make new fin
        endif
 
        ! new STOP feature to do immediate checkpt and exit
-       inquire(FILE="STOP.txt",exist=stopFound) 
+       inquire(FILE="STOP",exist=stopFound) 
           if (stopFound) then
           write(*,*)"STOP file found. Checkpointing and Stopping"
           write(*,*)"REMEMBER to remove file before restarting"

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -428,19 +428,29 @@ c                   adjust time steps for this and finer levels
 
                     go to 106
                  endif
+
                  if (ntogo(level) .gt. 100) then
                      write(6,*) "**** Too many dt reductions ****"
                      write(6,*) "**** Stopping calculation   ****"
                      write(6,*) "**** ntogo = ",ntogo(level)
                      write(6,1006) intratx(level-1),intraty(level-1),
      &                             kratio(level-1),level
-                     write(6,*) "Writing checkpoint file at t = ",time
+ 602                 format("**** Writing checkpoint file at t = ",
+     &                      d16.6)
+                     write(6,602) time
+ 603                 format("**** Writing extra output frames for ",
+     &                      "debugging at level-1 =",i3,
+     &                      " and level =",i3)
+                     write(6,603) level-1, level
                      if (num_gauges .gt. 0) then
                         do ii = 1, num_gauges
                            call print_gauges_and_reset_nextLoc(ii)
                         end do
                      endif
-                     call check(ncycle,time,nvar,naux)
+                     call valout(level-1,level-1,tlevel(level-1),
+     &                           nvar,naux)                       
+                     call valout(level,level,tlevel(level),nvar,naux)
+                     !call outtre(lstart(level),.true.,nvar,naux)
                      stop
                  endif
 


### PR DESCRIPTION
In some tests this leads to fewer ntogo errors (too many dt reductions) than the old way, but doesn't entirely fix the problem.

This PR also contains some other modifications to tick.f:

- Output frames rather than a checkpoint file if it dies with too many dt reductions (cannot properly checkpoint since not at end of coarse timestep)
- Some debug statements that can be turned on
- Properly compute `timenew`
- Look for file STOP rather than STOP.txt to signal user wants to stop and checkpoint ASAP.
