### PR TITLE
improvements to fgout_module for t arrays and D-Claw

### DIFF
--- a/src/2d/shallow/fgout_module.f90
+++ b/src/2d/shallow/fgout_module.f90
@@ -8,18 +8,18 @@ module fgout_module
         ! Grid data
         real(kind=8), pointer :: early(:,:,:)
         real(kind=8), pointer :: late(:,:,:)
-        
+
         ! Geometry
         integer :: num_vars(2),mx,my,point_style,fgno,output_format,output_style
         real(kind=8) :: dx,dy,x_low,x_hi,y_low,y_hi
-        
+
         ! Time Tracking and output types
         integer :: num_output,next_output_index
         real(kind=8) :: start_time,end_time,dt
 
         integer, allocatable :: output_frames(:)
         real(kind=8), allocatable :: output_times(:)
-    end type fgout_grid    
+    end type fgout_grid
 
 
     logical, private :: module_setup = .false.
@@ -32,27 +32,27 @@ module fgout_module
 
 
 contains
-                        
-    
+
+
     ! Setup routine that reads in the fixed grids data file and sets up the
     ! appropriate data structures
-    
+
     subroutine set_fgout(rest,fname)
 
         use amr_module, only: parmunit, tstart_thisrun
 
         implicit none
-        
+
         ! Subroutine arguments
         logical :: rest  ! restart?
         character(len=*), optional, intent(in) :: fname
-        
+
         ! Local storage
         integer, parameter :: unit = 7
         integer :: i,k
         type(fgout_grid), pointer :: fg
         real(kind=8) :: ts
-        
+
 
         if (.not.module_setup) then
 
@@ -75,7 +75,7 @@ contains
                 write(parmunit,*) '  No fixed grids specified for output'
                 return
             endif
-            
+
             ! Allocate fixed grids (not the data yet though)
             allocate(FGOUT_fgrids(FGOUT_num_grids))
 
@@ -97,28 +97,28 @@ contains
                     fg%start_time = fg%output_times(1)
                     fg%end_time = fg%output_times(fg%num_output)
                 endif
-                
+
                 read(unit,*) fg%point_style
                 read(unit,*) fg%output_format
                 read(unit,*) fg%mx, fg%my
                 read(unit,*) fg%x_low, fg%y_low
                 read(unit,*) fg%x_hi, fg%y_hi
-                
-            
+
+
                 ! Initialize next_output_index
                 ! (might be reset below in case of a restart)
                 fg%next_output_index = 1
-                   
+
                 if (fg%point_style .ne. 2) then
                     print *, 'set_fgout: ERROR, unrecognized point_style = ',\
                           fg%point_style
                 endif
-                
-               if (fg%output_style == 1) then    
+
+               if (fg%output_style == 1) then
                    ! Setup data for this grid
                    ! Set fg%dt (the timestep length between outputs)
                    if (fg%end_time <= fg%start_time) then
-                       if (fg%num_output > 1) then 
+                       if (fg%num_output > 1) then
                           print *,'set_fgout: ERROR for fixed grid', i
                           print *,'start_time <= end_time yet num_output > 1'
                           print *,'set end_time > start_time or set num_output = 1'
@@ -142,7 +142,7 @@ contains
                        endif
                     endif
                 endif
-                       
+
                do k=1,fg%num_output
                    if (rest) then
                        ! don't write initial time or earlier
@@ -151,7 +151,7 @@ contains
                        ! do write initial time
                        ts = tstart_thisrun-FGOUT_ttol
                    endif
-                       
+
                    if (fg%output_times(k) < ts) then
                         ! will not output this time in this run
                         ! (might have already be done when restarting)
@@ -184,30 +184,30 @@ contains
                 else
                     print *,'set_fgout: ERROR for fixed grid', i
                     print *,'y grid points my <= 0, set my >= 1'
-                endif 
-           
+                endif
+
                 ! set the number of variables stored for each grid
                 ! this should be (the number of variables you want to write out + 1)
                 fg%num_vars(1) = 6
-                
+
                 ! Allocate new fixed grid data array
                 allocate(fg%early(fg%num_vars(1), fg%mx,fg%my))
                 fg%early = nan()
