### PR TITLE
Updates to geoclaw bouss calling of PETSc to support shared memory

### DIFF
--- a/src/2d/bouss/amr2.f90
+++ b/src/2d/bouss/amr2.f90
@@ -127,18 +127,18 @@ program amr2
 
     ! Local variables
     integer :: i, iaux, mw, level
-    integer :: ierr
+    integer :: ierr ! error flag for PETSc calls
     integer :: ndim, nvar, naux, mcapa1, mindim, dimensional_split
     integer :: nstart, nsteps, nv1, nx, ny, lentotsave, num_gauge_SAVE
     integer :: omp_get_max_threads, maxthreads
     real(kind=8) :: time, ratmet, cut, dtinit, dt_max
-    logical :: vtime, rest, output_t0    
+    logical :: vtime, rest, output_t0
 
     ! Timing variables
     integer(kind=8) :: clock_start, clock_finish, clock_rate, ttotal, count_max
     real(kind=8) :: ttotalcpu
     integer(kind=8) :: tick_clock_finish
-    integer, parameter :: timing_unit = 48
+    integer :: timing_unit = 0
     character(len=512) :: timing_line, timing_substr
     character(len=*), parameter :: timing_base_name = "timing."
     character(len=*), parameter :: timing_header_format =                      &
@@ -160,10 +160,12 @@ program amr2
     character(len=*), parameter :: parmfile = 'fort.parameters'
 
 #ifdef HAVE_PETSC
-!   needs to be very first line in main
-      call PetscInitialize(ierr)
-      CHKERRA(ierr);
+    !   needs to be very first line in main
+    PetscCallA(PetscOptionsSetValue(PETSC_NULL_OPTIONS,'-mpi_linear_solver_server','',ierr))
+    PetscCallA(PetscOptionsSetValue(PETSC_NULL_OPTIONS,'-mpi_linear_solver_server_view','',ierr))
+    PetscCallA(PetscInitialize(ierr))
 #endif
+    timing_unit = 48
 
     ! Open parameter and debug files
     open(dbugunit,file=dbugfile,status='unknown',form='formatted')
@@ -599,7 +601,7 @@ program amr2
         time = t0
         nstart = 0
     endif
-
+    call PetscViewerASCIIStdoutSetFileUnit(outunit,ierr)
 
     write(parmunit,*) ' '
     write(parmunit,*) '--------------------------------------------'
@@ -860,7 +862,6 @@ program amr2
     write(*,format_string)
     write(*,*)
     write(timing_unit,*)
-    close(timing_unit)
 
     if (isolver.eq. 2) then
 !     if (countIterRef == 0) then
@@ -928,12 +929,16 @@ program amr2
 
     write(outunit,"(//,' ------  end of AMRCLAW integration --------  ')")
 
-    ! Close output and debug files.
-    close(outunit)
+    ! Close debug file.
     close(dbugunit)
+    close(outunit)
 
 #ifdef HAVE_PETSC
-      call PetscFinalize(ierr)
+    call PetscViewerASCIIStdoutSetFileUnit(timing_unit,ierr)
+    call PetscFinalize(ierr)
 #endif
 
-end program amr2
+    if (timing_unit .gt. 0) then
+       close(timing_unit)
+    endif
+    end program amr2

--- a/src/2d/bouss/bouss_module.f90
+++ b/src/2d/bouss/bouss_module.f90
@@ -49,8 +49,8 @@ module bouss_module
        integer :: numColsTot
 
        ! for CRS format
-       integer, allocatable, dimension(:) :: rowPtr, cols
-       real(kind=8), allocatable, dimension(:) :: vals 
+       integer, pointer :: rowPtr(:), cols(:)
+       real(kind=8), pointer :: vals(:)
 
        ! intfCountc are the # equations (cells)  added for you as a coarse grid
        ! these are the equations under a fine grid on the first interior cells
@@ -166,7 +166,7 @@ contains
         crs = .true.
     endif
 
-    ! crs = .false.  ! uncomment this line to force CRS with SGN for testing
+    !crs = .false.  ! uncomment this line to force CRS with SGN for testing
 
     !------------------------------------------
     if (rest) then

