### PR TITLE
Trying to fix storm.py

### DIFF
--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1065,7 +1065,7 @@ class Storm(object):
             with open(path, "w") as data_file:
                 # Write header
                 data_file.write(f"{num_casts}\n")
-                if isinstance(self.time_offset, datetime.datetime):
+                if isinstance(self.time_offset, np.datetime64):
                     data_file.write(\
                       f"{np.datetime_as_string(self.time_offset,unit='s')}\n\n")
                 else:

--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1066,8 +1066,8 @@ class Storm(object):
                 # Write header
                 data_file.write(f"{num_casts}\n")
                 if isinstance(self.time_offset, datetime.datetime):
-                    data_file.write(f"{np.datetime_as_string(self.time_offset, 
-                                                             unit='s')}\n\n")
+                    data_file.write(\
+                      f"{np.datetime_as_string(self.time_offset,unit='s')}\n\n")
                 else:
                     data_file.write(f"{str(self.time_offset)}\n\n")
 

--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1067,7 +1067,7 @@ class Storm(object):
                 data_file.write(f"{num_casts}\n")
                 if isinstance(self.time_offset, datetime.datetime):
                     data_file.write(f"{np.datetime_as_string(self.time_offset, 
-                                                             unit="s")}\n\n")
+                                                             unit='s')}\n\n")
                 else:
                     data_file.write(f"{str(self.time_offset)}\n\n")
 


### PR DESCRIPTION
@mandli: I'm trying to run all the GeoClaw examples and  I don't know what's wrong with this.

I fixed nested double quotes and then it didn't like an f-string split between lines, but now it still gives an error...

```
$ cd $CLAW/geoclaw/examples/storm-surge/ike
$ make data
            
Traceback (most recent call last):
  File "/Users/rjl/git/clawpack/geoclaw/src/python/geoclaw/surge/storm.py", line 1070, in write_geoclaw
    f"{np.datetime_as_string(self.time_offset,unit='s')}\n\n")
TypeError: input must have type NumPy datetime
```