-                
+
                 allocate(fg%late(fg%num_vars(1), fg%mx,fg%my))
                 fg%late = nan()
-                
+
            enddo
            close(unit)
-           
+
            FGOUT_tcfmax=-1.d16
 
            module_setup = .true.
         end if
 
     end subroutine set_fgout
-    
-    
+
+
     !=====================FGOUT_INTERP=======================================
     ! This routine interpolates q and aux on a computational grid
     ! to an fgout grid not necessarily aligned with the computational grid
@@ -216,10 +216,10 @@ contains
     subroutine fgout_interp(fgrid_type,fgrid, &
                             t,q,meqn,mxc,myc,mbc,dxc,dyc,xlowc,ylowc, &
                             maux,aux)
-    
-        use geoclaw_module, only: dry_tolerance  
+
+        use geoclaw_module, only: dry_tolerance
         implicit none
-    
+
         ! Subroutine arguments
         integer, intent(in) :: fgrid_type
         type(fgout_grid), intent(inout) :: fgrid
@@ -227,9 +227,9 @@ contains
         real(kind=8), intent(in) :: t,dxc,dyc,xlowc,ylowc
         real(kind=8), intent(in) :: q(meqn,1-mbc:mxc+mbc,1-mbc:myc+mbc)
         real(kind=8), intent(in) :: aux(maux,1-mbc:mxc+mbc,1-mbc:myc+mbc)
-    
+
         integer, parameter :: method = 0 ! interpolate in space?
-        
+
         ! Indices
         integer :: ifg,jfg,m,ic1,ic2,jc1,jc2
         integer :: bathy_index,eta_index
@@ -240,18 +240,18 @@ contains
         ! Geometry
         real(kind=8) :: xfg,yfg,xc1,xc2,yc1,yc2,xhic,yhic
         real(kind=8) :: geometry(4)
-        
+
         real(kind=8) :: points(2,2), eta_tmp
-        
+
         ! Work arrays for eta interpolation
         real(kind=8) :: eta(2,2),h(2,2)
-        
-        
+
+
         ! Alias to data in fixed grid
         integer :: num_vars
         real(kind=8), pointer :: fg_data(:,:,:)
-        
-        
+
+
         ! Setup aliases for specific fixed grid
         if (fgrid_type == 1) then
             num_vars = fgrid%num_vars(1)
@@ -264,103 +264,103 @@ contains
             stop
             ! fgrid_type==3 is deprecated, use fgmax grids instead
         endif
-            
-        xhic = xlowc + dxc*mxc  
-        yhic = ylowc + dyc*myc    
-        
+
+        xhic = xlowc + dxc*mxc
+        yhic = ylowc + dyc*myc
+
         ! Find indices of various quantities in the fgrid arrays
-        bathy_index = 4   ! works for both shallow and bouss 
+        bathy_index = 4   ! works for both shallow and bouss
         eta_index = 5     ! works for both shallow and bouss
-    
+
         !write(59,*) '+++ ifg,jfg,eta,geometry at t = ',t
-    
-        ! Primary interpolation loops 
+
+        ! Primary interpolation loops
         do ifg=1,fgrid%mx
             xfg=fgrid%x_low + (ifg-0.5d0)*fgrid%dx   ! cell centers
             do jfg=1,fgrid%my
                 yfg=fgrid%y_low + (jfg-0.5d0)*fgrid%dy   ! cell centers
-    
+
                 ! Check to see if this coordinate is inside of this grid
                 if (.not.((xfg < xlowc.or.xfg > xhic) &
                     .or.(yfg < ylowc.or.yfg > yhic))) then
-    
-                    ! find where xfg,yfg is in the computational grid and 
+
+                    ! find where xfg,yfg is in the computational grid and
                     ! compute the indices
                     !   (Note: may be subject to rounding error if fgout point
                     !    is right on a cell edge!)
                     ic1 = int((xfg - xlowc + dxc)/dxc)
                     jc1 = int((yfg - ylowc + dyc)/dyc)
-                    
+
                     if (method == 0) then
-                    
+
                         ! piecewise constant: take values from cell (ic1,jc1):
-                        
+
                         forall (m=1:meqn)
                             fg_data(m,ifg,jfg) = q(m,ic1,jc1)
                         end forall