--- a/src/2d/bouss/buildSparseMatrixMScoo.f90
+++ b/src/2d/bouss/buildSparseMatrixMScoo.f90
@@ -11,7 +11,7 @@ subroutine buildSparseMatrixMScoo(rhs,nvar,naux,levelBouss,numBoussCells)
     integer, intent(in) :: nvar, naux, levelBouss, numBoussCells
     
     !! pass in numBoussCells for this level so can dimension this array
-    real(kind=8) :: rhs(0:2*numBoussCells) 
+    real(kind=8) :: rhs(2*numBoussCells) 
     
     type(matrix_patchIndex), pointer :: mi
     type(matrix_levInfo),  pointer :: minfo

--- a/src/2d/bouss/buildSparseMatrixSGNcoo.f90
+++ b/src/2d/bouss/buildSparseMatrixSGNcoo.f90
@@ -16,7 +16,7 @@ subroutine buildSparseMatrixSGNcoo(q,qold,aux,soln,rhs,                    &
     integer, intent(in) :: nvar, naux, levelBouss, numBoussCells
     
     !! pass in numBoussCells for this level so can dimension these arrays
-    real(kind=8) :: soln(0:2*numBoussCells), rhs(0:2*numBoussCells) 
+    real(kind=8) :: soln(2*numBoussCells), rhs(2*numBoussCells) 
     
     type(matrix_patchIndex), pointer :: mi
     type(matrix_levInfo),  pointer :: minfo

--- a/src/2d/bouss/buildSparseMatrixSGNcrs.f90
+++ b/src/2d/bouss/buildSparseMatrixSGNcrs.f90
@@ -17,7 +17,7 @@ subroutine buildSparseMatrixSGNcrs(q,qold,aux,soln,rhs,rowPtr,cols,vals,   &
     integer, intent(inout) :: cols(0:24*numBoussCells)
     
     !! pass in numBoussCells for this level so can dimension these arrays
-    real(kind=8) :: soln(0:2*numBoussCells), rhs(0:2*numBoussCells) 
+    real(kind=8) :: soln(0:2*numBoussCells-1), rhs(0:2*numBoussCells-1) 
     
     type(matrix_patchIndex), pointer :: mi
     type(matrix_levInfo),  pointer :: minfo

--- a/src/2d/bouss/petsc_driver.f90
+++ b/src/2d/bouss/petsc_driver.f90
@@ -1,4 +1,4 @@
-subroutine petsc_driver(soln,rhs_geo,levelBouss,numBoussCells,time,topo_finalized)
+subroutine petsc_driver(solution,rhs,levelBouss,numBoussCells,time,topo_finalized)
 
     ! use petsc to solve sparse linear system
     ! called this way so can allocate storage of correct size
@@ -6,17 +6,12 @@ subroutine petsc_driver(soln,rhs_geo,levelBouss,numBoussCells,time,topo_finalize
     use bouss_module
 #ifdef HAVE_PETSC
 #include <petsc/finclude/petscksp.h>
-!!#include "petscmat.h"
     use petscksp
     implicit none
     
     integer, intent(in) :: levelBouss, numBoussCells
-    real(kind=8), intent(inout) :: rhs_geo(0:2*numBoussCells)
     real(kind=8), intent(in) :: time
     logical, intent(in) :: topo_finalized
-    
-    !! pass in numBoussCells for this level so can dimension this array
-    real(kind=8), intent(out) :: soln(0:2*numBoussCells)
     
     type(matrix_levInfo),  pointer :: minfo
     
@@ -87,6 +82,7 @@ subroutine petsc_driver(soln,rhs_geo,levelBouss,numBoussCells,time,topo_finalize
             end do
           else 
             ! using CRS sparse matrix format
+            CHKMEMQ;
             call MatCreateSeqAijWithArrays(PETSC_COMM_SELF,2*numBoussCells,  & 
                        2*numBoussCells,minfo%rowPtr,minfo%cols,  &
                        minfo%vals,Jr(levelBouss),ierr)
@@ -136,17 +132,15 @@ subroutine petsc_driver(soln,rhs_geo,levelBouss,numBoussCells,time,topo_finalize
       ! if you want to use previous soln as initial guess,
       ! set soln to old soln here
 
-      if (.not. crs) then
-        ! switch to 0-based indexing for COO triplet format
-        ! (already 0-based for CRS)
-        do i = 1, 2*numBousscells
-           rhs_geo(i-1) = rhs_geo(i) 
-        end do
-      endif 
+!      if (.not. crs) then
+!        ! switch to 0-based indexing for COO triplet format
+!        ! (already 0-based for CRS)
+!        do i = 1, 2*numBousscells
+!           rhs_geo(i-1) = rhs_geo(i) 
+!        end do
+!      endif 
       
-      call VecCreateSeqWithArray(PETSC_COMM_SELF,1,n,rhs_geo,rhs,ierr)
-      CHKERRA(ierr)
-      call VecCreateSeqWithArray(PETSC_COMM_SELF,1,n,soln,solution,ierr)
+
       CHKERRA(ierr)
 
       ! save matrices for debugging. comment out to turn off
@@ -167,23 +161,17 @@ subroutine petsc_driver(soln,rhs_geo,levelBouss,numBoussCells,time,topo_finalize
       !endif
 
       ! check if need to adjust soln back to 1 indexing
-      if (.not. crs) then ! bump both  back up
-        do i = 1, 2*numBoussCells
-          soln(2*numBoussCells-i+1) = soln(2*numBoussCells-i)
-          rhs_geo(2*numBoussCells-i+1) = rhs_geo(2*numBoussCells-i) 
-        end do
-      endif
+!      if (.not. crs) then ! bump both  back up
+!        do i = 1, 2*numBoussCells
+!          soln(2*numBoussCells-i+1) = soln(2*numBoussCells-i)
+!          rhs_geo(2*numBoussCells-i+1) = rhs_geo(2*numBoussCells-i) 
+!        end do
+!      endif
       
       !! if itnum > itmax then
       !! call KSPGetResidualNorm(ksp(levelBouss),resmax,ierr)
       CHKERRA(ierr)
       ! petsc already puts solution into my array soln so just return
-
-       ! create and destroy each step since fast
-       call VecDestroy(rhs,ierr)
-       CHKERRA(ierr)
-       call VecDestroy(solution,ierr)
-       CHKERRA(ierr)
 #endif
 
 end subroutine petsc_driver

--- a/src/2d/bouss/prepBuildSparseMatrixSGNcoo.f90
+++ b/src/2d/bouss/prepBuildSparseMatrixSGNcoo.f90
@@ -11,7 +11,7 @@ subroutine prepBuildSparseMatrixSGNcoo(soln,rhs,nvar,naux,levelBouss,numBoussCel
     integer, intent(in) :: nvar, naux, levelBouss, numBoussCells
     
     !! pass in numBoussCells for this level so can dimension this array
-    real(kind=8) :: soln(0:2*numBoussCells), rhs(0:2*numBoussCells) 
+    real(kind=8) :: soln(2*numBoussCells), rhs(2*numBoussCells) 
     real(kind=8) fms
     
     type(matrix_patchIndex), pointer :: mi

--- a/src/2d/bouss/prepBuildSparseMatrixSGNcrs.f90
+++ b/src/2d/bouss/prepBuildSparseMatrixSGNcrs.f90
@@ -11,7 +11,7 @@ subroutine prepBuildSparseMatrixSGNcrs(soln,rhs,nvar,naux,levelBouss,numBoussCel
     integer, intent(in) :: nvar, naux, levelBouss, numBoussCells
     
     !! pass in numBoussCells for this level so can dimension this array
-    real(kind=8) :: soln(0:2*numBoussCells), rhs(0:2*numBoussCells) 
+    real(kind=8) :: soln(0:2*numBoussCells-1), rhs(0:2*numBoussCells-1) 
     
     type(matrix_patchIndex), pointer :: mi
     type(matrix_levInfo),  pointer :: minfo

--- a/src/2d/bouss/restrt.f
+++ b/src/2d/bouss/restrt.f
@@ -77,12 +77,22 @@ c     # need to allocate for dynamic memory:
      5              timeRegridding,timeRegriddingCPU,
      6              timeValout,timeValoutCPU
 
-!     WRITE(*,*)"REMEMBER:  RESETTING Solver TIMERS For special tests"
-!     timeLinSolve = 0
-!     timeLinSolveCPU = 0.d0
-!     timePrepBuild = 0
-!     timePrepBuildCPU = 0.d0
-
+      WRITE(*,*)"REMEMBER:  RESETTING Solver TIMERS For special tests"
+      timeLinSolve = 0
+      timeLinSolveCPU = 0.d0
+      timePrepBuild = 0
+      timePrepBuildCPU = 0.d0
+      timeTick = 0
+      timeTickCPU = 0.0d0
+      timeStepgrid = 0
+      timeStepgridCPU = 0.0d0
+      timeBound = 0
+      timeBoundCPU = 0.d0
+      timeRegridding = 0
+      timeRegriddingCPU = 0.d0
+      timeValout = 0
+      timeValoutCPU = 0.d0
+      
       if (mxnest .gt. mxnold) then
         do ifg = 1, FG_num_fgrids
           fg => FG_fgrids(ifg)

--- a/src/2d/bouss/rpt2_geoclaw_sym.f
+++ b/src/2d/bouss/rpt2_geoclaw_sym.f
@@ -1,0 +1,264 @@
+! =====================================================
+      subroutine rpt2(ixy,imp,maxm,meqn,mwaves,maux,mbc,mx,
+     &                ql,qr,aux1,aux2,aux3,asdq,bmasdq,bpasdq)
+! =====================================================
+      use geoclaw_module, only: g => grav, tol => dry_tolerance
+      use geoclaw_module, only: coordinate_system,earth_radius,deg2rad
+
+      implicit none
+!
+!     # Riemann solver in the transverse direction using an einfeldt
+!     Jacobian.
+
+!-----------------------last modified 1/10/05----------------------
+
+      integer ixy,maxm,meqn,maux,mwaves,mbc,mx,imp
+
+      double precision  ql(meqn,1-mbc:maxm+mbc)
+      double precision  qr(meqn,1-mbc:maxm+mbc)
+      double precision  asdq(meqn,1-mbc:maxm+mbc)
+      double precision  bmasdq(meqn,1-mbc:maxm+mbc)
+      double precision  bpasdq(meqn,1-mbc:maxm+mbc)
+      double precision  aux1(maux,1-mbc:maxm+mbc)
+      double precision  aux2(maux,1-mbc:maxm+mbc)
+      double precision  aux3(maux,1-mbc:maxm+mbc)
+
+      double precision  s(mwaves)
+      double precision  r(meqn,mwaves)
+      double precision  beta(mwaves)
+      double precision  abs_tol
+      double precision  hl,hr,hul,hur,hvl,hvr,vl,vr,ul,ur,bl,br
+      double precision  uhat,vhat,hhat,roe1,roe3,s1,s2,s3,s1down,s3up
+      double precision  delf1,delf2,delf3,dxdcd,dxdcu
+      double precision  dxdcm,dxdcp,topo1,topo3,eta
+
+      integer i,m,mw,mu,mv
+      
+      !write(83,*) 'rpt2, imp = ',imp
+          
+      ! initialize all components to 0:
+      bmasdq(:,:) = 0.d0
+      bpasdq(:,:) = 0.d0
+
+      abs_tol=tol
+
+      if (ixy.eq.1) then
+        mu = 2
+        mv = 3
+      else
+        mu = 3
+        mv = 2
+      endif
+
+      do i=2-mbc,mx+mbc
+
+         hl=qr(1,i-1) 
+         hr=ql(1,i) 
+         hul=qr(mu,i-1) 
+         hur=ql(mu,i) 
+         hvl=qr(mv,i-1) 
+         hvr=ql(mv,i)
+
+!===========determine velocity from momentum===========================
+       if (hl.lt.abs_tol) then
+          hl=0.d0
+          ul=0.d0
+          vl=0.d0
+       else
+          ul=hul/hl
+          vl=hvl/hl
+       endif
+
+       if (hr.lt.abs_tol) then
+          hr=0.d0
+          ur=0.d0
+          vr=0.d0
+       else
+          ur=hur/hr
+          vr=hvr/hr
+       endif
+
+       do mw=1,mwaves
+          s(mw)=0.d0
+          beta(mw)=0.d0
+          do m=1,meqn
+             r(m,mw)=0.d0
+          enddo
+       enddo
+      dxdcp = 1.d0
+      dxdcm = 1.d0
+
+      if (hl <= tol .and. hr <= tol) go to 90
+
+*      !check and see if cell that transverse waves are going in is high and dry
+       if (imp.eq.1) then
+            eta = qr(1,i-1)  + aux2(1,i-1)
+            topo1 = aux1(1,i-1)
+            topo3 = aux3(1,i-1)
+c            s1 = vl-sqrt(g*hl)
+c            s3 = vl+sqrt(g*hl)
+c            s2 = 0.5d0*(s1+s3)
+       else
+            eta = ql(1,i) + aux2(1,i)
+            topo1 = aux1(1,i)
+            topo3 = aux3(1,i)
+c            s1 = vr-sqrt(g*hr)
+c            s3 = vr+sqrt(g*hr)
+c            s2 = 0.5d0*(s1+s3)
+       endif
+       if (eta.lt.max(topo1,topo3)) go to 90
+
+      if (coordinate_system.eq.2) then
+         if (ixy.eq.2) then
+             dxdcp=(earth_radius*deg2rad)
+            dxdcm = dxdcp
+         else
+            if (imp.eq.1) then
+               dxdcp = earth_radius*cos(aux3(3,i-1))*deg2rad
+               dxdcm = earth_radius*cos(aux1(3,i-1))*deg2rad
+            else
+               dxdcp = earth_radius*cos(aux3(3,i))*deg2rad
+               dxdcm = earth_radius*cos(aux1(3,i))*deg2rad
+            endif
+         endif
+      endif
+
+c=====Determine some speeds necessary for the Jacobian=================
+c            vhat=(vr*dsqrt(hr))/(dsqrt(hr)+dsqrt(hl)) +
+c     &        (vl*dsqrt(hl))/(dsqrt(hr)+dsqrt(hl))
+c
+c            uhat=(ur*dsqrt(hr))/(dsqrt(hr)+dsqrt(hl)) +
+c     &        (ul*dsqrt(hl))/(dsqrt(hr)+dsqrt(hl))
+c            hhat=(hr+hl)/2.d0
+
+            ! Note that we used left right states to define Roe averages,
+            ! which is consistent with those used in rpn2.
+            ! But now we are computing upgoing, downgoing waves either in
+            ! cell on left (if imp==1) or on right (if imp==2) so we
+            ! should perhaps use Roe averages based on values above or below,
+            ! but these aren't available.
+
+            !roe1=vhat-dsqrt(g*hhat)
+            !roe3=vhat+dsqrt(g*hhat)
+
+            ! modified to at least use hl,vl or hr,vr properly based on imp:
+            ! (since s1 and s3 are now vertical velocities,
+            ! it made no sense to use h,v in cell i-1 for downgoing 
+            ! and cell i for upgoing)
+
+            if (imp == 1) then
+                ! asdq is leftgoing, use q from cell i-1:
+                if (hl <= tol) go to 90
+                s1 = vl-dsqrt(g*hl)
+                s3 = vl+dsqrt(g*hl)
+                s2 = vl
+                uhat = ul
+                hhat = hl
+            else
+                ! asdq is rightgoing, use q from cell i:
+                if (hr <= tol) go to 90
+                s1 = vr-dsqrt(g*hr)
+                s3 = vr+dsqrt(g*hr)
+                s2 = vr
+                uhat = ur
+                hhat = hr
+            endif
+
+            ! don't use Roe averages:
+            !s1=dmin1(roe1,s1down)
+            !s3=dmax1(roe3,s3up)
+
+            !s2=0.5d0*(s1+s3)
+
+           s(1)=s1
+           s(2)=s2
+           s(3)=s3
+c=======================Determine asdq decomposition (beta)============
+         delf1=asdq(1,i)
+         delf2=asdq(mu,i)
+         delf3=asdq(mv, i)
+
+         ! fixed bug in beta(2): uhat in place of s(2)
+         beta(1) = (s3*delf1/(s3-s1))-(delf3/(s3-s1))
+         beta(2) = -uhat*delf1 + delf2
+         beta(3) = (delf3/(s3-s1))-(s1*delf1/(s3-s1))
+c======================End =================================================
+
+c=====================Set-up eigenvectors===================================
+         r(1,1) = 1.d0
+         r(2,1) = uhat    ! fixed bug, uhat not s2
+         r(3,1) = s1
+
+         r(1,2) = 0.d0
+         r(2,2) = 1.d0
+         r(3,2) = 0.d0
+
+         r(1,3) = 1.d0
+         r(2,3) = uhat    ! fixed bug, uhat not s2
+         r(3,3) = s3
+c============================================================================
+90      continue
+c============= compute fluctuations==========================================
+
+               bmasdq(1,i)=0.0d0
+               bpasdq(1,i)=0.0d0
+               bmasdq(2,i)=0.0d0
+               bpasdq(2,i)=0.0d0
+               bmasdq(3,i)=0.0d0
+               bpasdq(3,i)=0.0d0
+               
+               do  mw=1,3
+                  print*,  s(mw)
+                  print*,  abs(s(mw))
+                  print*, g,hhat
+                  print*, dsqrt(g*hhat)
+               if ((abs(s(mw)) > 0.d0) .and. 
+     &             (abs(s(mw)) < 0.001d0*dsqrt(g*hhat))) then
+                 ! split correction symmetrically if nearly zero
+                 ! Note wave drops out if s(mw)==0 exactly, so don't split
+                 bmasdq(1,i) =bmasdq(1,i) +
+     &                        0.5d0*dxdcm*s(mw)*beta(mw)*r(1,mw)
+                 bmasdq(mu,i)=bmasdq(mu,i)+ 
+     &                        0.5d0*dxdcm*s(mw)*beta(mw)*r(2,mw)
+                 bmasdq(mv,i)=bmasdq(mv,i)+ 
+     &                        0.5d0*dxdcm*s(mw)*beta(mw)*r(3,mw)
+                 bpasdq(1,i) =bpasdq(1,i) + 
+     &                        0.5d0*dxdcp*s(mw)*beta(mw)*r(1,mw)
+                 bpasdq(mu,i)=bpasdq(mu,i)+ 
+     &                        0.5d0*dxdcp*s(mw)*beta(mw)*r(2,mw)
+                 bpasdq(mv,i)=bpasdq(mv,i)+ 
+     &                        0.5d0*dxdcp*s(mw)*beta(mw)*r(3,mw)
+               elseif (s(mw).lt.0.d0) then
+                 bmasdq(1,i) =bmasdq(1,i) + dxdcm*s(mw)*beta(mw)*r(1,mw)
+                 bmasdq(mu,i)=bmasdq(mu,i)+ dxdcm*s(mw)*beta(mw)*r(2,mw)
+                 bmasdq(mv,i)=bmasdq(mv,i)+ dxdcm*s(mw)*beta(mw)*r(3,mw)
+               elseif (s(mw).gt.0.d0) then
+                 bpasdq(1,i) =bpasdq(1,i) + dxdcp*s(mw)*beta(mw)*r(1,mw)
+                 bpasdq(mu,i)=bpasdq(mu,i)+ dxdcp*s(mw)*beta(mw)*r(2,mw)
+                 bpasdq(mv,i)=bpasdq(mv,i)+ dxdcp*s(mw)*beta(mw)*r(3,mw)
+               endif
+            enddo
+            
+        !if ((i>3) .and. (i<6)) then
+        if (.false.) then
+            ! DEBUG
+            write(83,*) 'i = ',i
+            write(83,831) s(1),s(2),s(3)
+            write(83,831) beta(1),beta(2),beta(3)
+            do m=1,3
+                write(83,831) r(m,1),r(m,2),r(m,3)
+            enddo
+            do m=1,3
+                write(83,831) asdq(m,i), bmasdq(m,i), bpasdq(m,i)
+ 831            format(3d20.12)
+            enddo
+        endif
+c========================================================================
+         enddo  ! do i loop
+c
+
+
+c
+
+      return
+      end


### PR DESCRIPTION
Shared memory is used to transfer data from OpenMP code to MPI processes instead of nonscalable message passing