### PR TITLE
Change Timing for Gauge Updating

### DIFF
--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -277,12 +277,12 @@ c969     format(" thread ",i4," updated by ",e15.7, " new dt ",e15.7)
           rnode(timemult,mptr)  = rnode(timemult,mptr)+delt
 
 c     This currently is a sanity check to make sure we moved time
-      time = rnode(timemult,mptr)
-      if (num_gauges > 0 .and. .not. (abs(time - t0) < TOLERANCE) ) then
-           call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot),
-     .                       alloc(locaux:locaux+naux*mitot*mjtot),
-     .                       xlow,ylow,nvar,mitot,mjtot,naux,mptr)
-      endif
+C       time = rnode(timemult,mptr)
+C       if (num_gauges > 0 .and. .not. (abs(time - t0) < TOLERANCE) ) then
+      call update_gauges(alloc(locnew:locnew+nvar*mitot*mjtot),
+     .                         alloc(locaux:locaux+naux*mitot*mjtot),
+     .                         xlow,ylow,nvar,mitot,mjtot,naux,mptr)
+C       endif
 c
       return
       end


### PR DESCRIPTION
This PR moves the `update_gauge` call to after a step is taken.  It also puts a condition on an initial time `abs(t0 - time) < TOLERANCE` so that the initial time is still recorded at the initial time.