### PR TITLE
Draft: topoarea() fix?

### DIFF
--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -1360,7 +1360,10 @@ recursive subroutine topoarea(x1,x2,y1,y2,m,area)
          ! only using coarsest topo grid -- compute directly...
          call intersection(indicator,area,xmlo,xmhi, &
              ymlo,ymhi, x1,x2,y1,y2, &
-             xlowtopo(mfid),xhitopo(mfid),ylowtopo(mfid),yhitopo(mfid))
+             xlowtopo(mfid)-dxtopo(mfid), &
+             xhitopo(mfid)+dxtopo(mfid), &
+             ylowtopo(mfid)-dytopo(mfid), &
+             yhitopo(mfid)+dytopo(mfid))
 
     else
         ! recursive call to compute area using one fewer topo grids:
@@ -1369,8 +1372,10 @@ recursive subroutine topoarea(x1,x2,y1,y2,m,area)
         ! region of intersection of cell with new topo grid:
         call intersection(indicator,area_m,x1m,x2m, &
              y1m,y2m, x1,x2,y1,y2, &
-             xlowtopo(mfid),xhitopo(mfid),ylowtopo(mfid),yhitopo(mfid))
-
+             xlowtopo(mfid)-dxtopo(mfid), &
+             xhitopo(mfid)+dxtopo(mfid), &
+             ylowtopo(mfid)-dytopo(mfid), &
+             yhitopo(mfid)+dytopo(mfid))
         
         if (area_m > 0) then
         


### PR DESCRIPTION
@rjleveque , @mandli - I'm working on a synthetic problem and came across a *potential* bug in the topoarea calculations. 

In my application I have created a topo grid that perfectly aligns with my simulation grid. When I did this, I ran into topoarea errors indicating that my topography was not big enough for the domain. I think this occurred because the topoarea calculation considers the grid cell center of the topo and not the grid cell extent (perhaps by design?)

Including a buffer of +/- dx and dy around the x/y low/hi extent of the topo in the topoarea calculation addressed this issue for me. 

Is the use of topo grid cell centers by design or an error?

