### PR TITLE
Change Time Format of Storm Surge Title

### DIFF
--- a/src/2d/shallow/surge/storm_module.f90
+++ b/src/2d/shallow/surge/storm_module.f90
@@ -162,7 +162,7 @@ contains
                 case(2)
                     rotation => S_rotation
                 case default
-                    stop " *** ERROR *** Roation override invalid."
+                    stop " *** ERROR *** Rotation override invalid."
             end select
             read(unit,*)
 

--- a/src/python/geoclaw/surge/plot.py
+++ b/src/python/geoclaw/surge/plot.py
@@ -428,7 +428,7 @@ def add_pressure(plotaxes, bounds=None, plot_type='pcolor', shrink=1.0):
         pass
 
 
-def add_land(plotaxes, plot_type='pcolor', bounds=None):
+def add_land(plotaxes, plot_type='pcolor', bounds=[0, 50]):
     """Add plotitem for land"""
 
     if plot_type == 'pcolor':
@@ -436,9 +436,8 @@ def add_land(plotaxes, plot_type='pcolor', bounds=None):
         plotitem.show = True
         plotitem.plot_var = geoplot.land
         plotitem.pcolor_cmap = land_cmap
-        if bounds is not None:
-            plotitem.pcolor_cmin = bounds[0]
-            plotitem.pcolor_cmax = bounds[1]
+        plotitem.pcolor_cmin = bounds[0]
+        plotitem.pcolor_cmax = bounds[1]
         plotitem.add_colorbar = False
         plotitem.amr_celledges_show = [0] * 10
         plotitem.amr_patchedges_show = [1, 1, 1, 1, 1, 0, 0]

--- a/src/python/geoclaw/surge/plot.py
+++ b/src/python/geoclaw/surge/plot.py
@@ -122,13 +122,35 @@ def plot_landfall_gauge(gauge, axes, landfall=0.0, style='b', kwargs={}):
 # ========================================================================
 #  Surge related helper functions
 # ========================================================================
-def days_figure_title(current_data, land_fall=0.0):
-    t = (current_data.t - land_fall) / (60**2 * 24)
-    days = int(t)
-    hours = (t - int(t)) * 24.0
+def days_figure_title(cd, land_fall=0.0, new_time=False):
+    r"""Helper function that puts the time relative to landfall in title
 
-    title = current_data.plotaxes.title
-    plt.title('%s at day %3i, hour %2.1f' % (title, days, hours))
+    New version of title is available if *new_time = True*
+    """
+    if new_time:
+        if cd.t < land_fall:
+            sign = "-"
+        else:
+            sign = " "
+        minutes, seconds = divmod(abs(np.round(cd.t - land_fall)), 60)
+        hours, minutes = divmod(minutes, 60)
+        days, hours = divmod(hours, 24)
+        days = int(days)
+        hours = int(hours)
+        minutes = int(minutes)
+        if cd.t < 0:
+            sign = "-"
+        else:
+            sign = " "
+        title = cd.plotaxes.title
+        plt.title(f'{title} at t = {sign}{days:d}, {hours:02d}:{minutes:02d}')
+    else:
+        t = (cd.t - land_fall) / (60**2 * 24)
+        days = int(t)
+        hours = (t - int(t)) * 24.0
+
+        title = cd.plotaxes.title
+        plt.title('%s at day %3i, hour %2.1f' % (title, days, hours))
 
 
 def surge_afteraxes(current_data, track, land_fall=0.0, plot_direction=False,

--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1164,9 +1164,15 @@ class Storm(object):
     # ================
     #  Track Plotting
     # ================
-    def plot(self, ax, radius=None, t_range=None, coordinate_system=2, track_style='ko--',
-             categorization="NHC", fill_alpha=0.25, fill_color='red'):
-        """TO DO:  Write doc-string"""
+    def plot(self, ax, t_range=None, coordinate_system=2, 
+                       track_style='ko--', categorization="NHC", 
+                       radius=None, fill_alpha=0.25, fill_color='red'):
+        """TO DO:  Write doc-string
+
+        Quick notes:
+         - *radius = None* will not plot a swath
+         - *track_style = {}* will plot categories for the track
+         """
 
         import matplotlib.pyplot as plt
 
@@ -1198,17 +1204,15 @@ class Storm(object):
             colors = [track_style.get(category, cat_color_defaults[category])
                       for category in self.category(categorization=categorization)]
             for i in range(t.shape[0] - 1):
-                ax.plot(x[i:i+2], y[i:i+2], color=colors[i], marker="o")
+                ax.plot(x[i:i+2], y[i:i+2], color=colors[i])
 
         else:
             raise ValueError("The `track_style` should be a string or dict.")
 
         # Plot swath
-        if (isinstance(radius, float) or isinstance(radius, np.ndarray)
-                or radius is None):
-
-            if radius is None:
-                # Default behavior
+        if radius is not None:
+            # Any string as of right now will trigger this
+            if isinstance(radius, str):
                 if self.storm_radius is None:
                     raise ValueError("Cannot use storm radius for plotting "
                                      "the swath as the data is not available.")
@@ -1265,7 +1269,6 @@ class Storm(object):
 
     # =========================================================================
     # Other Useful Routines
-
     def category(self, categorization="NHC", cat_names=False):
         r"""Categorizes storm based on relevant storm data
 
@@ -1318,9 +1321,7 @@ class Storm(object):
                        12: "Hurricane"}
 
         elif categorization.upper() == "NHC":
-            # TODO:  Change these to m/s (knots are how these are defined).
-            # Definitely not in the correct format now
-            # TODO:  Add TD and TS designations
+            # NHC uses knots
             speeds = units.convert(self.max_wind_speed, "m/s", "knots")
             category = (np.zeros(speeds.shape) +
                         (speeds < 30) * -1 +


### PR DESCRIPTION
This PR adds a new way to display time in the figure titles that is more standardized.  Defaults to the old way for now.

Also includes plotting fixes to the `Storm` object's `plot` function.