-                        
+
                         fg_data(bathy_index,ifg,jfg) = aux(1,ic1,jc1)
-                        
+
                         ! for pw constant we take B, h, eta from same cell,
                         ! so setting eta = h+B should be fine even near shore:
                         fg_data(eta_index,ifg,jfg) = fg_data(1,ifg,jfg) &
                                 + fg_data(bathy_index,ifg,jfg)
-                        
-         
+
+
                     else if (method == 1) then
-                    
+
                         ! bilinear used to interpolate to xfg,yfg
                         ! (not recommended)
-                        
+
                         ! define constant parts of bilinear
                         if (ic1.eq.mxc) ic1=mxc-1
-                        if (jc1.eq.myc) jc1=myc-1 
+                        if (jc1.eq.myc) jc1=myc-1
                         ic2 = ic1 + 1
                         jc2 = jc1 + 1
-                            
+
                         xc1 = xlowc + dxc * (ic1 - 0.5d0)
                         yc1 = ylowc + dyc * (jc1 - 0.5d0)
                         xc2 = xlowc + dxc * (ic2 - 0.5d0)
                         yc2 = ylowc + dyc * (jc2 - 0.5d0)
-                    
+
                         geometry = [(xfg - xc1) / dxc, &
                                     (yfg - yc1) / dyc, &
                                     (xfg - xc1) * (yfg - yc1) / (dxc*dyc), &
                                     1.d0]
-                    
-        
+
+
                         ! Interpolate all conserved quantities and bathymetry
                         forall (m=1:meqn)
                             fg_data(m,ifg,jfg) = &
-                                interpolate(q(m,ic1:ic2,jc1:jc2), geometry) 
+                                interpolate(q(m,ic1:ic2,jc1:jc2), geometry)
                         end forall
 
-                        fg_data(bathy_index,ifg,jfg) = & 
+                        fg_data(bathy_index,ifg,jfg) = &
                                 interpolate(aux(1,ic1:ic2,jc1:jc2),geometry)
 
-                        
+
                         ! surface eta = h + B:
-                        
+
                         ! Note that for pw bilinear interp there may
                         ! be a problem interpolating each separately since
                         ! interpolated h + interpolated B may be much larger
                         ! than eta should be offshore.
                         eta = q(1,ic1:ic2,jc1:jc2) + aux(1,ic1:ic2,jc1:jc2)
                         fg_data(eta_index,ifg,jfg) = interpolate(eta,geometry)
-                        ! NEED TO FIX                        
+                        ! NEED TO FIX
                     endif
-                                                        
-                    
+
+
                     ! save the time this fgout point was computed:
                     fg_data(num_vars,ifg,jfg) = t
-                    
-                    
+
+
                 endif ! if fgout point is on this grid
             enddo ! fgout y-coordinate loop
         enddo ! fgout x-coordinte loop
-    
+
     end subroutine fgout_interp
-    
+
 
     !================ fgout_write ==========================================
     ! This routine interpolates in time and then outputs a grid at
@@ -372,12 +372,12 @@ contains
 
         use geoclaw_module, only: dry_tolerance
         implicit none
-        
+
         ! Subroutine arguments
         type(fgout_grid), intent(inout) :: fgrid
         real(kind=8), intent(in) :: out_time
         integer, intent(in) :: out_index
-              
+
         ! I/O
         integer, parameter :: unit = 87
         character(len=15) :: fg_filename
@@ -385,14 +385,14 @@ contains
         character(len=8) :: file_format
         integer :: grid_number,ipos,idigit,out_number,columns
         integer :: ifg,ifg1, iframe,iframe1
-        
+
         integer, parameter :: method = 0  ! interpolate in time?
-        
-        ! Output format strings 
+
+        ! Output format strings
         ! These are now the same as in outval for frame data, for compatibility
         ! For fgout grids there is only a single grid (ngrids=1)
         ! and we set AMR_level=0, naux=0, nghost=0 (so no extra cells in binary)
-        
+
         character(len=*), parameter :: header_format =                         &
                                     "(i6,'                 grid_number',/," // &
                                      "i6,'                 AMR_level',/,"   // &
