### PR TITLE
Add NetCDF Formatted Storm Support

### DIFF
--- a/examples/storm-surge/isaac/Makefile
+++ b/examples/storm-surge/isaac/Makefile
@@ -21,8 +21,10 @@ PLOTDIR = _plots               # Directory for plots
 
 # Environment variable FC should be set to fortran compiler, e.g. gfortran
 # If using NetCDF reading use these flags
-FFLAGS += -DNETCDF -I$(NETCDF4_DIR)/include -L$(NETCDF4_DIR)/lib
-LFLAGS += -I$(NETCDF4_DIR)/include -L$(NETCDF4_DIR)/lib -lnetcdff
+# FFLAGS += -DNETCDF -I$(NETCDF4_DIR)/include -L$(NETCDF4_DIR)/lib
+# LFLAGS += -I$(NETCDF4_DIR)/include -L$(NETCDF4_DIR)/lib -lnetcdff
+FFLAGS += -DNETCDF $(shell nf-config --fflags)
+LFLAGS += $(FFLAGS) $(shell nf-config --flibs) $(shell nc-config --libs)
 
 # ---------------------------------
 # package sources for this program:

--- a/examples/storm-surge/isaac/setrun.py
+++ b/examples/storm-surge/isaac/setrun.py
@@ -406,6 +406,7 @@ def setgeo(rundata):
     # Storm parameters - Parameterized storm (Holland 1980)
     data.storm_specification_type = 'holland80'  # (type 1)
     # data.storm_specification_type = 'OWI'
+    data.storm_specification_type = 'netcdf'
     data.storm_file = (Path() / 'isaac.storm').resolve()
 
     # Convert ATCF data to GeoClaw format
@@ -443,6 +444,10 @@ def setgeo(rundata):
         isaac.file_paths.append((Path() / "isaac.nc").resolve())
 
         isaac.write(data.storm_file, file_format='OWI')
+    elif data.storm_specification_type == 'netcdf':
+        isaac.data_file_format = "NWS13"
+        isaac.file_paths.append((Path() / "isaac.nc").resolve())
+        isaac.write(data.storm_file, file_format='netcdf')
 
     else:
         raise ValueError("Invalid storm specification type.")

--- a/examples/storm-surge/isaac/setrun.py
+++ b/examples/storm-surge/isaac/setrun.py
@@ -400,54 +400,49 @@ def setgeo(rundata):
     data.display_landfall_time = True
 
     # AMR parameters, m/s and m respectively
-    data.wind_refine = [20.0, 40.0, 60.0]
-    data.R_refine = [60.0e3, 40e3, 20e3]
+    import pandas as pd
+    import xarray as xr
+    data.wind_refine = pd.DataFrame([[20.0], [40.0], [60.0]])
+    data.R_refine = xr.DataArray([60.0e3, 40e3, 20e3])
 
     # Storm parameters - Parameterized storm (Holland 1980)
-    data.storm_specification_type = 'holland80'  # (type 1)
-    # data.storm_specification_type = 'OWI'
-    data.storm_specification_type = 'netcdf'
+    # data.storm_specification_type = 'holland80'
+    data.storm_specification_type = 'data'
     data.storm_file = (Path() / 'isaac.storm').resolve()
-
-    # Convert ATCF data to GeoClaw format
-    clawutil.data.get_remote_file(
-                   "http://ftp.nhc.noaa.gov/atcf/archive/2012/bal092012.dat.gz")
-    atcf_path = scratch_dir / "bal092012.dat"
-    # Note that the get_remote_file function does not support gzip files which
-    # are not also tar files.  The following code handles this
-    with gzip.open(atcf_path.with_suffix(".dat.gz"), 'rb') as atcf_file,    \
-            open(atcf_path, 'w') as atcf_unzipped_file:
-        atcf_unzipped_file.write(atcf_file.read().decode('ascii'))
-
-    # Uncomment/comment out to use the old version of the Ike storm file
-    isaac = Storm(path=atcf_path, file_format="ATCF")
-
+    isaac = Storm()
     # Calculate landfall time - Need to specify as the file above does not
     # include this info (~2345 UTC - 6:45 p.m. CDT - on August 28)
     isaac.time_offset = np.datetime64("2012-08-29T00:00")
 
