### PR TITLE
Add Plotting Capabilities to Storm Object

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -414,7 +414,7 @@ class Topography(object):
 
 
     def __init__(self, path=None, topo_type=None, topo_func=None, 
-                       unstructured=False):
+                       unstructured=False, **kwargs):
         r"""Topography initialization routine.
         
         See :class:`Topography` for more info.
@@ -444,7 +444,7 @@ class Topography(object):
 
         if path:
             self.read(path=path, topo_type=topo_type,
-                      unstructured=unstructured)
+                      unstructured=unstructured, **kwargs)
 
     def set_xyZ(self, X, Y, Z):
         r"""


### PR DESCRIPTION
Add a `plot` function to the `Storm` object that can
1. plot the track and time points of the storm,
2. plot a swath of the storm that is a given radius from the track,
3. and plot the category of the storm.

All of these have some options about how it determines what and how to plot.  There are also some examples that have now been added to [surge examples](https://github.com/mandli/surge-examples/tree/master/synthetic/boundary), especially as a means for looking at boundary conditions.