### PR TITLE
Add gctransect function to util.py

### DIFF
--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -27,12 +27,12 @@ the full 8 digits if you want it transparent).
  - png2kml - create kml file wrapping a png figure to be viewed on GE
  - kml_build_colorbar - create a colorbar to display on GE
  - topo2kmz - create kmz file showing onshore and offshore topography
+ - transect2kml - create kml file showing a set of points on a transect
  - kml_header - used internally
  - kml_footer - used internally
  - kml_region - used internally
  - kml_gauge - used internally
  - kml_png - used internally
-
  - strip_archive_extensions - strip off things like .tar or .gz
 """
 
@@ -1498,3 +1498,55 @@ def topo2kmz(topo, zlim=(-20,20), mask_outside_zlim=True, sea_level=0.,
             zip.write(file) 
         print('Created %s' % os.path.abspath(fname_kmz))
     os.chdir(savedir)
+
+def transect2kml(xtrans, ytrans, fname='transect.kml'):
+    """
+    Create a kml file for points with long,lat specified by xtrans,ytrans.
+    Label each point with number and coordinates.
+    Adjust longitudes in coordinates so they are all between -180 and 180
+    to display properly in Google Earth (but labels are original values).
+    """
+
+    with open(fname,'w') as kml_file:
+           
+        kml_file.write("""<?xml version="1.0" encoding="UTF-8"?>
+        <kml xmlns="http://www.opengis.net/kml/2.2"
+        xmlns:gx="http://www.google.com/kml/ext/2.2">
+        <Document><name>transect_points</name>
+        
+        <Style id="Red">
+        <IconStyle><color>FF0000FF</color></IconStyle>
+        </Style>
+        
+        <Style id="Yellow">
+        <IconStyle><color>FF00FFFF</color></IconStyle>
+        </Style>
+        """)
+            
+        for k in range(len(xtrans)):
+            x = xtrans[k]
+            y = ytrans[k]
+            if x < -180:
+                xge = x+360
+            elif x > 180:
+                xge = x-360
+            else:
+                xge = x
+            style_id = 'Red'
+            name = 'Transect point %i' % k
+            kml_file.write("""
+            <Placemark><name>%s</name>
+            <description>%.5f, %.5f</description>
+            <styleUrl>#%s</styleUrl>
+            <Point>
+            <coordinates>
+            %.9f, %.9f, 0.0
+            </coordinates>
+            </Point>
+            </Placemark>
+            """ % (name,x,y,style_id,xge,y))
+        
+        kml_file.write("\n</Document>\n</kml>")
+            
+    print('Created ', fname)
+    

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -33,7 +33,7 @@ the full 8 digits if you want it transparent).
  - kml_region - used internally
  - kml_gauge - used internally
  - kml_png - used internally
- - strip_archive_extensions - strip off things like .tar or .gz
+ - kml_cb - used internally
 """
 
 try:

--- a/src/python/geoclaw/util.py
+++ b/src/python/geoclaw/util.py
@@ -206,7 +206,16 @@ def gctransect(x1,y1,x2,y2,npts,coords='W',units='degrees',Rearth=Rearth):
     If coords='E' the points will all have -0 <= x < 2*pi.
     With continuity at the date line x = \pm pi.
 
-    Based on https://math.stackexchange.com/questions/1783746/equation-of-a-great-circle-passing-through-two-points
+    Sample usage for 50 points on great circle from Tohoku to Crescent City:
+
+        from clawpack.geoclaw import util,kmltools
+        xtrans,ytrans = util.gctransect(142,37,-124.2,41.74,50,'W')
+        kmltools.transect2kml(xtrans,ytrans)
+        # then open transect.kml to view on Google Earth
+
+    Based in part on formulas in
+         https://math.stackexchange.com/questions/1783746
+
     """
     from numpy import pi,sin,cos,arcsin,sqrt,arctan2,array,dot,zeros,linspace
     
@@ -227,19 +236,20 @@ def gctransect(x1,y1,x2,y2,npts,coords='W',units='degrees',Rearth=Rearth):
     d = dot(V1,V2)
     beta = sqrt(1/(1-d**2))
     alpha = -beta*d
-    #print('d = %.6f, alpha = %.6f, beta = %.6f' % (d,alpha,beta))
-    W1 = alpha*V1 + beta*V2
-    yW1 = arcsin(W1[2])
-    xW1 = arcsin(W1[1]/cos(yW1))
-    #print('W = ',xW1/d2r, yW1/d2r)
+    W = alpha*V1 + beta*V2
+    yW = arcsin(W[2])
+    xW = arcsin(W[1]/cos(yW))
+
+    # compute transect points:
     t2 = arcsin(1/beta)
     if d<0: t2 = pi - t2
-    #print('t2 = %.6f' % t2)
     t = linspace(0, t2, npts)
+
     xtrans = zeros(npts)
     ytrans = zeros(npts)
+
     for j,tj in enumerate(t):
-        V = cos(tj)*V1 + sin(tj)*W1
+        V = cos(tj)*V1 + sin(tj)*W
         yV = arcsin(V[2])        # latitude between -pi/2 and pi/2
         xV = arctan2(V[1],V[0])  # longitude between -pi and pi
 
@@ -256,13 +266,6 @@ def gctransect(x1,y1,x2,y2,npts,coords='W',units='degrees',Rearth=Rearth):
         xtrans[j] = xV
         ytrans[j] = yV
         
-    if 0:
-        # debug:
-        print('     V1 = ',V1)
-        print('     V2 = ',V2)
-        print('Final V = ',V)
-        print('xtrans = ',xtrans)
-        print('ytrans = ',ytrans)
     return xtrans, ytrans
     
 

--- a/src/python/geoclaw/util.py
+++ b/src/python/geoclaw/util.py
@@ -167,7 +167,7 @@ def bearing(x0, y0, x1, y1, units='degrees', bearing_units='degrees'):
         u = U(r) * sin(beta)  # beta measured from North!
         v = U(r) * cos(beta)
     """
-    from math import atan2, degrees
+    from math import atan2, degrees, radians
 
     if units == 'degrees':
         # convert to radians:
@@ -192,7 +192,7 @@ def bearing(x0, y0, x1, y1, units='degrees', bearing_units='degrees'):
     elif bearing_units != 'degrees':
         raise Exception("unrecognized bearing_units")
 
-    return b
+    return beta
     
 
 def fetch_noaa_tide_data(station, begin_date, end_date, time_zone='GMT',


### PR DESCRIPTION
`util.gctransect` computes points on a great circle connecting two points specified by lat-long coordinates.  If the points are far apart then this transect is more sensible to use for plotting a cross-section of a tsunami than the straight line in lat-long space connecting the points.

`kmltools.transect2kml` creates a kml file to view the points on Google Earth.

Also fixes a bug in `util.bearing` that computes the bearing from one point to another.