-    if data.storm_specification_type == "holland80":
+    if data.storm_specification_type == 'holland80':
+        # Convert ATCF data to GeoClaw format
+        clawutil.data.get_remote_file(
+                       "http://ftp.nhc.noaa.gov/atcf/archive/2012/bal092012.dat.gz")
+        atcf_path = scratch_dir / "bal092012.dat"
+        # Note that the get_remote_file function does not support gzip files which
+        # are not also tar files.  The following code handles this
+        with gzip.open(atcf_path.with_suffix(".dat.gz"), 'rb') as atcf_file,    \
+                open(atcf_path, 'w') as atcf_unzipped_file:
+            atcf_unzipped_file.write(atcf_file.read().decode('ascii'))
+
+        # Uncomment/comment out to use the old version of the Ike storm file
+        isaac.read(path=atcf_path, file_format="ATCF")
+
         isaac.write(data.storm_file, file_format='geoclaw')
 
-    elif data.storm_specification_type == "OWI":
-
-        # :TODO: write out Isaac fields into appropriate file format, currently
-        # we are just storing the files as is
-
+    elif data.storm_specification_type == "data":
         # ASCII
-        # isaac.data_file_format = 'NWS12'
-        # isaac.file_paths.append((Path() / "isaac.PRE").resolve())
-        # isaac.file_paths.append((Path() / "isaac.WIN").resolve())
+        isaac.file_format = 'NWS12'
+        isaac.file_paths.append((Path() / "isaac.PRE").resolve())
+        isaac.file_paths.append((Path() / "isaac.WIN").resolve())
 
-        # NetCDF file
-        isaac.data_file_format = "NWS13"
-        isaac.file_paths.append((Path() / "isaac.nc").resolve())
+        # NetCDF
+        # isaac.file_format = "NWS13"
+        # isaac.file_paths.append((Path() / "isaac.nc").resolve())
+        # # For NetCDF we need to set this to the epoch or things do not work yet
+        # isaac.time_offset = np.datetime64("1970-01-01")
 
-        isaac.write(data.storm_file, file_format='OWI')
-    elif data.storm_specification_type == 'netcdf':
-        isaac.data_file_format = "NWS13"
-        isaac.file_paths.append((Path() / "isaac.nc").resolve())
-        isaac.write(data.storm_file, file_format='netcdf')
+        isaac.write(data.storm_file, file_format='data')
 
     else:
         raise ValueError("Invalid storm specification type.")

--- a/examples/storm-surge/isaac/test_storm.py
+++ b/examples/storm-surge/isaac/test_storm.py
@@ -6,34 +6,75 @@ import pytest
 import numpy as np
 
 import clawpack.geoclaw.surge.storm
+import clawpack.geoclaw.util as util
 
-data_file_format_map = {1: ["ascii", 1, "nws12"], 
-                        2: ["netcdf", 2, "nws13"]}
+file_format_map = {1: ["ascii", 1, "nws12", "owi"], 
+                   2: ["netcdf", 2, "nws13"]}
 
-@pytest.mark.skip("Unimplemented test.")
-def test_geoclaw_storm():
-    """Test of Storm geoclaw formatted I/O"""
-    assert False
+def create_netcdf_storm_file(path):
+    """"""
+    xr = pytest.importorskip("xarray")
+    size = (3, 5, 3)
+    coords = [('longitude', np.linspace(-1, 1, size[0])), 
+              ('latitude', np.linspace(-2, 2, size[1])), 
+              ('valid_time', np.linspace(0, 2, size[2]))]
+    wind_x = xr.DataArray(np.random.rand(*size),  coords=coords)
+    wind_y = xr.DataArray(np.random.rand(*size), coords=coords)
+    P = xr.DataArray(np.random.rand(*size), coords=coords)
+    ds = xr.Dataset({'u': wind_x, 'v': wind_y, 'pressure': P,})
+    ds.to_netcdf(path)
 
-@pytest.mark.parametrize("data_file_format", 
-                         ['ascii', 'netcdf', 1, 2, 'nws12', 'nws13'])
-def test_OWI_storm(data_file_format):
+
+@pytest.mark.parametrize("file_format", ['ascii', 'netcdf'])
+def test_data_storms(file_format, tmp_path):
     """Test of Storm OWI formatted I/O"""
+
+    storm_path = Path(tmp_path) / "test.storm"
     storm = clawpack.geoclaw.surge.storm.Storm()
     storm.time_offset = np.datetime64("2012-08-29")
-    storm.data_file_format = data_file_format
-    if data_file_format in ['ascii', 1, 'nws12']:
+    storm.file_format = file_format
+    storm.window_type = 1
+    storm.ramp_width = 3
+    if file_format == 'ascii':
         storm.file_paths = [Path("storm_1.PRE"), Path("storm_1.WIN"),
                             Path("storm_2.PRE"), Path("storm_2.WIN")]
+        storm.write(storm_path, file_format="data")
+        read_storm = clawpack.geoclaw.surge.storm.Storm(storm_path, 
+                                                        file_format="data")
     else:
