### PR TITLE
Remove deprecation warning for topotype 1

### DIFF
--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -153,8 +153,8 @@ contains
                     write(GEO_PARM_UNIT,*) '   ',topofname(i)
                     write(GEO_PARM_UNIT,*) '  itopotype = ', itopotype(i)
                     if (abs(itopotype(i)) == 1) then
-                        print *, 'WARNING: topotype 1 has been deprecated'
-                        print *, 'converting to topotype > 1 is encouraged'
+                        print *, 'converting to topotype > 1 might reduce
+file size'
                         print *, 'python tools for converting files are provided'
                     endif
                     call read_topo_header(topofname(i),itopotype(i),mxtopo(i), &


### PR DESCRIPTION
Since we still use topotype 1 for simple flat topography.