### PR TITLE
Add nonuniform_grid_tools to meson.build

### DIFF
--- a/src/python/geoclaw/meson.build
+++ b/src/python/geoclaw/meson.build
@@ -13,6 +13,7 @@ python_sources = {
     'kmltools.py',
     'marching_front.py',
     'most2geoclaw.py',
+    'nonuniform_grid_tools.py',
     'okada.py',
     'plotfg.py',
     'resolution.py',


### PR DESCRIPTION
@ketch found a fix to the module _nonuniform_grid_tools.py_ not being imported with
`from clawpack.geoclaw import nonuniform_grid_tools`.