-        storm.file_paths = [Path("storm.nc")]
-    storm.write(Path("test.storm"), file_format="OWI")
-    read_storm = clawpack.geoclaw.surge.storm.Storm(Path("test.storm"), 
-                                                    file_format="OWI")
-    assert (storm.time_offset == read_storm.time_offset)
-    assert (storm.data_file_format in
-            data_file_format_map[read_storm.data_file_format])
-    assert (storm.file_paths == read_storm.file_paths)
+        storm.file_paths = [tmp_path / "storm.nc"]
+        create_netcdf_storm_file(storm.file_paths[0])
+        storm.write(storm_path, file_format="data", 
+                                dim_mapping={"t": "valid_time"})
+        read_storm = clawpack.geoclaw.surge.storm.Storm(storm_path, 
+                                                        file_format="data")
 
-if __name__ == '__main__':
-    test_OWI_storm()
+    assert (storm.time_offset == read_storm.time_offset)
+    assert (storm.file_format in
+            file_format_map[read_storm.file_format])
+    assert (storm.window_type == read_storm.window_type)
+    assert (storm.ramp_width == read_storm.ramp_width)
+    for (i, path) in enumerate(storm.file_paths):
+        assert read_storm.file_paths[i] == path
+
+
+def test_netcdf_var_mapping(tmp_path):
+    """Test NetCDF file reading"""
+
+    storm_data_file = Path(tmp_path) / "storm.nc"
+    create_netcdf_storm_file(storm_data_file)
+
+    # Test name finding
+    _dim_mapping = util.get_netcdf_names(storm_data_file, 
+                                         lookup_type='dim',
+                                         verbose=True,
+                                         user_mapping={'t': 'valid_time'})
+    _var_mapping = util.get_netcdf_names(storm_data_file, 
+                                         lookup_type='var',
+                                         verbose=True)
+    assert _dim_mapping == {'x': 'longitude', 
+                            'y': 'latitude', 
+                            't': 'valid_time'}
+    assert _var_mapping == {'wind_u': 'u', 
+                            'wind_v': 'v', 
+                            'pressure': 'pressure'}

--- a/src/2d/shallow/surge/data_storm_module.f90
+++ b/src/2d/shallow/surge/data_storm_module.f90
@@ -68,7 +68,7 @@ contains
         use netcdf
 #endif
 
-        use amr_module, only: t0
+        use amr_module, only: t0, tfinal
         use utility_module, only: to_upper, check_netcdf_error
         use utility_module, only: seconds_from_epoch, ISO_time_format
 
@@ -203,6 +203,7 @@ contains
                 case(2)
 #ifdef NETCDF                    
                     ! Open file and get file ID
+                    ! :TODO: Only read in times that are between t0 and tfinal
                     print *, "Reading storm NetCDF file ", storm%paths(1)
                     call check_netcdf_error(nf90_open(storm%paths(1), nf90_nowrite, nc_fid))
                     ! Check dim/var number

--- a/src/2d/shallow/surge/data_storm_module.f90
+++ b/src/2d/shallow/surge/data_storm_module.f90
@@ -82,10 +82,7 @@ contains
         
         ! NetCDF
         integer :: nc_fid, num_dims, num_vars, var_id
-        character(len=16) :: dim_names(3), var_names(3)
-
-        ! DEBUG
-        character(len=256) :: line
+        character(len=16) :: name, dim_names(3), var_names(3)
 
         if (.not.module_setup) then
             ! Open data file
@@ -195,7 +192,15 @@ contains
                         print *, "  num_dims = ", num_dims
                         print *, "  num_vars = ", num_vars
                         stop
-                    end if  
+                    end if
+
+                    ! Get dimensions
+                    call check_netcdf_error(nf90_inq_dimid(nc_fid, dim_names(1), var_ID))
+                    call check_netcdf_error(nf90_inquire_dimension(nc_fid, var_ID, name, mx))
+                    call check_netcdf_error(nf90_inq_dimid(nc_fid, dim_names(2), var_ID))
+                    call check_netcdf_error(nf90_inquire_dimension(nc_fid, var_ID, name, my))
+                    call check_netcdf_error(nf90_inq_dimid(nc_fid, dim_names(3), var_ID))
+                    call check_netcdf_error(nf90_inquire_dimension(nc_fid, var_ID, name, mt))
 
                     ! allocate arrays in storm object
                     allocate(storm%pressure(mx, my, mt))
@@ -224,10 +229,6 @@ contains
 
                     ! Close file to stop corrupting the netcdf files
                     call check_netcdf_error(nf90_close(nc_fid))
-
-                    ! print "('t    = ', 3D25.16)", storm%time(1:3)
-                    print *, storm%time
-                    stop
 #else
                     print *, "GeoClaw was not compiled with NetCDF support."
                     stop