@@ -402,7 +402,7 @@ contains
                                      "e26.16,'    ylow', /,"                // &
                                      "e26.16,'    dx', /,"                  // &
                                      "e26.16,'    dy',/)"
-                                     
+
         character(len=*), parameter :: t_file_format = "(e18.8,'    time', /," // &
                                            "i6,'                 meqn'/,"   // &
                                            "i6,'                 ngrids'/," // &
@@ -410,64 +410,64 @@ contains
                                            "i6,'                 ndim'/,"   // &
                                            "i6,'                 nghost'/," // &
                                            "a10,'             format'/,/)"
-        
+
         ! Other locals
         integer :: i,j,m
         real(kind=8) :: t0,tf,tau, qaug(6)
         real(kind=8), allocatable :: qeta(:,:,:)
         real(kind=4), allocatable :: qeta4(:,:,:)
         real(kind=8) :: h_early,h_late,topo_early,topo_late
-        
+
         allocate(qeta(4, fgrid%mx, fgrid%my))  ! to store h,hu,hv,eta
-        
-        
-        ! Interpolate the grid in time, to the output time, using 
-        ! the solution in fgrid1 and fgrid2, which represent the 
+
+
+        ! Interpolate the grid in time, to the output time, using
+        ! the solution in fgrid1 and fgrid2, which represent the
         ! solution on the fixed grid at the two nearest computational times
         do j=1,fgrid%my
             do i=1,fgrid%mx
-                
+
                 ! Check for small numbers
                 forall(m=1:fgrid%num_vars(1)-1,abs(fgrid%early(m,i,j)) < 1d-90)
                     fgrid%early(m,i,j) = 0.d0
                 end forall
 
                 if (method == 0) then
-                
+
                     ! no interpolation in time, use solution from full step:
                     qaug = fgrid%early(:,i,j)
-                    
+
                     ! note that CFL condition ==> waves can't move more than 1
                     ! cell per time step on each level, so solution from nearest
                     ! full step should be correct to within a cell width
                     ! Better to use early than late since for refinement tracking
                     ! wave moving out into still water.
-                
+
                 else if (method == 1) then
-                
+
                     ! interpolate in time. May have problems near shore?
-                    
-                    ! Fetch times for interpolation, this is done per grid point 
+
+                    ! Fetch times for interpolation, this is done per grid point
                     ! since each grid point may come from a different source
                     t0 = fgrid%early(fgrid%num_vars(1),i,j)
                     tf = fgrid%late(fgrid%num_vars(1),i,j)
                     tau = (out_time - t0) / (tf - t0)
-                    
+
                     ! check for small values:
                     forall(m=1:fgrid%num_vars(1)-1,abs(fgrid%late(m,i,j)) < 1d-90)
                         fgrid%late(m,i,j) = 0.d0
                     end forall
-                    
+
                     ! linear interpolation:
                     qaug = (1.d0-tau)*fgrid%early(:,i,j) + tau*fgrid%late(:,i,j)
-                    
+
                     ! If resolution changed between early and late time, may be
                     ! problems near shore when interpolating B, h, eta
                     ! separately (at least in case when B changed and point
                     ! was dry at one time and wet the other).
                     ! Switch back to fgrid%early values, only in this case.
                     ! This is implemented below but not extensively tested.
-                    
+
                     if (qaug(1) > 0.d0) then
                         topo_early = fgrid%early(4,i,j)
                         topo_late = fgrid%late(4,i,j)
@@ -485,13 +485,13 @@ contains
                         endif
                     endif
                 endif
-                
+
                 ! Output the conserved quantities and eta value
                 qeta(1,i,j) = qaug(1)  ! h
                 qeta(2,i,j) = qaug(2)  ! hu
                 qeta(3,i,j) = qaug(3)  ! hv
                 qeta(4,i,j) = qaug(5)  ! eta
-                
+
             enddo
         enddo
 
@@ -514,8 +514,8 @@ contains
             cframeno(ipos:ipos) = char(ichar('0') + idigit)
             iframe1 = iframe1/10
             enddo
-            
-        fg_filename = 'fgout' // cfgno // '.q' // cframeno 
+
+        fg_filename = 'fgout' // cfgno // '.q' // cframeno
 
         open(unit,file=fg_filename,status='unknown',form='formatted')
 
