### PR TITLE
Fix src/bouss/amr2.f90 call to set_fgout, adding nvar

### DIFF
--- a/examples/bouss/README.txt
+++ b/examples/bouss/README.txt
@@ -1,4 +1,6 @@
 
+GeoClaw Boussinesq solver examples
+
 The radial_flat subdirectory contains one example using the Boussinesq
 solver introduced in Clawpack v5.10.0.
 
@@ -14,8 +16,12 @@ OpenMP along with MPI.  Some flags have to be set as environment variables
 or directly in the application Makefile, e.g. see the lines commented out in
 radial_flat/Makefile.
 
+The file setenv.sh illustrates how you might set some environment
+variables for the bash shell.
+
 A file petscMPIoptions is also required to set some PETSc parameters for the
 iterative method used to solve the large sparse linear systems that arise at 
 each refinement level when the Boussinesq equations are solved. 
 One of the environment variables mentioned above points to this file, and a
 sample is included in this directory.
+

--- a/examples/bouss/radial_flat/README.rst
+++ b/examples/bouss/radial_flat/README.rst
@@ -8,6 +8,15 @@ A Gaussian hump of water at the origin spreads out over a flat bottom,
 as specified by the topo file `flat100.txt` (uniform water depth 100 m).
 The equations are solved in Cartesian coordinates with the SGN equations.
 
+Running the GeoClaw Boussinesq solvers requires PETSc and MPI.
+For more details see the documentation
+  https://www.clawpack.org/bouss2d.html
+and
+  $CLAW/geoclaw/examples/bouss/README.txt
+Run
+  make check
+in this directory to check if things seem ok for running this code.
+
 A flagregion specified by `RuledRectangle_Diagonal.data` (that is created by
 code in `setrun.py` is used to allow flagging for refinement to
 level 2 only near the diagonal (for abs(x-y) < 1000).  The code is set up to

--- a/src/2d/bouss/amr2.f90
+++ b/src/2d/bouss/amr2.f90
@@ -513,7 +513,7 @@ program amr2
         call read_dtopo_settings()        ! specifies file with dtopo from earthquake
         call read_topo_settings(rest)     ! specifies topography (bathymetry) files
         call set_qinit()                  ! specifies file with dh if this used instead
-        call set_fgout(rest)            ! Fixed grid settings
+        call set_fgout(rest,nvar)         ! Fixed grid settings
         call setup_variable_friction()    ! Variable friction parameter
         call set_storm()                  ! Set storm parameters
         call set_regions()                ! Set refinement regions
@@ -548,7 +548,7 @@ program amr2
         call read_topo_settings(rest)     ! specifies topography (bathymetry) files
         call set_qinit()                  ! specifies file with dh if this used instead
 
-        call set_fgout(rest)              ! Fixed grid settings
+        call set_fgout(rest,nvar)         ! Fixed grid settings
         call setup_variable_friction()    ! Variable friction parameter
         call set_multilayer()             ! Set multilayer SWE parameters
         call set_storm()                  ! Set storm parameters


### PR DESCRIPTION
This was modified in the shallow/amr2.f90 code to support more fgout flexibility in #624, and this change is also required in the bouss version.

Also enhanced the examples/bouss README files a bit.