--- a/src/2d/shallow/surge/data_storm_module.f90
+++ b/src/2d/shallow/surge/data_storm_module.f90
@@ -142,7 +142,7 @@ contains
             close(data_unit)
 
             write(log_unit, "('Landfall = ',a)") storm%landfall
-            write(log_unit, "('Format = ',i2)") file_format
+            ! write(log_unit, "('Format = ',i2)") file_format
             write(log_unit, "('dims = ',a)") dim_names
             write(log_unit, "('vars = ',a)") var_names
             write(log_unit, *) "File Paths = ", storm%paths(1)
@@ -177,30 +177,22 @@ contains
             ! Number of time steps in data
             storm%num_casts = mt
             
-            ! Fill out variable data/info
-            do n = 1, nvars
-                ! read file for one variable and parse the data in storm object
-                call check_netcdf_error(nf90_inquire_variable(nc_fid, n, var_name, var_type, num_dims, dim_ids))
-                if ('PRESSURE' == to_upper(var_name)) then
-                    call check_netcdf_error(nf90_inq_varid(nc_fid, var_name, var_id))
-                    call check_netcdf_error(nf90_get_var(nc_fid, var_id, storm%pressure))
-                elseif(ANY((/'LON      ','LONGITUDE'/) == to_upper(var_name))) then
-                    call check_netcdf_error(nf90_inq_varid(nc_fid, var_name, var_id))
-                    call check_netcdf_error(nf90_get_var(nc_fid, var_id, storm%longitude))
-                elseif(ANY((/'LAT     ', 'LATITUDE'/) == to_upper(var_name))) then
-                    call check_netcdf_error(nf90_inq_varid(nc_fid, var_name, var_id))
-                    call check_netcdf_error(nf90_get_var(nc_fid, var_id, storm%latitude))
-                elseif(ANY((/'TIME', 'T   '/) == to_upper(var_name))) then
-                    call check_netcdf_error(nf90_inq_varid(nc_fid, var_name, var_id))
-                    call check_netcdf_error(nf90_get_var(nc_fid, var_id, storm%time))
-                elseif(ANY((/'U     ', 'WIND_U', 'UU    '/) == to_upper(var_name))) then
-                    call check_netcdf_error(nf90_inq_varid(nc_fid, var_name, var_id))
-                    call check_netcdf_error(nf90_get_var(nc_fid, var_id, storm%wind_u))
-                elseif(ANY((/'V     ', 'WIND_V', 'VV    '/) == to_upper(var_name))) then
-                    call check_netcdf_error(nf90_inq_varid(nc_fid, var_name, var_id))
-                    call check_netcdf_error(nf90_get_var(nc_fid, var_id, storm%wind_v))
-                end if
-            end do
+            ! Dimensions
+            call check_netcdf_error(nf90_inq_varid(nc_fid, dim_names(1), var_ID))
+            call check_netcdf_error(nf90_get_var(nc_fid, var_ID, storm%longitude))
+            call check_netcdf_error(nf90_inq_varid(nc_fid, dim_names(2), var_ID))
+            call check_netcdf_error(nf90_get_var(nc_fid, var_ID, storm%latitude))
+            call check_netcdf_error(nf90_inq_varid(nc_fid, dim_names(3), var_ID))
+            call check_netcdf_error(nf90_get_var(nc_fid, var_ID, storm%time))
+            
+            ! Wind
+            call check_netcdf_error(nf90_inq_varid(nc_fid, var_names(1), var_ID))
+            call check_netcdf_error(nf90_get_var(nc_fid, var_ID, storm%wind_u))
+            call check_netcdf_error(nf90_inq_varid(nc_fid, var_names(2), var_ID))
+            call check_netcdf_error(nf90_get_var(nc_fid, var_ID, storm%wind_v))
+            ! Pressure
+            call check_netcdf_error(nf90_inq_varid(nc_fid, var_names(3), var_ID))
+            call check_netcdf_error(nf90_get_var(nc_fid, var_ID, storm%pressure))
 
             ! Close file to stop corrupting the netcdf files
             call check_netcdf_error(nf90_close(nc_fid))

--- a/src/2d/shallow/surge/data_storm_module.f90
+++ b/src/2d/shallow/surge/data_storm_module.f90
@@ -76,8 +76,8 @@ contains
         integer, intent(in) :: storm_spec_type, log_unit
 
         ! General data
-        integer :: i, io_status, file_format, num_data_files
         integer, parameter :: data_unit = 10
+        integer :: i, io_status, file_format, num_data_files
         integer :: mt, mx, my, time(6, 2)
 
         ! ASCII

