### PR TITLE
New speed_limit parameter to avoid too many dt reductions

### DIFF
--- a/src/2d/shallow/b4step2.f90
+++ b/src/2d/shallow/b4step2.f90
@@ -14,6 +14,7 @@ subroutine b4step2(mbc,mx,my,meqn,q,xlower,ylower,dx,dy,t,dt,maux,aux,actualstep
 
     use geoclaw_module, only: dry_tolerance
     use geoclaw_module, only: g => grav
+    use geoclaw_module, only: speed_limit
     use topo_module, only: num_dtopo,topotime
     use topo_module, only: aux_finalized
     use topo_module, only: xlowdtopo,xhidtopo,ylowdtopo,yhidtopo
@@ -23,6 +24,7 @@ subroutine b4step2(mbc,mx,my,meqn,q,xlower,ylower,dx,dy,t,dt,maux,aux,actualstep
     use amr_module, only: xhidomain => xupper
     use amr_module, only: yhidomain => yupper
     use amr_module, only: xperdom,yperdom,spheredom,NEEDS_TO_BE_SET
+    use amr_module, only: outunit
 
     use storm_module, only: set_storm_fields
 
@@ -38,7 +40,7 @@ subroutine b4step2(mbc,mx,my,meqn,q,xlower,ylower,dx,dy,t,dt,maux,aux,actualstep
 
     ! Local storage
     integer :: index,i,j,k,dummy
-    real(kind=8) :: h,u,v
+    real(kind=8) :: h,u,v, sratio, xs,ys, s
 
     ! Check for NaNs in the solution
     call check4nans(meqn,mbc,mx,my,q,t,1)
@@ -50,6 +52,42 @@ subroutine b4step2(mbc,mx,my,meqn,q,xlower,ylower,dx,dy,t,dt,maux,aux,actualstep
         q(1,i,j) = max(q(1,i,j),0.d0)
         q(2:3,i,j) = 0.d0
     end forall
+
+    ! Check for fluid speed sqrt(u**2 + v**2) > speed_limit
+    ! and reset by scaling (u,v) down to this value (preserving direction)
+    ! Note: similar check is done in getmaxspeed
+    ! This helps avoid too many dt reductions when flow off very steep topo
+    ! with delta B larger than fluid depth gives big speeds in Riemann solution 
+    ! (shallow water equations aren't valid for flow off a cliff)
+
+    do j=1-mbc,my+mbc
+        do i=1-mbc,mx+mbc
+            if (q(1,i,j) > 0.d0) then
+                s = sqrt((q(2,i,j)**2 + q(3,i,j)**2)) / q(1,i,j)
+                if (s > speed_limit) then
+                    sratio = speed_limit / s
+                    q(2,i,j) = q(2,i,j) * sratio
+                    q(3,i,j) = q(3,i,j) * sratio
+
+                    if (.true.) then
+                        ! write out info useful for investigating topo:
+                        xs = xlower + (i-0.5d0)*dx
+                        ys = ylower + (j-0.5d0)*dy
+                        write(6,604) t, i,j, mx,my, dx
+                        write(outunit,604) t, i,j, mx,my, dx
+                        write(6,603) s,q(1,i,j),aux(1,i,j),xs,ys
+                        write(outunit,603) s,q(1,i,j),aux(1,i,j),xs,ys
+
+ 604                    format('b4step2 at t =',f10.2, '  i,j,mx,my:',4i4, &
+                               '  dx = ',f10.7)
+ 603                    format('     reset s =',f9.2,'  h=',e11.3, ' B=',f8.2,&
+                               '  x,y = ', f11.6,',',f10.6)
+                    endif
+               endif
+            endif
+        enddo
+    enddo
+
 
 
     if (aux_finalized < 2 .and. actualstep) then

--- a/src/2d/shallow/geoclaw_module.f90
+++ b/src/2d/shallow/geoclaw_module.f90
@@ -44,7 +44,8 @@ module geoclaw_module
     real(kind=8) :: friction_depth
     
     ! Method parameters    
-    real(kind=8) :: dry_tolerance
+    real(kind=8) :: dry_tolerance  ! smaller depths set to zero in places
+    real(kind=8) :: speed_limit    ! larger water speeds limited to this value
 
 contains
 
@@ -67,7 +68,7 @@ contains
         ! Locals
         integer, parameter :: unit = 127
 
-        integer :: i
+        integer :: i, iostat
         character(len=128) :: line
 
         if (.not.module_setup) then
@@ -116,6 +117,14 @@ contains
             endif
             read(unit,*)
             read(unit,*) dry_tolerance
+
+            read(unit,*,iostat=iostat) speed_limit
+            if (iostat .ne. 0) then
+                ! speed_limit only set in version > 5.11.0
+                ! if newer GeoClaw run with older geoclaw.data then use:
+                speed_limit = rinfinity
+                print *, '*** no speed_limit set'
+            endif
             
             close(unit)
 

--- a/src/2d/shallow/getmaxspeed.f90
+++ b/src/2d/shallow/getmaxspeed.f90
@@ -1,21 +1,24 @@
-real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx,hy)
+real(kind=8) function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx,hy)
 
     use geoclaw_module, only: dry_tolerance, coordinate_system
-    use geoclaw_module, only: grav, earth_radius, DEG2RAD
-      
+    use geoclaw_module, only: grav, earth_radius, DEG2RAD, speed_limit
+
     implicit none
-    
+
     ! Arguments
     integer, intent(in) :: mitot,mjtot,nvar,naux,nghost
     real(kind=8), intent(in) :: hx,hy
-    real(kind=8), intent(in) :: val(nvar,mitot,mjtot), aux(naux,mitot,mjtot)
-    
+    real(kind=8), intent(inout) :: val(nvar,mitot,mjtot), aux(naux,mitot,mjtot)
+
     ! Locals
     integer :: i,j
     real(kind=8) :: ymetric,hyphys,xmetric,hxphys,u,v,sig,sp_over_h
 
+    real(kind=8) :: s,sratio
 
     sp_over_h = 0.d0   ! compute max speed over h, since dx may not equal dy
+                       ! (note hx=dx, hy=dy for historical reasons)
+
     if (coordinate_system == 2) then
         do j = nghost+1, mjtot-nghost
             ymetric = earth_radius*deg2rad
@@ -27,8 +30,18 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                 if (val(1,i,j) > dry_tolerance) then
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
+                    s = sqrt(u**2 + v**2)
+                    if (s > speed_limit) then
+                        sratio = speed_limit / s
+                        val(2,i,j) = val(2,i,j) * sratio
+                        val(3,i,j) = val(3,i,j) * sratio
+                        u = u * sratio
+                        v = v * sratio
+                        write(6,*) '+++ getmaxspeed reset s = ',s
+                    endif
                     sig = sqrt(grav*val(1,i,j))
-                    sp_over_h = max((abs(u)+sig)/hxphys,(abs(v)+sig)/hyphys,sp_over_h)
+                    sp_over_h = max((abs(u)+sig)/hxphys, &
+                                    (abs(v)+sig)/hyphys, sp_over_h)
                 endif
             end do
         end do
@@ -38,13 +51,23 @@ real(kind=8) pure function get_max_speed(val,mitot,mjtot,nvar,aux,naux,nghost,hx
                 if (val(1,i,j) > dry_tolerance) then
                     u  = val(2,i,j) / val(1,i,j)
                     v  = val(3,i,j) / val(1,i,j)
+                    s = sqrt(u**2 + v**2)
+                    if (s > speed_limit) then
+                        sratio = speed_limit / s
+                        val(2,i,j) = val(2,i,j) * sratio
+                        val(3,i,j) = val(3,i,j) * sratio
+                        u = u * sratio
+                        v = v * sratio
+                        write(6,*) '+++ getmaxspeed reset s = ',s
+                    endif
                     sig = sqrt(grav*val(1,i,j))
-                    sp_over_h = max((abs(u)+sig)/hx,(abs(v)+sig)/hy,sp_over_h)
+                    sp_over_h = max((abs(u)+sig)/hx, &
+                                    (abs(v)+sig)/hy, sp_over_h)
                 endif
             end do
         end do
     endif
-      
+
     get_max_speed = sp_over_h
 
 end function get_max_speed

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -72,6 +72,7 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
         self.add_attribute('dry_tolerance',1e-3)
         self.add_attribute('friction_depth',1.0e6)
         self.add_attribute('sea_level',0.0)
+        self.add_attribute('speed_limit',50.)
 
 
     def write(self,data_source='setrun.py', out_file='geoclaw.data'):
@@ -111,6 +112,7 @@ class GeoClawData(clawpack.clawutil.data.ClawData):
         self.data_write()
 
         self.data_write('dry_tolerance')
+        self.data_write('speed_limit')
 
         self.close_data_file()
 


### PR DESCRIPTION
A new parameter `rundata.geo_data.speed_limit` can be set in `setrun.py` and is used in `b4step2.f90` and `getmaxspeed.f90` to scale down the fluid speed `sqrt(u**2 + v**2)` if it is larger than this value (preserving the flow direction).

This helps avoid crashing the code with "too many dt reductions" in cases when flow off very steep topography with delta B larger than the fluid depth gives big speeds in the Riemann solution (shallow water equations aren't valid for flow off a cliff).

If not specified in `setrun.py`, the default value `speed_limit = 50` m/s (approx 100 knots) is set in `data.py`. This is much larger than physically reasonable speeds for most problems, so this should give consistent results with past version of GeoClaw for runs that don't die along the way.

In practice it is better to use a smaller value for most problems. Setting `speed_limit = 20` has been found to work well for several tsunami inundation problems, eliminating the tiny time steps that are sometimes forced by unphysical huge speeds in one cell, and allowing jobs to run to completion that otherwise fail in sevaral tests. This speed is probably larger than fluid speeds expected in most tsunami, storm surge, or flooding problems.

But more experiments are needed to try to optimize this.  And for some extreme problems, such as asteroid-impact mega-tsunamis or catastrophic dam failures, larger values of `speed_limit` may be appropriate.