### PR TITLE
set rundata.geo_data.sphere_source = 1 by default in data.py

### DIFF
--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -61,7 +61,7 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
         self.add_attribute('ambient_pressure', 101.3e3) # Nominal atmos pressure
         self.add_attribute('earth_radius',Rearth)
         self.add_attribute('coordinate_system',1)
-        self.add_attribute('sphere_source',0)  # should set to 1 by default?
+        self.add_attribute('sphere_source',1)  # New starting in v5.10.0
         self.add_attribute('coriolis_forcing',True)
         self.add_attribute('theta_0',45.0)
         self.add_attribute('friction_forcing',True)


### PR DESCRIPTION
Starting in v5.9.1, spherical source terms originally missing from the shallow water equations could be added as an option. Change so that the default behavior is to add the source term in mass but not the terms in the momentum equations, which seem to have almost no effect on practical problems.

This will change the results for some tsunami propagation problems over long distances, particularly in the N-S direction, but should give more correct behavior.

See https://www.clawpack.org/sphere_source.html and also #569, #570.