@@ -524,17 +524,17 @@ contains
         if (fgrid%num_vars(2) > 1) then
            columns = columns + 2
         endif
-        
+
         !write(6,*) '+++ fgout out_time = ',out_time
         !write(6,*) '+++ fgrid%num_vars: ',fgrid%num_vars(1),fgrid%num_vars(2)
-        
+
         ! Write out header in .q file:
         !write(unit,header_format) out_time,fgrid%mx,fgrid%my, &
         !     fgrid%x_low,fgrid%y_low, fgrid%x_hi,fgrid%y_hi, columns
 
         write(unit,header_format) fgrid%fgno, 0, fgrid%mx,fgrid%my, &
             fgrid%x_low,fgrid%y_low, fgrid%dx, fgrid%dy
-            
+
         if (fgrid%output_format == 1) then
             ! ascii output added to .q file:
             do j=1,fgrid%my
@@ -544,20 +544,20 @@ contains
                 enddo
                 write(unit,*) ' '  ! blank line required between rows
             enddo
-        endif  
-        
+        endif
+
         close(unit)
-        
+
         if (fgrid%output_format == 3) then
             ! binary output goes in .b file as full 8-byte (float64):
-            fg_filename = 'fgout' // cfgno // '.b' // cframeno 
+            fg_filename = 'fgout' // cfgno // '.b' // cframeno
             open(unit=unit, file=fg_filename, status="unknown",    &
                  access='stream')
             write(unit) qeta
             close(unit)
         else if (fgrid%output_format == 2) then
             ! binary output goes in .b file as 4-byte (float32):
-            fg_filename = 'fgout' // cfgno // '.b' // cframeno 
+            fg_filename = 'fgout' // cfgno // '.b' // cframeno
             open(unit=unit, file=fg_filename, status="unknown",    &
                  access='stream')
             allocate(qeta4(4, fgrid%mx, fgrid%my))  ! for 4-byte binary output
@@ -566,44 +566,44 @@ contains
             deallocate(qeta4)
             close(unit)
         endif
-        
+
         deallocate(qeta)
 
         ! time info .t file:
 
-        
+
         if (fgrid%output_format == 1) then
             file_format = 'ascii'
         else if (fgrid%output_format == 2) then
             file_format = 'binary32'
         else if (fgrid%output_format == 3) then
             file_format = 'binary64'
-        else 
+        else
             write(6,*) '*** unrecognized fgrid%output_format = ', &
                         fgrid%output_format
             write(6,*) '*** should be ascii, binary32, or binary64'
         endif
-    
-        fg_filename = 'fgout' // cfgno // '.t' // cframeno 
+
+        fg_filename = 'fgout' // cfgno // '.t' // cframeno
         open(unit=unit, file=fg_filename, status='unknown', form='formatted')
         ! time, num_eqn+1, num_grids, num_aux, num_dim, num_ghost:
         write(unit, t_file_format) out_time, 4, 1, 0, 2, 0, file_format
         close(unit)
-        
+
         print "(a,i4,a,i4,a,e18.8)",'Writing fgout grid #',fgrid%fgno, &
               '  frame ',out_index,' at time =',out_time
-      
+
         ! Index into qeta for binary output
         ! Note that this implicitly assumes that we are outputting only h, hu, hv
         ! and will not output more (change num_eqn parameter above)
-        
+
     end subroutine fgout_write
-              
-    
+
+
     ! =========================================================================
     ! Utility functions for this module
     ! Returns back a NaN
-    
+
     real(kind=8) function nan()
         real(kind=8) dnan
         integer inan(2)
@@ -612,21 +612,21 @@ contains
         inan(2)=2147483647
         nan=dnan
     end function nan
-    
+
     ! Interpolation function (in space)
     ! Given 4 points (points) and geometry from x,y,and cross terms
-    
+
     real(kind=8) pure function interpolate(points,geometry) result(interpolant)
-                            
+
         implicit none
-                                
+
         ! Function signature
         real(kind=8), intent(in) :: points(2,2)
         real(kind=8), intent(in) :: geometry(4)
         integer :: icell, jcell
-        
+
         ! pw bilinear
