### PR TITLE
Updates for bouss in src/2d/shallow

### DIFF
--- a/src/1d_classic/shallow/claw1ez.f
+++ b/src/1d_classic/shallow/claw1ez.f
@@ -340,7 +340,7 @@ c
           open(unit=iunit_fgmax, file='fgmax.txt', status='unknown',
      &         form='formatted')
           write(iunit_fgmax,*) 
-     &          '# xcell, topo, hmax, smax, hssmax, arrival_time'
+     &          '# xcell, topo, hmax, smax, hssmax, etamax, arrival_time'
           do i=1,mx
              etamax = hmax(i) + aux(1,i)
              write(iunit_fgmax,451) xcell(i),aux(1,i),hmax(i),smax(i),

--- a/src/1d_classic/shallow/setaux.f90
+++ b/src/1d_classic/shallow/setaux.f90
@@ -25,7 +25,7 @@ subroutine setaux(mbc,mx,xlower,dx,maux,aux)
     real(kind=8) :: xcell,a
 
     if (mx+1 .ne. mx_edge) then
-        write(6,*) 'mx_edge from grid.data must agree with mx+1'
+        write(6,*) 'mx_edge from celledges.data must agree with mx+1'
         write(6,*) 'mx_edge = ',mx_edge
         write(6,*) 'mx = ',mx
         stop

--- a/src/2d/shallow/qinit.f90
+++ b/src/2d/shallow/qinit.f90
@@ -24,6 +24,7 @@ subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
     real(kind=8) :: veta(1-mbc:mx+mbc,1-mbc:my+mbc)
     real(kind=8) :: ddxy
     
+    q = 0.d0   ! initialize all elements to 0
     
     if (variable_eta_init) then
         ! Set initial surface eta based on eta_init
@@ -31,8 +32,6 @@ subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
       else
         veta = sea_level  ! same value everywhere
       endif
-
-    q(2:3,:,:) = 0.d0   ! set momenta to zero
 
     forall(i=1:mx, j=1:my)
         q(1,i,j) = max(0.d0, veta(i,j) - aux(1,i,j))
@@ -68,18 +67,6 @@ subroutine qinit(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
     ! Add perturbation to initial conditions
     if (qinit_type > 0) then
         call add_perturbation(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux)
-    endif
-
-    if (.false.) then
-        open(23, file='fort.aux',status='unknown',form='formatted')
-        print *,'Writing out aux arrays'
-        print *,' '
-        do j=1,my
-            do i=1,mx
-                write(23,*) i,j,(q(m,i,j),m=1,meqn)
-            enddo
-        enddo
-        close(23)
     endif
     
 end subroutine qinit

--- a/src/2d/shallow/stepgrid.f
+++ b/src/2d/shallow/stepgrid.f
@@ -47,9 +47,12 @@ c      dimension work(mwork)
       logical :: dump = .false.
       logical, intent (in) :: actualstep
       type(fgout_grid), pointer :: fgout
-      logical, allocatable :: fgout_interp_needed(:)
+      logical :: fgout_interp_needed(FGOUT_num_grids)
       real(kind=8) :: fgout_tnext
 c
+#ifdef WHERE_AM_I
+      write(*,*) "     starting stepgrid grid ",mptr 
+#endif
       FGOUT_tcfmax = -rinfinity
       level = node(nestlevel,mptr)
       
@@ -113,10 +116,8 @@ C       mwork1 = mwork - mused              !# remaining space (passed to step2)
 c
       tc0=time !# start of computational step
       tcf=tc0+dt !# end of computational step
-      
-c     Check if fgout interpolation needed before and after step:
 
-      allocate(fgout_interp_needed(FGOUT_num_grids))
+c     Check if fgout interpolation needed before and after step:
 
 !$OMP CRITICAL (FixedGrids)
 
@@ -310,7 +311,10 @@ c            write(*,545) i,j,(q(i,j,ivar),ivar=1,nvar)
          end do
          end do
       endif
-c
+
+#ifdef WHERE_AM_I
+      write(*,*) "     ending   stepgrid grid ",mptr 
+#endif
       return
       end
 


### PR DESCRIPTION
Mostly transparent updates for shallow that make some subroutines work fine also for bouss version so we don't replicate code.

Also change `fgout_interp_needed` array from allocatable to stack based.