### PR TITLE
Properly set fgout q_out_vars to default

### DIFF
--- a/examples/tsunami/chile2010_fgmax-fgout/plot_fgout.py
+++ b/examples/tsunami/chile2010_fgmax-fgout/plot_fgout.py
@@ -13,6 +13,7 @@ output_format = 'binary'
 
 # Instantiate object for reading fgout frames:
 fgout_grid = fgout_tools.FGoutGrid(fgno, outdir, output_format)
+fgout_grid.read_fgout_grids_data()
 
 # Plot one frame of fgout data 
 fgframe = 20

--- a/src/python/geoclaw/fgout_tools.py
+++ b/src/python/geoclaw/fgout_tools.py
@@ -341,9 +341,12 @@ class FGoutGrid(object):
         # Note output_format will be reset by read_fgout_grids_data:
         self.output_format = output_format
 
-        self.q_out_vars = [1,2,3,4]  # list of which components to print
-                                          # default: h,hu,hv,eta (5=topo)
-        self.nqout = None # number of vars to print out
+        # list of which components to print:
+        try:
+            # default: h,hu,hv,eta as in previous versions of GeoClaw
+            self.q_out_vars = [1,2,3,self.qmap['eta']]
+        except:
+            self.q_out_vars = [1,2,3]  # if qmap['eta'] not defined
 
         self.drytol = 1e-3          # used for computing u,v from hu,hv
 

--- a/src/python/geoclaw/fgout_tools.py
+++ b/src/python/geoclaw/fgout_tools.py
@@ -342,10 +342,10 @@ class FGoutGrid(object):
         self.output_format = output_format
 
         # list of which components to print:
-        try:
+        if 'eta' in self.qmap.keys():
             # default: h,hu,hv,eta as in previous versions of GeoClaw
             self.q_out_vars = [1,2,3,self.qmap['eta']]
-        except:
+        else:
             self.q_out_vars = [1,2,3]  # if qmap['eta'] not defined
 
         self.drytol = 1e-3          # used for computing u,v from hu,hv


### PR DESCRIPTION
Should be `[h,hu,hv,eta]` as in old versions, but now `qmap['eta']` varies depending on equations being solved (e.g. `geoclaw-bouss` or `dclaw`).