### PR TITLE
Move `b4step` call out of `stepgrid` and into `advanc`

### DIFF
--- a/src/2d/bouss/advanc_splitRev2Calls.f
+++ b/src/2d/bouss/advanc_splitRev2Calls.f
@@ -311,8 +311,11 @@ c
       rvoll(level) = rvoll(level) + nx * ny
 !$OMP END CRITICAL(rv)
 
-
+c     Call b4step2 here so that time dependent arrays can be filled properly
       locaux = node(storeaux,mptr)
+      call b4step2(nghost, nx, ny, nvar, alloc(locnew), 
+     &             rnode(cornxlo,mptr), rnode(cornylo,mptr), hx, hy, 
+     &             time, dt, naux, alloc(locaux))
 c
       if (node(ffluxptr,mptr) .ne. 0) then
          lenbc  = 2*(nx/intratx(level-1)+ny/intraty(level-1))

--- a/src/2d/bouss/stepgrid.f
+++ b/src/2d/bouss/stepgrid.f
@@ -157,8 +157,9 @@ c     This has been moved to tick.f, after advancing all patches on
 c     finest level.  No need to check on each patch separately.
 c::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-       call b4step2(mbc,mx,my,nvar,q,
-     &             xlowmbc,ylowmbc,dx,dy,time,dt,maux,aux,actualstep)
+c      This call has been moved out to advanc
+c       call b4step2(mbc,mx,my,nvar,q,
+c     &             xlowmbc,ylowmbc,dx,dy,time,dt,maux,aux,actualstep)
       
 c::::::::::::::::::::::::FGOUT DATA before step:::::::::::::::::::::::
 c     # fill in values at fgout points affected at time tc0

--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -221,8 +221,11 @@ c
       rvoll(level) = rvoll(level) + nx * ny
 !$OMP END CRITICAL(rv)
 
-
+c     Call b4step2 here so that time dependent arrays can be filled properly
       locaux = node(storeaux,mptr)
+      call b4step2(nghost, nx, ny, nvar, alloc(locnew), 
+     &             rnode(cornxlo,mptr), rnode(cornylo,mptr), hx, hy, 
+     &             time, dt, naux, alloc(locaux))
 c
       if (node(ffluxptr,mptr) .ne. 0) then
          lenbc  = 2*(nx/intratx(level-1)+ny/intraty(level-1))

--- a/src/2d/shallow/stepgrid.f
+++ b/src/2d/shallow/stepgrid.f
@@ -149,8 +149,9 @@ c     This has been moved to tick.f, after advancing all patches on
 c     finest level.  No need to check on each patch separately.
 c::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::
 
-       call b4step2(mbc,mx,my,nvar,q,
-     &             xlowmbc,ylowmbc,dx,dy,time,dt,maux,aux,actualstep)
+c      This call has been moved out to advanc
+c       call b4step2(mbc,mx,my,nvar,q,
+c     &              xlowmbc,ylowmbc,dx,dy,time,dt,maux,aux,actualstep)
       
 c::::::::::::::::::::::::FGOUT DATA before step:::::::::::::::::::::::
 c     # fill in values at fgout points affected at time tc0


### PR DESCRIPTION
This moves `b4step` so that it is called before `qad` and gauges are recorded so that the `aux` array can be filled properly if needed, e.g. when `aux` is time dependent.  This fixes #653 and the equivalent change in AMRClaw is [here](https://github.com/clawpack/amrclaw/pull/303).