### PR TITLE
post 5.11 fixes for dclaw: fgout_tools and fgout xarray backends 

### DIFF
--- a/src/python/geoclaw/fgout_tools.py
+++ b/src/python/geoclaw/fgout_tools.py
@@ -342,11 +342,13 @@ class FGoutGrid(object):
         self.output_format = output_format
 
         # list of which components to print:
-        if 'eta' in self.qmap.keys():
-            # default: h,hu,hv,eta as in previous versions of GeoClaw
-            self.q_out_vars = [1,2,3,self.qmap['eta']]
+        if qmap == 'dclaw':
+            # default: h,hu,hv,hm,pb,hchi,bdif,eta, DClaw
+            self.q_out_vars = [1,2,3,4,5,6,7]
         else:
-            self.q_out_vars = [1,2,3]  # if qmap['eta'] not defined
+            self.q_out_vars = [1,2,3] # use Geoclaw values as default.
+        if 'eta' in self.qmap.keys():
+            self.q_out_vars.append(self.qmap['eta'])
 
         self.drytol = 1e-3          # used for computing u,v from hu,hv
 

--- a/src/python/geoclaw/xarray_backends.py
+++ b/src/python/geoclaw/xarray_backends.py
@@ -221,7 +221,11 @@ class FGOutBackend(BackendEntrypoint):
         if fgout_grid.point_style != 2:
             raise ValueError("FGOutBackend only works with fg.point_style=2")
 
-        fgout_grid.read_fgout_grids_data()
+        try:
+            fgout_grid.read_fgout_grids_data()
+        except AssertionError:
+            fgout_grid.read_fgout_grids_data_pre511()
+
         fgout = fgout_grid.read_frame(frameno)
 
         time = fgout.t


### PR DESCRIPTION
@rjleveque - A few v5.11 changes made using the fgout tools with D-Claw output not work as expected because of how the default q_out_vars are handled. 

I didn't find this issue until now because it took me a while to have a need to re-process pre-5.11 output with post 5.11 code.

Happy to revise further if you think this needs additional updates.

Thanks!