--- a/src/2d/shallow/surge/storm_module.f90
+++ b/src/2d/shallow/surge/storm_module.f90
@@ -116,8 +116,7 @@ contains
         use model_storm_module, only: set_willoughby_fields
 
         use data_storm_module, only: set_data_storm => set_storm
-        use data_storm_module, only: set_netcdf_fields
-        use data_storm_module, only: set_owi_fields
+        use data_storm_module, only: set_ascii_fields, set_netcdf_fields
 
         use utility_module, only: get_value_count
 
@@ -240,15 +239,7 @@ contains
                 call set_model_storm(storm_file_path, model_storm,         &
                                      storm_specification_type, log_unit)
             else if (storm_specification_type < 0) then
-                select case(storm_specification_type)
-                    case(-1) ! NetCDF
-                        set_data_fields => set_netcdf_fields
-                    case(-2) ! OWI
-                        set_data_fields => set_OWI_fields
-                    case default
-                        print *, "Storm specification data type ",               &
-                                    storm_specification_type, "not available."
-                end select
+                set_data_fields => set_ascii_fields
                 call set_data_storm(storm_file_path, data_storm, &
                                     storm_specification_type, log_unit) 
             end if

--- a/src/2d/shallow/surge/storm_module.f90
+++ b/src/2d/shallow/surge/storm_module.f90
@@ -116,7 +116,7 @@ contains
         use model_storm_module, only: set_willoughby_fields
 
         use data_storm_module, only: set_data_storm => set_storm
-        use data_storm_module, only: set_HWRF_fields
+        use data_storm_module, only: set_netcdf_fields
         use data_storm_module, only: set_owi_fields
 
         use utility_module, only: get_value_count
@@ -241,8 +241,8 @@ contains
                                      storm_specification_type, log_unit)
             else if (storm_specification_type < 0) then
                 select case(storm_specification_type)
-                    case(-1) ! HWRF
-                        set_data_fields => set_HWRF_fields
+                    case(-1) ! NetCDF
+                        set_data_fields => set_netcdf_fields
                     case(-2) ! OWI
                         set_data_fields => set_OWI_fields
                     case default

