### PR TITLE
remove topo module args from call to cellgridintegrate in multilayer

### DIFF
--- a/src/2d/shallow/multilayer/setaux.f90
+++ b/src/2d/shallow/multilayer/setaux.f90
@@ -150,17 +150,11 @@ subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux)
                         call wrap_coords(x,y,xperm,xper,xperp,yperm,yper, &
                                          yperp,dx,dy)
                         call cellgridintegrate(topo_integral,  &
-                            xperm,xper,xperp,yperm,yper,yperp, &
-                            xlowtopo,ylowtopo,xhitopo,yhitopo,dxtopo,dytopo, &
-                            mxtopo,mytopo,mtopo,i0topo,mtopoorder, &
-                            mtopofiles,mtoposize,topowork)
+                                               xperm,xperp,yperm,yperp)
                     endif
                 else
                     ! Cell does not extend outside of physical domain
-                    call cellgridintegrate(topo_integral,xm,x,xp,ym,y,yp, &
-                            xlowtopo,ylowtopo,xhitopo,yhitopo,dxtopo,dytopo, &
-                            mxtopo,mytopo,mtopo,i0topo,mtopoorder, &
-                            mtopofiles,mtoposize,topowork)
+                    call cellgridintegrate(topo_integral,xm,xp,ym,yp)
                 endif
 
                 ! Correct for geometry


### PR DESCRIPTION
Update src/2d/shallow/multilayer/setaux.f90 to elimate arguments from cellgridintegrate calls.

The same change was made in shallow/setaux.f90 in #579 but missed here.