### PR TITLE
Fix bug related to tracking pressure at gauges

### DIFF
--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -669,11 +669,7 @@ contains
             gauges(i)%level(n) = level
             gauges(i)%data(1,n) = tgrid
             do j = 1, gauges(i)%num_out_vars
-                if (j .eq. pressure_index) then
-                  gauges(i)%data(1 + j, n) = var(j)/ambient_pressure
-                else
-                  gauges(i)%data(1 + j, n) = var(j)
-                endif
+                gauges(i)%data(1 + j, n) = var(j)
             end do
             
             gauges(i)%buffer_index = n + 1


### PR DESCRIPTION
This fixes a bug caused by code that was meant to divide the pressure at a gauge by the ambient pressure.  Unfortunately this really never worked and somewhat randomly was dividing other gauge values by the ambient pressure.  This fix removes the division and leaves it up to post-processing to do this if one wants that and therefore fixes the bug.