--- a/src/2d/shallow/topo_module.f90
+++ b/src/2d/shallow/topo_module.f90
@@ -1511,6 +1511,7 @@ subroutine intersection(indicator,area,xintlo,xinthi, &
 
 end subroutine intersection
 
+! :TODO: Use the utility module's version of these
 #ifdef NETCDF
     subroutine check_netcdf_error(ios)
 

--- a/src/2d/shallow/utility_module.f90
+++ b/src/2d/shallow/utility_module.f90
@@ -135,6 +135,31 @@ contains
 
     end subroutine parse_values
 
+    ! === Geometry Functions ===================================================
+    !
+    
+    !  point_in_rectangle(p, rect) - Returns whether p is in rect.
+    !    real(kind=8) :: p(2), rect(4)
+    !    rect is in the format (lower x, lower y, upper x, upper y)
+    pure logical function point_in_rectangle(p, rect)
+        implicit none
+        real(kind=8), intent(in) :: p(2), rect(4)
+        point_in_rectangle = p(1) >= rect(1) .and. p(1) <= rect(3) .and. &
+                             p(2) >= rect(2) .and. p(2) <= rect(4)
+    end function point_in_rectangle
+
+    !  rects_intersect(rect1, rect2) - Returns whether rectangles intersect
+    !    real(kind=8) :: rect1(4), rect2(4)
+    !    rects are in the format (lower x, lower y, upper x, upper y)
+    pure logical function rects_intersect(rect1, rect2)
+        implicit none
+        real(kind=8), intent(in) :: rect1(4), rect2(4)
+        rects_intersect = .not. (rect1(3) < rect2(1) .or.  &
+                                 rect1(4) < rect2(2) .or.  &
+                                 rect1(1) > rect2(3) .or.  &
+                                 rect1(2) > rect2(4))
+    end function rects_intersect
+
     ! ==========================================================================
     ! seconds_from_epoch() Calculates seconds from UNIX epoch (1970) from a
     ! datetime. Returns the total seconds from the epoch includes leap years and

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -537,7 +537,7 @@ class SurgeData(clawpack.clawutil.data.ClawData):
 
     # Provide some mapping between model names and integers
     storm_spec_dict_mapping = {'owi': -2,
-                               "hwrf": -1,
+                               "netcdf": -1,
                                None: 0,
                                'holland80': 1,
                                'holland08': 8,

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -15,7 +15,7 @@ Classes representing parameters for GeoClaw runs
  - QinitData
  - SurgeData
  - MultilayerData
- - FrictionData 
+ - FrictionData
  - BoussData
  - GridData1D
  - BoussData1D
@@ -358,16 +358,16 @@ class FGmaxData(clawpack.clawutil.data.ClawData):
                         self.num_fgmax_val = int(value)
                     elif varname == "num_fgmax_grids":
                         num_fgmax_grids = int(value)
-                
+
                 # Contains a fixed grid number
                 elif "# fgno" in line:
                     value, tail = line.split("#")
                     fig_numbers.append(int(value))
 
         if len(fig_numbers) != num_fgmax_grids:
-            raise ValueError("Number of FGMaxGrid numbers found does not ", 
+            raise ValueError("Number of FGMaxGrid numbers found does not ",
                              "equal the number of grids recorded.")
-        
+
         # Read each fgmax grid
         import clawpack.geoclaw.fgmax_tools
         for (i, grid_num) in enumerate(fig_numbers):
@@ -594,7 +594,7 @@ class SurgeData(clawpack.clawutil.data.ClawData):
                 raise ValueError("Unknown rotation_override specification.")
         else:
             self.rotation_override = int(self.rotation_override)
-        self.data_write('rotation_override', 
+        self.data_write('rotation_override',
                         description="(Override storm rotation)")
         self.data_write()
 
@@ -673,6 +673,44 @@ class FrictionData(clawpack.clawutil.data.ClawData):
         # File support
         self.add_attribute('friction_files', [])
 
+
+    def read(self, path="friction.data", force=False):
+        r"""Read friction data file"""
+
+        with open(os.path.abspath(path), 'r') as data_file:
+            # Header
+            data_file.readline()
+            data_file.readline()
+            data_file.readline()
+            data_file.readline()
+            data_file.readline()
+            data_file.readline()
+
+            # Generic data
+            self.variable_friction = bool(data_file.readline().split("=:")[0])
+            self.friction_index = int(data_file.readline().split("=:")[0])
+            data_file.readline()
+            num_regions = int(data_file.readline().split("=:")[0])
+            data_file.readline()
+            # Regions
+            self.friction_regions = []
+            for n in range(num_regions):
+                lower = self._convert_line(data_file.readline())
+                upper = self._convert_line(data_file.readline())
+                depths = self._convert_line(data_file.readline())
+                coeff = self._convert_line(data_file.readline())
+                self.friction_regions.append([lower, upper, depths, coeff])
+                data_file.readline()
+            self.friction_files = [] # Is not supported
+
+    def _convert_line(self, line):
+        values = []
+        for value in line.split("=:")[0].split(" "):
+            if len(value) > 1:
+                values.append(float(value))
+        return values
+
+
     def write(self, out_file='friction.data', data_source='setrun.py'):
 
         self.open_data_file(out_file, data_source)
@@ -703,7 +741,8 @@ class FrictionData(clawpack.clawutil.data.ClawData):
             for friction_file in self.friction_files:
                 # if path is relative in setrun, assume it's relative to the
                 # same directory that out_file comes from
-                fname = os.path.abspath(os.path.join(os.path.dirname(out_file),friction_file))
+                fname = os.path.abspath(os.path.join(os.path.dirname(out_file),
+                                                     friction_file))
                 self._out_file.write("'%s' %s\n " % fname)
 
         self.close_data_file()

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -536,8 +536,7 @@ class SurgeData(clawpack.clawutil.data.ClawData):
     r"""Data object describing storm surge related parameters"""
 
     # Provide some mapping between model names and integers
-    storm_spec_dict_mapping = {'owi': -2,
-                               "netcdf": -1,
+    storm_spec_dict_mapping = {"data": -1,
                                None: 0,
                                'holland80': 1,
                                'holland08': 8,

--- a/src/python/geoclaw/surge/plot.py
+++ b/src/python/geoclaw/surge/plot.py
@@ -45,6 +45,29 @@ land_cmap = geoplot.land_colors
 
 surge_data = geodata.SurgeData()
 
+# ===========================
+#  General Drawing Functions
+# ===========================
+def draw_box(ax, box, style='r-', fill=True):
+    r"""Draw the box specified
+
+    :Input:
+     - *ax* (matplotlib.Axes) axes object to plot on
+     - *box* (list) set of coordinates defined box.  First two coordinates are 
+       the lower left corner and the last two coordiantes are the upper corner.
+     - *style* (str) string that will be used to specify the style of the lines.
+       Default = *'r-'*.
+     - *fill* (bool) If True draws a filled box.  Not implemented.
+
+    :TODO:
+     - Handle fill request
+    """
+    ax.plot([box[0], box[2]], [box[1], box[1]], style) # Bottom
+    ax.plot([box[0], box[2]], [box[3], box[3]], style) # Top
+    ax.plot([box[0], box[0]], [box[1], box[3]], style) # Left
+    ax.plot([box[2], box[2]], [box[1], box[3]], style) # Right
+
+
 # ==============================
 #  Track Plotting Functionality
 # ==============================

--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -924,25 +924,34 @@ class Storm(object):
         with path.open() as data_file:
             data_file.readline()
             self.time_offset = np.datetime64(data_file.readline()[:19])
-            self.file_format = int(data_file.readline().partition("#")[0].rstrip())
+            self.file_format = int(
+                                data_file.readline().partition("#")[0].rstrip())
             num_files = int(data_file.readline().partition("#")[0].rstrip())
+            self.window_type = int(
+                                data_file.readline().partition("#")[0].rstrip())
+            self.ramp_width = float(
+                                data_file.readline().partition("#")[0].rstrip())
+            # self.window = [value for value in 
+            #             data_file.readline().partition("#")[0].rstrip().split()]
+            data_file.readline()
             data_file.readline()
             data_file.readline()
 
             # We do not keep track of any of the format specific information
             if self.file_format == 1:
-                self.readline()
-                self.readline()
+                data_file.readline()
+                data_file.readline()
             elif self.file_format == 2:
-                self.readline()
-                self.readline()
-                self.readline()
+                data_file.readline()
+                data_file.readline()
+                data_file.readline()
+                data_file.readline()
             else:
                 raise TypeError(f"Unknown storm data file format type" +
                                 f" '{self.file_format}' provided.")
 
             for i in range(num_files):
-                self.file_paths.append(self.readline())
+                self.file_paths.append(Path(data_file.readline().rstrip()))
 
 
     # =========================================================================

--- a/src/python/geoclaw/surge/storm.py
+++ b/src/python/geoclaw/surge/storm.py
@@ -1287,8 +1287,8 @@ class Storm(object):
                 data_file.write(f"{str(_dim_mapping['x'])} ")
                 data_file.write(f"{str(_dim_mapping['y'])} ")
                 data_file.write(f"{str(_dim_mapping['t'])}\n")
-                data_file.write(f"{str(_var_mapping['wind_x'])} ")
-                data_file.write(f"{str(_var_mapping['wind_y'])} ")
+                data_file.write(f"{str(_var_mapping['wind_u'])} ")
+                data_file.write(f"{str(_var_mapping['wind_v'])} ")
                 data_file.write(f"{str(_var_mapping['pressure'])}\n")
                 data_file.write("\n")
 

--- a/src/python/geoclaw/util.py
+++ b/src/python/geoclaw/util.py
@@ -372,13 +372,13 @@ def get_netcdf_names(path, lookup_type='dim', user_mapping=None, verbose=False):
     return var_names
     
 
-def wrap_coordinates(input_path, output_path=None, force=False, dim_mapping=None):
+def wrap_coords(input_path, output_path=None, force=False, dim_mapping=None):
     r"""Wrap the x coordinates of a NetCDF file from [0, 360] to [-180, 180]
 
     :Input:
      - *input_path* (path) Path to input file.
      - *output_path* (path) Path to output file.  Default is slightly modified
-       version of *input_path* with 'swap' appended.
+       version of *input_path* with 'wrap' appended.
      - *force* (bool) By default this routine will not overwrite a file that
        alreaady exists.  The value *force = True* will overwrite the file.  
        Default is False
@@ -387,17 +387,19 @@ def wrap_coordinates(input_path, output_path=None, force=False, dim_mapping=None
     """
 
     if not output_path:
-        output_path = input_path.parent / f"{input_path.stem}_swap{input_path.suffix}"
+        output_path = (input_path.parent / 
+                                f"{input_path.stem}_wrap{input_path.suffix}")
 
     if not output_path.exists() or force:
         dim_mapping = util.get_netcdf_names(input_path, lookup_type='dim', 
-                                                        user_mapping=dim_mapping)
+                                                       user_mapping=dim_mapping)
         ds = xr.open_dataset(input_path)
         lon_atrib = ds.coords[dim_mapping['x']].attrs
-        ds.coords[dim_mapping['x']] = (ds.coords[dim_mapping['x']] + 180) % 360 - 180
-        swapped_ds = ds.sortby(ds[dim_mapping['x']])
-        swapped_ds.coords[dim_mapping['x']].attrs = lon_atrib
-        swapped_ds.to_netcdf(output_path)
+        ds.coords[dim_mapping['x']] = \
+                                (ds.coords[dim_mapping['x']] + 180) % 360 - 180
+        wrapped_ds = ds.sortby(ds[dim_mapping['x']])
+        wrapped_ds.coords[dim_mapping['x']].attrs = lon_atrib
+        wrapped_ds.to_netcdf(output_path)
 
 
 def fetch_noaa_tide_data(station, begin_date, end_date, time_zone='GMT',

--- a/src/python/geoclaw/util.py
+++ b/src/python/geoclaw/util.py
@@ -386,12 +386,14 @@ def wrap_coords(input_path, output_path=None, force=False, dim_mapping=None):
        file, not just 'x'.  Default is {}.
     """
 
+    import xarray as xr
+
     if not output_path:
         output_path = (input_path.parent / 
                                 f"{input_path.stem}_wrap{input_path.suffix}")
 
     if not output_path.exists() or force:
-        dim_mapping = util.get_netcdf_names(input_path, lookup_type='dim', 
+        dim_mapping = get_netcdf_names(input_path, lookup_type='dim', 
                                                        user_mapping=dim_mapping)
         ds = xr.open_dataset(input_path)
         lon_atrib = ds.coords[dim_mapping['x']].attrs

--- a/src/python/geoclaw/util.py
+++ b/src/python/geoclaw/util.py
@@ -275,6 +275,11 @@ def gctransect(x1,y1,x2,y2,npts,coords='W',units='degrees',Rearth=Rearth):
 def get_netcdf_names(path, lookup_type='dim', user_mapping=None, verbose=False):
     r"""Determine names of dimensions/variables in the NetCDF file at *path*
 
+    Note that if a file has multiple matching variables that the first it finds
+    will be the one used.  It is best practice to provide the label if there
+    are multiple available, e.g. 'msl' (mean sealevel pressure) and 'sp'
+    (surface pressure) for pressure.
+
     Default dimension mapping:
      - "x": ["x", "longitude", "lon"]
      - "y": ["y", "latitude", "lat"]
@@ -282,9 +287,9 @@ def get_netcdf_names(path, lookup_type='dim', user_mapping=None, verbose=False):
      - "t": ["t", "time"]
 
     Default variable mapping:
-     - "wind_x":   ["wind_x", "u10", "u"]
-     - "wind_y":   ["wind_y", "v10", "v"]
-     - "pressure": ["pressure"]
+     - "wind_u":   ["wind_x", "wind_u", "u10", "u"]
+     - "wind_v":   ["wind_y", "wind_v", "v10", "v"]
+     - "pressure": ["pressure", "msl", "sp"]
      - "topo":     ["topo", "elevation", "z", "band1"]
 
     :Input:
@@ -323,9 +328,9 @@ def get_netcdf_names(path, lookup_type='dim', user_mapping=None, verbose=False):
         else:
             raise ValueError(f"{len(var_names)} present, not sure what to do.")
     elif 'var' in lookup_type.lower():
-        _var_mapping = {"wind_x":   (False, ["wind_x", "u10", "u"]),
-                        "wind_y":   (False, ["wind_y", "v10", "v"]),
-                        "pressure": (False, ["pressure"]),
+        _var_mapping = {"wind_u":   (False, ["wind_u", "wind_x", "u10", "u"]),
+                        "wind_v":   (False, ["wind_v", "wind_y", "v10", "v"]),
+                        "pressure": (False, ["pressure", "msl", "sp"]),
                         "topo":     (False, ["topo", "elevation", "z", "band1"])
                }
         var_names = [var_name.lower() for var_name in data.keys()]


### PR DESCRIPTION
This adds general support for reading and interpolating storms from NetCDF data.  It generalizes the previous support for OWI format storms, both the ASCII and NetCDF file formats.  This PR includes
- New functionality in the `storm` module and ways of specifying date based storms.  See the examples for more details on how we now support specification.
- Moved some common utility functions to the `utility_module.f90`.  Ongoing process to remove all duplicate code.
- Streamlined and made more robust reading of NetCDF storm files.
- Provides functionality for specifying a window for which the storm fields will be applied and interpolated onto with the corresponding ramping function.  Default is to use the entire domain.
- Provides two new utility functions for NetCDF files:
  1. `wrap_coords`: Coordinate wrapping for NetCDF files.  If the file has coordinates that go from longitude = [0, 360] this function will wrap and output the file in [-180, 180].  Probably could easily be modified to not use the prime meridian as the zero point, e.g. the [anit-prime-meridian](https://en.wikipedia.org/wiki/Prime_meridian).  Has been tested on topography as well as storm files.
  2. `get_netcdf_names`: Provides NetCDF file dimension and variable name introspection.  This can inspect a NetCDF file and try to determine the names of common coordinate dimensions and variable names so that they can be passed into Fortran rather than discovering them inside of Fortran code.  Currently has built-in names for storms and topography.