### PR TITLE
echo INCLUDE when doing make check in bouss/radial_flat

### DIFF
--- a/examples/bouss/radial_flat/Makefile
+++ b/examples/bouss/radial_flat/Makefile
@@ -126,6 +126,7 @@ check:
 	@env | grep PETSC_OPTIONS
 	@echo PETSC_DIR = $(PETSC_DIR)
 	@echo PETSC_ARCH = $(PETSC_ARCH)
+	@echo INCLUDE = $(INCLUDE)
 	@echo CLAW_MPIEXEC = $(CLAW_MPIEXEC)
 	@echo RUNEXE = $(RUNEXE)
 	@echo EXE = $(EXE)


### PR DESCRIPTION
I found this useful when debugging a new install.