### PR TITLE
modify so gauge values always written at start time regardless of min_time_increment

### DIFF
--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -163,17 +163,17 @@ contains
             read(UNIT, *)
             read(UNIT, *) (gauges(i)%gtype, i=1, num_gauges)
 
-            do i=1,num_gauges
-                ! initialize last_time so that first gauge output will be
-                ! at time gauges(i)%t_start regardless of min_time_increment:
-                gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
-                                      - gauges(i)%min_time_increment
-            enddo
 
             ! Read in q fields
             read(UNIT, *)
             read(UNIT, *)
             do i = 1, num_gauges
+
+                ! initialize last_time so that first gauge output will be
+                ! at time gauges(i)%t_start regardless of min_time_increment:
+                gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
+                                      - gauges(i)%min_time_increment
+
                 allocate(gauges(i)%q_out_vars(num_eqn))
                 read(UNIT, *) gauges(i)%q_out_vars
 

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -141,7 +141,6 @@ contains
                 ! note that for lagrangian gauges, the x,y values read here 
                 ! might be overwritten if this is a restart
                 gauges(i)%buffer_index = 1
-                gauges(i)%last_time = gauges(i)%t_start
                 ! keep track of last position for lagrangian gauges,
                 ! initialize here in case checkpoint happens before 
                 ! ever writing this gauge:
@@ -163,6 +162,13 @@ contains
             read(UNIT, *)
             read(UNIT, *)
             read(UNIT, *) (gauges(i)%gtype, i=1, num_gauges)
+
+            do i=1,num_gauges
+                ! initialize last_time so that first gauge output will be
+                ! at time gauges(i)%t_start regardless of min_time_increment:
+                gauges(i)%last_time = gauges(i)%t_start - 1.d0 &
+                                      - gauges(i)%min_time_increment
+            enddo
 
             ! Read in q fields
             read(UNIT, *)


### PR DESCRIPTION
Previously if `min_time_increment > 0` was set for a gauge it wouldn't capture the gauge value until this long after the starting time value `t1` specified for the gauge.