### PR TITLE
Better comments and new tests in examples/bouss/radial_flat/Makefile

### DIFF
--- a/examples/bouss/radial_flat/Makefile
+++ b/examples/bouss/radial_flat/Makefile
@@ -1,4 +1,13 @@
 # Makefile for Clawpack code in this directory.
+
+# Version for Boussinesq solvers in GeoClaw, which requires PETSc and MPI
+# See https://www.clawpack.org/bouss2d.html
+#
+# Execute this command to check that enviornment variables set properly:
+#    make check
+# before compiling or executing the code!
+# Then do `make new` if using the Boussinesq version for the first time.
+
 # This version only sets the local files and frequently changed
 # options, and then includes the standard makefile pointed to by CLAWMAKE.
 CLAWMAKE = $(CLAW)/clawutil/src/Makefile.common
@@ -13,15 +22,34 @@ CLAWMAKE = $(CLAW)/clawutil/src/Makefile.common
 
 CLAW_PKG = geoclaw                  # Clawpack package to use
 
-# These environment variables need to be set properly, usually in your shell:
-#PETSC_DIR=/Users/rjl/git/Clones/petsc
+# These environment variables need to be set properly, usually in your
+# shell, but they could be explicitly set here:
+#PETSC_DIR=/full/path/to/petsc
 #PETSC_ARCH=arch-darwin-c-opt
 
 # The file petscMPIoptions sets parameters for MPI and the iterative solver:
-PETSC_OPTIONS=-options_file $(CLAW)/geoclaw/examples/bouss/petscMPIoptions
+# PETSC_OPTIONS must be set as an environment variable!
+# e.g. in bash:
+#   export PETSC_OPTIONS="-options_file $CLAW/geoclaw/examples/bouss/petscMPIoptions"
+
+ifndef PETSC_DIR
+  $(error PETSC_DIR not set)
+endif
+
+ifndef PETSC_ARCH
+  $(error PETSC_ARCH not set)
+endif
+
+ifndef PETSC_OPTIONS
+  PETSC_OPTIONS=MISSING
+  $(error PETSC_OPTIONS must be declared as environment variable)
+endif
+
+# How many MPI processes to use:
+BOUSS_MPI_PROCS ?= 6
 
 EXE = $(PWD)/xgeoclaw
-RUNEXE="${PETSC_DIR}/${PETSC_ARCH}/bin/mpiexec -n 6"
+RUNEXE="${PETSC_DIR}/${PETSC_ARCH}/bin/mpiexec -n ${BOUSS_MPI_PROCS}"
 SETRUN_FILE = setrun.py           # File containing function to make data
 OUTDIR = _output                  # Directory for output
 SETPLOT_FILE = setplot.py         # File containing function to set plots
@@ -83,3 +111,16 @@ SOURCES = \
 # Include Makefile containing standard definitions and make options:
 include $(CLAWMAKE)
 
+.PHONY: check
+
+check:
+	@echo ===================
+	@echo CLAW = $(CLAW)
+	@echo OMP_NUM_THREADS = $(OMP_NUM_THREADS)
+	@echo BOUSS_MPI_PROCS = $(BOUSS_MPI_PROCS)
+	@env | grep PETSC_OPTIONS
+	@echo PETSC_DIR = $(PETSC_DIR)
+	@echo PETSC_ARCH = $(PETSC_ARCH)
+	@echo RUNEXE = $(RUNEXE)
+	@echo FFLAGS = $(FFLAGS)
+	@echo ===================

--- a/examples/bouss/setenv.sh
+++ b/examples/bouss/setenv.sh
@@ -1,16 +1,17 @@
 
-# This is the bash file used by RJL to set the parameters needed
+# This is a sample bash script to set the parameters needed
 # to run the Bouss version of GeoClaw with MPI and OpenMP.
 # Adjust as needed for your system...
 
-export CLAW=/Users/rjl/clawpack_src/clawpack_bouss
-export PYTHONPATH=$CLAW
-echo CLAW is set to $CLAW
+# You also need to set CLAW, FC, and perhaps PYTHONPATH
 
-export PETSC_DIR=/Users/rjl/git/Clones/petsc
+# For more information, see
+#   https://www.clawpack.org/bouss2d.html
+#   https://www.clawpack.org/setenv.html
+
+export PETSC_DIR=/full/path/to/petsc
 export PETSC_ARCH=arch-darwin-c-opt
 export PETSC_OPTIONS="-options_file $CLAW/geoclaw/examples/bouss/petscMPIoptions"
 export OMP_NUM_THREADS=6
+export BOUSS_MPI_PROCS=6  # only used in Clawpack Boussinesq example
 
-# set prompt to show working directory and reminder bouss parameters are set:
-PS1='[\W] bouss $ '


### PR DESCRIPTION
To make sure user has necessary environment variables set to use PETSc, MPI. Otherwise gives an error, e.g. `Makefile:36: *** PETSC_DIR not set.  Stop.`

Also a new target, so that `make check` prints out the relevant variables, e.g.

```
===================
CLAW = /Users/rjl/clawpack_src/clawpack_master
OMP_NUM_THREADS = 6
BOUSS_MPI_PROCS = 6
PETSC_OPTIONS=-options_file /Users/rjl/clawpack_src/clawpack_master/geoclaw/examples/bouss/petscMPIoptions
PETSC_DIR = /Users/rjl/git/Clones/petsc
PETSC_ARCH = arch-darwin-c-opt
RUNEXE = /Users/rjl/git/Clones/petsc/arch-darwin-c-opt/bin/mpiexec -n 6
FFLAGS = -O2 -fopenmp -DHAVE_PETSC -ffree-line-length-none
===================
```

We might want to adopt something similar in `Makefile.common` to be used in all Clawpack examples (showing only CLAW, FFLAGS, and OMP_NUM_THREADS by default).

This PR also cleans up `examples/bouss/setenv.sh` to be a better generic example with links for more info.
