### PR TITLE
Clean up Makefile for examples/bouss/radial_flat/1d_radial

### DIFF
--- a/examples/bouss/radial_flat/1d_radial/Makefile
+++ b/examples/bouss/radial_flat/1d_radial/Makefile
@@ -59,14 +59,3 @@ SOURCES = \
 # Include Makefile containing standard definitions and make options:
 include $(CLAWMAKE)
 
-# Construct the topography data
-.PHONY: topo all
-
-topo:
-	python make_celledges.py
-
-all: 
-	$(MAKE) topo
-	$(MAKE) .plots
-	$(MAKE) .htmls
-


### PR DESCRIPTION
Flat topo specified in `flat.tt1`.

Ignore incorrect commit message.