### PR TITLE
Gauge filenames

### DIFF
--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -207,18 +207,12 @@ contains
             end do
 
             ! Create gauge output files
-            ! with format gauge00012.txt or gauge1234567.txt
             do i = 1, num_gauges
                 num = gauges(i)%gauge_num
-                ! convert num to string numstr:
-                if (num > 100000) then
-                    ! > 5 digits,  no padding
-                    write (numstr,'(I0)') num
-                else
-                    ! <= 5 digits, add zero padding
-                    write (numstr,'(I5.5)') num
-                endif
 
+                ! convert num to string numstr with zero padding if <5 digits
+                ! since we want format gauge00012.txt or gauge1234567.txt:
+                write (numstr,'(I0.5)') num
                 gauges(i)%file_name = 'gauge'//trim(numstr)//'.txt'
 
                 if (gauges(i)%file_format >= 2) then

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -58,8 +58,8 @@ module gauges_module
         integer :: gauge_num
         integer :: gdata_bytes
 
-        character(len=14) :: file_name      ! for header (and data if 'ascii')
-        character(len=14) :: file_name_bin  ! used if file_format='binary'
+        character(len=24) :: file_name      ! for header (and data if 'ascii')
+        character(len=24) :: file_name_bin  ! used if file_format='binary'
 
         ! Location in time and space
         real(kind=8) :: x, y, t_start, t_end
@@ -116,6 +116,7 @@ contains
         integer, parameter :: UNIT = 7
         character(len=128) :: header_1
         character(len=40) :: q_column, aux_column
+        character(len=15) :: numstr
 
         if (.not.module_setup) then
 
@@ -206,18 +207,22 @@ contains
             end do
 
             ! Create gauge output files
+            ! with format gauge00012.txt or gauge1234567.txt
             do i = 1, num_gauges
-                gauges(i)%file_name = 'gaugexxxxx.txt'  ! ascii
                 num = gauges(i)%gauge_num
-                do pos = 10, 6, -1
-                    digit = mod(num,10)
-                    gauges(i)%file_name(pos:pos) = char(ichar('0') + digit)
-                    num = num / 10
-                end do
+                ! convert num to string numstr:
+                if (num > 100000) then
+                    ! > 5 digits,  no padding
+                    write (numstr,'(I0)') num
+                else
+                    ! <= 5 digits, add zero padding
+                    write (numstr,'(I5.5)') num
+                endif
+
+                gauges(i)%file_name = 'gauge'//trim(numstr)//'.txt'
 
                 if (gauges(i)%file_format >= 2) then
-                    gauges(i)%file_name_bin = gauges(i)%file_name
-                    gauges(i)%file_name_bin(12:14) = 'bin'
+                    gauges(i)%file_name_bin = 'gauge'//trim(numstr)//'.bin'
                 endif
 
 
@@ -243,7 +248,7 @@ contains
 
                 if (.not. restart) then
                     ! Write header to .txt file:
-                    header_1 = "('# gauge_id= ',i5,' " //                 &
+                    header_1 = "('# gauge_id= ',i0,' " //                 &
                                "location=( ',1e17.10,' ',1e17.10,' ) " // &
                                "num_var= ',i2)"
                     write(OUTGAUGEUNIT, header_1) gauges(i)%gauge_num,    &


### PR DESCRIPTION
This addresses https://github.com/clawpack/geoclaw/issues/541, creating filenames in the same format as previously if the gauge number has 5 or fewer digits, e.g. `gauge00012.txt`, but allows up to 15 digits, e.g. `gauge123456789.txt`.

If this seems ok, I'll do the same thing in amrclaw.

Note that gauges are still read in fine for plotting regardless of the number of digits, with no changes needed in `pyclaw.gauges.GaugeSolution`.

Note that this is implemented via these two lines (where `numstr` is a character variable):

```
write (numstr,'(I0.5)') num
gauges(i)%file_name = 'gauge'//trim(numstr)//'.txt'
```

This is a much cleaner way to do it than the old way of starting with `gaugexxxxx.txt` and changing one character at a time!

We should eventually make this change also in creating filenames like `fort.t0001`, in `valout.f90`, both for cleaner code and greater flexibility if the user needs more digits than we originally planned for.