-        ! This is set up as a dot product between the approrpriate terms in 
+        ! This is set up as a dot product between the approrpriate terms in
         ! the input data.  This routine could be vectorized or a BLAS routine
         ! used instead of the intrinsics to ensure that the fastest routine
         ! possible is being used
@@ -634,8 +634,8 @@ contains
                        points(1,2)-points(1,1), &
                        points(1,1) + points(2,2) - (points(2,1) + points(1,2)), &
                        points(1,1)] * geometry)
-                       
+
     end function interpolate
-    
+
 
 end module fgout_module

--- a/src/python/geoclaw/fgout_tools.py
+++ b/src/python/geoclaw/fgout_tools.py
@@ -178,6 +178,7 @@ class FGoutGrid(object):
         self.npts = None
         self.nx = None
         self.ny = None
+        self.output_style = 1
         self.tstart =  None
         self.tend = None
         self.nout = None
@@ -372,18 +373,33 @@ class FGoutGrid(object):
             errmsg = "fgout output_format must be ascii, binary32, or binary64"
             raise NotImplementedError(errmsg)
 
-        assert self.tstart is not None, 'Need to set tstart'
-        assert self.tend is not None, 'Need to set tend'
-        assert self.nout is not None, 'Need to set nout'
-        assert self.point_style is not None, 'Need to set point_style'
+
         
         # write header, independent of point_style:
         #fid = open(self.input_file_name,'w')
         fid.write("\n")
         fid.write("%i                           # fgno\n" % self.fgno)
-        fid.write("%16.10e            # tstart\n"  % self.tstart)
-        fid.write("%16.10e            # tend\n"  % self.tend)
-        fid.write("%i %s           # nout\n" % (self.nout, 11*" "))
+
+        fid.write("%i                           # output_style\n" \
+                    % self.output_style)
+        
+        if self.output_style == 1:
+            assert self.tstart is not None, 'Need to set tstart'
+            assert self.tend is not None, 'Need to set tend'
+            assert self.nout is not None, 'Need to set nout'
+            fid.write("%i %s           # nout\n" % (self.nout, 11*" "))
+            fid.write("%16.10e            # tstart\n"  % self.tstart)
+            fid.write("%16.10e            # tend\n"  % self.tend)
+        elif self.output_style == 2:
+            self.nout = len(self.output_times)
+            fid.write("%i %s           # nout\n" % (self.nout, 11*" "))
+            
+            # remove [] and , from list of times:
+            output_times_str = repr(list(self.output_times))[1:-1]
+            output_times_str = output_times_str.replace(',','')
+            fid.write("%s            # output_times\n"  % output_times_str)
+        else:
+            raise ValueError('fgout output_style must be 1 or 2')
         fid.write("%i %s              # point_style\n" \
                             % (self.point_style,12*" "))
         fid.write("%i %s              # output_format\n" \

--- a/src/python/geoclaw/fgout_tools.py
+++ b/src/python/geoclaw/fgout_tools.py
@@ -185,6 +185,7 @@ class FGoutGrid(object):
         self.fgno = fgno
         self.outdir = outdir
         self.output_format = output_format
+        self.dclaw = False
         
         self.drytol = 1e-3          # used for computing u,v from hu,hv
 
@@ -430,6 +431,7 @@ class FGoutGrid(object):
             print("   upper right = (%15.10f,%15.10f)" % (x2,y2))
             print("   dx = %15.10e,  dy = %15.10e" % (dx,dy))
             
+            fid.write("%s                     # dclaw" % self.dclaw)
 
 
     def read_frame(self, frameno):


### PR DESCRIPTION
Allow specifying `fgout.output_times` as a general list or array of times rather than equally spaced, if you set `fgout.output_style = 2`.  The default is `fgout.output_style = 1` that takes the previous input. Changes to `fgout_tools.py` allow specifying these values in `setrun.py`.

Then we also made this more general so that it could handle D-Claw output as well as GeoClaw, with a new attribute `fgout.dclaw` that is `False` by default, but setting this to `True` outputs 7 components of `q` instead of only 3 (plus `eta` in both cases).

I plan to also modify this so that you can specify fewer components rather than all of them. 

Also cleaned up a bunch of trailing white space.