### PR TITLE
handle 0 radius

### DIFF
--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -643,7 +643,7 @@ contains
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
-                if (r == 0) then
+                if ((mwr / r)**B > 100) then
                     wind = 0
                 else
                     wind = sqrt((mwr / r)**B &
@@ -715,7 +715,7 @@ contains
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
-                if (r == 0) then
+                if ((mwr / r)**B > 100) then
                     wind = 0
                 else
                     wind = sqrt((mwr / r)**B &
@@ -803,7 +803,7 @@ contains
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
-                if (r == 0) then
+                if ((mwr / r)**B > 100) then
                     wind = 0
                 else
                     ! # HOLLAND 2010 WIND SPEED CALCULATION
@@ -1318,7 +1318,7 @@ contains
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
-                if (r == 0) then
+                if ((mwr / r)**B > 100) then
                     wind = 0
                 else
                     ! Speed of wind at this point
@@ -1406,7 +1406,7 @@ contains
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
-                if (r == 0) then
+                if ((mwr / r)**B > 100) then
                     wind = 0
                 else
                     ! Speed of wind at this point

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -259,7 +259,10 @@ contains
         implicit none
 
         real(kind=8), intent(in) :: Pc, r, dp, mwr, B
-        if (r < 1d-16) then
+
+        ! for any situation that could raise an underflow error, we set the
+        ! second term to 0
+        if ((mwr / r)**B > 100) then
             pres = Pc
         else
             pres = Pc + dp * exp(-(mwr / r)**B)

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -259,7 +259,7 @@ contains
         implicit none
 
         real(kind=8), intent(in) :: Pc, r, dp, mwr, B
-        if (r == 0) then
+        if (r < 1d-16) then
             pres = Pc
         else
             pres = Pc + dp * exp(-(mwr / r)**B)

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -252,6 +252,22 @@ contains
     end function storm_direction
 
     ! ==========================================================================
+    ! set_pressure
+    !   Set pressure at a radius r
+    ! ==========================================================================
+    pure real(kind=8) function set_pressure(Pc, r, dp, mwr, r, B) result(pres)
+        implicit none
+
+        real(kind=8), intent(in) :: Pc, r, dp, mwr, r, B
+        if (r == 0) then
+            pres = Pc
+        else
+            pres = Pc + dp * exp(-(mwr / r)**B)
+        endif
+
+    end function set_pressure
+
+    ! ==========================================================================
     !  storm_index(t,storm)
     !    Finds the index of the next storm data point
     ! ==========================================================================
@@ -620,12 +636,17 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
-                ! Speed of wind at this point
-                wind = sqrt((mwr / r)**B &
+                ! Set speed of wind at this point, handling case of grid cell centroid
+                ! at eye of storm
+                if (r == 0) then
+                    wind = 0
+                else
+                    wind = sqrt((mwr / r)**B &
                         * exp(1.d0 - (mwr / r)**B) * mod_mws**2.d0 &
                         + (r * f)**2.d0 / 4.d0) - r * f / 2.d0
+                endif
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
@@ -687,12 +708,17 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
-                ! Speed of wind at this point
-                wind = sqrt((mwr / r)**B &
+                ! Set speed of wind at this point, handling case of grid cell centroid
+                ! at eye of storm
+                if (r == 0) then
+                    wind = 0
+                else
+                    wind = sqrt((mwr / r)**B &
                         * exp(1.d0 - (mwr / r)**B) * mod_mws**2.d0 &
                         + (r * f)**2.d0 / 4.d0) - r * f / 2.d0
+                endif
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
@@ -770,15 +796,21 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
-                ! # HOLLAND 2010 WIND SPEED CALCULATION
-                if (r <= mwr) then
-                    xx = 0.5
+                ! Set speed of wind at this point, handling case of grid cell centroid
+                ! at eye of storm
+                if (r == 0) then
+                    wind = 0
                 else
-                    xx = 0.5 + (r - mwr) * (xn - 0.5) / (rn - mwr)
+                    ! # HOLLAND 2010 WIND SPEED CALCULATION
+                    if (r <= mwr) then
+                        xx = 0.5
+                    else
+                        xx = 0.5 + (r - mwr) * (xn - 0.5) / (rn - mwr)
+                    endif
+                    wind = mod_mws * ((mwr / r)**B * exp(1.d0 - (mwr / r)**B))**xx
                 endif
-                wind = mod_mws * ((mwr / r)**B * exp(1.d0 - (mwr / r)**B))**xx
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
                     wind_index, pressure_index, r, radius, tv, mod_mws, theta, &
@@ -1205,7 +1237,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
                 ! Speed of wind at this point
                 ! Note that in reality SLOSH does not directly input mws but instead
@@ -1279,13 +1311,19 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
-                ! Speed of wind at this point
-                if (r < mwr) then
-                    wind = mws * (r / mwr)
+                ! Set speed of wind at this point, handling case of grid cell centroid
+                ! at eye of storm
+                if (r == 0) then
+                    wind = 0
                 else
-                    wind = mws * (mwr / r)
+                    ! Speed of wind at this point
+                    if (r < mwr) then
+                        wind = mws * (r / mwr)
+                    else
+                        wind = mws * (mwr / r)
+                    endif
                 endif
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
@@ -1361,13 +1399,19 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
-                ! Speed of wind at this point
-                if (r < mwr) then
-                    wind = mws * (r / mwr)
+                ! Set speed of wind at this point, handling case of grid cell centroid
+                ! at eye of storm
+                if (r == 0) then
+                    wind = 0
                 else
-                    wind = mws * (mwr / r)**alpha
+                    ! Speed of wind at this point
+                    if (r < mwr) then
+                        wind = mws * (r / mwr)
+                    else
+                        wind = mws * (mwr / r)**alpha
+                    endif
                 endif
 
                 call post_process_wind_estimate(maux, mbc, mx, my, i, j, wind, aux, &
@@ -1433,7 +1477,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
                 ! Speed of wind at this point
                 ! Commented out version has 2 more free parameters that we would need
@@ -1516,7 +1560,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = Pc + dp * exp(-(mwr / r)**B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
 
                 ! Speed of wind at this point
                 ! (.9 and 1.1 are chosen as R1 and R2 rather than fit )

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -255,7 +255,7 @@ contains
     ! set_pressure
     !   Set pressure at a radius r
     ! ==========================================================================
-    pure real(kind=8) function set_pressure(Pc, r, dp, mwr, r, B) result(pres)
+    real(kind=8) pure function set_pressure(Pc, r, dp, mwr, r, B) result(pres)
         implicit none
 
         real(kind=8), intent(in) :: Pc, r, dp, mwr, r, B

--- a/src/2d/shallow/surge/model_storm_module.f90
+++ b/src/2d/shallow/surge/model_storm_module.f90
@@ -255,10 +255,10 @@ contains
     ! set_pressure
     !   Set pressure at a radius r
     ! ==========================================================================
-    real(kind=8) pure function set_pressure(Pc, r, dp, mwr, r, B) result(pres)
+    real(kind=8) pure function set_pressure(Pc, r, dp, mwr, B) result(pres)
         implicit none
 
-        real(kind=8), intent(in) :: Pc, r, dp, mwr, r, B
+        real(kind=8), intent(in) :: Pc, r, dp, mwr, B
         if (r == 0) then
             pres = Pc
         else
@@ -636,7 +636,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
@@ -708,7 +708,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
@@ -796,7 +796,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
@@ -1237,7 +1237,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Speed of wind at this point
                 ! Note that in reality SLOSH does not directly input mws but instead
@@ -1311,7 +1311,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
@@ -1399,7 +1399,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Set speed of wind at this point, handling case of grid cell centroid
                 ! at eye of storm
@@ -1477,7 +1477,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Speed of wind at this point
                 ! Commented out version has 2 more free parameters that we would need
@@ -1560,7 +1560,7 @@ contains
                 call calculate_polar_coordinate(x, y, sloc, r, theta)
 
                 ! Set pressure field
-                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, r, B)
+                aux(pressure_index,i,j) = set_pressure(Pc, r, dp, mwr, B)
 
                 ! Speed of wind at this point
                 ! (.9 and 1.1 are chosen as R1 and R2 rather than fit )


### PR DESCRIPTION
This addresses an issue in the edge case where `r`, the distance of the grid cell centroid to the storm eye, is 0. Previously this would result in either floating point errors or nan's in the `q` array, depending on the compile flags.

[Google group discussion](https://groups.google.com/g/claw-users/c/BPAfEZZTrMI/m/8oE1idBdBgAJ)