### PR TITLE
Add support for overriding topography array ordering

### DIFF
--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -225,6 +225,9 @@ contains
                 ! The finest topography will be given priority in any region
                 ! mtopoorder(rank) = i means that i'th topography file has rank rank,
                 ! where the file with rank=1 is the finest and considered first.
+                !
+                ! If override_topo_order is .true. then the order that the files were
+                ! specified is used directly
                 if (override_topo_order) then
                     do i=1, mtopofiles
                         mtopoorder(i) = i

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -229,7 +229,7 @@ contains
                 ! If override_topo_order is .true. then the order that the files were
                 ! specified is used directly
                 if (override_topo_order) then
-                    do i=1, mtopofiles
+                    do i=mtopofiles, -1, 1
                         mtopoorder(i) = i
                     end do
                 else

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -21,6 +21,7 @@ module topo_module
     real(kind=8), allocatable :: dxtopo(:), dytopo(:)
     real(kind=8), allocatable :: topotime(:)
     integer(kind=8), allocatable :: mtopo(:), i0topo(:)
+    logical :: override_topo_order
 
     integer, allocatable :: mxtopo(:), mytopo(:), mtopoorder(:)
     integer, allocatable :: itopotype(:)
@@ -124,6 +125,7 @@ contains
             ! Primary topography type, read in topography files specified
             if (test_topography == 0) then
                 read(iunit,*) mtopofiles
+                read(iunit,*) override_topo_order
 
                 if (mtopofiles == 0) then
                     write(GEO_PARM_UNIT,*) '   mtopofiles = 0'
@@ -223,24 +225,30 @@ contains
                 ! The finest topography will be given priority in any region
                 ! mtopoorder(rank) = i means that i'th topography file has rank rank,
                 ! where the file with rank=1 is the finest and considered first.
-                do i=1,mtopofiles
-                    finer_than = 0
-                    do j=1,mtopofiles
-                        if (j /= i) then
-                            area_i=dxtopo(i)*dytopo(i)
-                            area_j=dxtopo(j)*dytopo(j)
-                            if (area_i < area_j) finer_than = finer_than + 1
-                            ! if two files have the same resolution, order is
-                            ! arbitrarily chosen
-                            if ((area_i == area_j).and.(j < i)) then
-                                finer_than = finer_than + 1
+                if (override_topo_order) then
+                    do i=1, mtopofiles
+                        mtopoorder(i) = i
+                    end do
+                else
+                    do i=1,mtopofiles
+                        finer_than = 0
+                        do j=1,mtopofiles
+                            if (j /= i) then
+                                area_i=dxtopo(i)*dytopo(i)
+                                area_j=dxtopo(j)*dytopo(j)
+                                if (area_i < area_j) finer_than = finer_than + 1
+                                ! if two files have the same resolution, order is
+                                ! arbitrarily chosen
+                                if ((area_i == area_j).and.(j < i)) then
+                                    finer_than = finer_than + 1
+                                endif
                             endif
-                        endif
+                        enddo
+                        ! ifinerthan tells how many other files, file i is finer than
+                        rank = mtopofiles - finer_than
+                        mtopoorder(rank) = i
                     enddo
-                    ! ifinerthan tells how many other files, file i is finer than
-                    rank = mtopofiles - finer_than
-                    mtopoorder(rank) = i
-                enddo
+                end if
 
                 write(GEO_PARM_UNIT,*) ' '
                 write(GEO_PARM_UNIT,*) '  Ranking of topography files', &

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -229,7 +229,7 @@ contains
                 ! If override_topo_order is .true. then the order that the files were
                 ! specified is used directly
                 if (override_topo_order) then
-                    do i=mtopofiles, -1, 1
+                    do i=mtopofiles, 1, -1
                         mtopoorder(i) = i
                     end do
                 else

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -160,9 +160,10 @@ class TopographyData(clawpack.clawutil.data.ClawData):
         super(TopographyData,self).__init__()
 
         # Topography data
-        self.add_attribute('topo_missing',99999.)
-        self.add_attribute('test_topography',0)
-        self.add_attribute('topofiles',[])
+        self.add_attribute('topo_missing', 99999.0)
+        self.add_attribute('test_topography', 0)
+        self.add_attribute('override_order', False)
+        self.add_attribute('topofiles', [])
 
         # Jump discontinuity
         self.add_attribute('topo_location',-50e3)
@@ -188,6 +189,7 @@ class TopographyData(clawpack.clawutil.data.ClawData):
         if self.test_topography == 0:
             ntopofiles = len(self.topofiles)
             self.data_write(value=ntopofiles,alt_name='ntopofiles')
+            self.data_write(name="override_order", description="(Override order topo files are used)")
             for tfile in self.topofiles:
 
                 if len(tfile) == 6:


### PR DESCRIPTION
This PR adds the abiility to override the priority that a topography file receives.  

Previously topography files are ordered first by their resolution and then by the order they are given in `setrun.py`.  This PR adds a parameter `override_order` so that the order that the topography files are specified in `setrun.py` always dictates the order that they will be used.

This is useful if you have two or more topography files that are nearly the same resolution and there is a preference for their order that does not match this.