### PR TITLE
Improve kmltools for regions / lines crossing the dateline

### DIFF
--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -351,7 +351,7 @@ def regions2kml(rundata=None,fname='regions.kml',verbose=True,combined=True):
                 xge = xge + 360.
             if x.min() < -180 or x.max() > 180:
                 # cannot deal with this case easily
-                print('+++ polygon spans date line, might not display properly')
+                print('*** polygon spans date line, might not display properly')
 
             v = "\n"
             for j in range(len(x)):
@@ -603,7 +603,7 @@ def poly2kml(xy,fname=None,name='poly',color='00FF00', width=3,
         xge = xge + 360.
     if x.min() < -180 or x.max() > 180:
         # cannot deal with this case easily
-        print('+++ polygon spans date line, might not display properly')
+        print('*** polygon spans date line, might not display properly')
 
     v = "\n"
     for j in range(len(x)):
@@ -737,21 +737,18 @@ def kml_footer():
 
 def kml_region(mapping, vertex_text=None):
 
-    print('+++ vertex_text = ', vertex_text)
     # if all x values are > 180 or all are < -180 shift the values for plotting
     if 'x3' in mapping:
         xge = np.array([mapping['x1'], mapping['x2'], mapping['x3'],mapping['x4']])
     else:
         xge = np.array([mapping['x1'], mapping['x2']])
-    print('+++ initial xge = ',xge)
     if xge.min() > 180:
         xge = xge - 360.
     if xge.max() < -180:
         xge = xge + 360.
     if xge.min() < -180 or xge.max() > 180:
         # cannot deal with this case easily
-        print('+++ kml_region spans date line, might not display properly')
-    print('+++ final xge = ',xge)
+        print('*** kml_region spans date line, might not display properly')
 
     mapping['x1'] = xge[0]
     mapping['x2'] = xge[1]

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -346,11 +346,11 @@ def regions2kml(rundata=None,fname='regions.kml',verbose=True,combined=True):
         v = v + "%s,%s,%s\n" % (f2s(x[0]),f2s(y[0]),f2s(elev))
         v.replace(' ','')
 
-        region_text = kml_region(mapping, v)
+        region_text = kml_region(mapping)  #, v)
+        kml_text = kml_text + region_text
 
         fname = flagregion.name + '.kml'
-        region_text = kml_region(mapping, v)
-        kml_text = kml_text + region_text
+        #region_text = kml_region(mapping, v)
 
         if not combined:
             kml_text = kml_text + kml_footer()
@@ -699,6 +699,28 @@ def kml_footer():
 
 
 def kml_region(mapping, vertex_text=None):
+
+    print('+++ vertex_text = ', vertex_text)
+    # if all x values are > 180 or all are < -180 shift the values for plotting
+    if 'x3' in mapping:
+        xge = np.array([mapping['x1'], mapping['x2'], mapping['x3'],mapping['x4']])
+    else:
+        xge = np.array([mapping['x1'], mapping['x2']])
+    print('+++ initial xge = ',xge)
+    if xge.min() > 180:
+        xge = xge - 360.
+    if xge.max() < -180:
+        xge = xge + 360.
+    if xge.min() < -180 or xge.max() > 180:
+        print('+++ kml_region spans date line, might not display properly')
+    print('+++ final xge = ',xge)
+
+    mapping['x1'] = xge[0]
+    mapping['x2'] = xge[1]
+    if 'x3' in mapping:
+        mapping['x3'] = xge[2]
+        mapping['x4'] = xge[3]
+
 
     if vertex_text is None:
         if 'x3' in mapping:

--- a/src/python/geoclaw/kmltools.py
+++ b/src/python/geoclaw/kmltools.py
@@ -334,23 +334,36 @@ def regions2kml(rundata=None,fname='regions.kml',verbose=True,combined=True):
         mapping['width'] = 2
 
         if flagregion.spatial_region_type == 1:
-            x1,x2,y1,y2 = flagregion.spatial_region
-            x = [x1,x1,x2,x2,x1]
-            y = [y1,y2,y2,y1,y1]
+            #x1,x2,y1,y2 = flagregion.spatial_region
+            #x = [x1,x1,x2,x2,x1]
+            #y = [y1,y2,y2,y1,y1]
+            region_text = kml_region(mapping)  # mapping contains rectangle
         else:
+            # for Ruled Rectangles, must list all vertices:
             x,y = flagregion.spatial_region.vertices()
 
-        v = "\n"
-        for j in range(len(x)):
-            v = v + "%s,%s,%s\n" % (f2s(x[j]),f2s(y[j]),f2s(elev))
-        v = v + "%s,%s,%s\n" % (f2s(x[0]),f2s(y[0]),f2s(elev))
-        v.replace(' ','')
+            # if all x values are > 180 or all are < -180 shift the values
+            # for coordinates (original values still appear in description):
+            xge = np.array(x)
+            if xge.min() > 180:
+                xge = xge - 360.
+            if xge.max() < -180:
+                xge = xge + 360.
+            if x.min() < -180 or x.max() > 180:
+                # cannot deal with this case easily
+                print('+++ polygon spans date line, might not display properly')
 
-        region_text = kml_region(mapping)  #, v)
+            v = "\n"
+            for j in range(len(x)):
+                v = v + "%s,%s,%s\n" % (f2s(xge[j]),f2s(y[j]),f2s(elev))
+            v = v + "%s,%s,%s\n" % (f2s(xge[0]),f2s(y[0]),f2s(elev))
+            v.replace(' ','')
+
+            region_text = kml_region(mapping, v)
+
         kml_text = kml_text + region_text
 
         fname = flagregion.name + '.kml'
-        #region_text = kml_region(mapping, v)
 
         if not combined:
             kml_text = kml_text + kml_footer()
@@ -582,10 +595,20 @@ def poly2kml(xy,fname=None,name='poly',color='00FF00', width=3,
     mapping['color'] = color
     mapping['width'] = width
 
+    # if all x values are > 180 or all are < -180 shift the values for plotting
+    xge = np.array(x)
+    if xge.min() > 180:
+        xge = xge - 360.
+    if xge.max() < -180:
+        xge = xge + 360.
+    if x.min() < -180 or x.max() > 180:
+        # cannot deal with this case easily
+        print('+++ polygon spans date line, might not display properly')
+
     v = "\n"
     for j in range(len(x)):
-        v = v + "%s,%s,%s\n" % (f2s(x[j]),f2s(y[j]),f2s(elev))
-    v = v + "%s,%s,%s\n" % (f2s(x[0]),f2s(y[0]),f2s(elev))
+        v = v + "%s,%s,%s\n" % (f2s(xge[j]),f2s(y[j]),f2s(elev))
+    v = v + "%s,%s,%s\n" % (f2s(xge[0]),f2s(y[0]),f2s(elev))
     v.replace(' ','')
 
     region_text = kml_region(mapping, v)
@@ -655,15 +678,29 @@ def gauges2kml(rundata=None, fname='gauges.kml', verbose=True):
     for rnum,gauge in enumerate(gauges):
         t1,t2 = gauge[3:5]
         x1,y1 = gauge[1:3]
+
+        # adjust point location for GE so -180 <= xge <= 180:
+        if x1 < -180:
+            xge = x1+360
+        elif x1 > 180:
+            xge = x1-360
+        else:
+            xge = x1
+
         gaugeno = gauge[0]
         if verbose:
-            print("Gauge %i: %s, %s  \n" % (gaugeno,f2s(x1),f2s(y1)) \
-                    + "  t1 = %s,  t2 = %s" % (f2s(t1),f2s(t2)))
+            if xge == x1:
+                print("Gauge %i: x = %s, y = %s  \n" % (gaugeno,f2s(x1),f2s(y1)) \
+                        + "  t1 = %s,  t2 = %s" % (f2s(t1),f2s(t2)))
+            else:
+                print("Gauge %i: x = %s (%s), y = %s  \n" \
+                        % (gaugeno,f2s(x1),f2s(xge),f2s(y1)) \
+                        + "  t1 = %s,  t2 = %s" % (f2s(t1),f2s(t2)))
         mapping = {}
         mapping['gaugeno'] = gaugeno
         mapping['t1'] = t1
         mapping['t2'] = t2
-        mapping['x1'] = x1
+        mapping['x1'] = xge
         mapping['y1'] = y1
         mapping['elev'] = elev
         mapping['name'] = 'Gauge %i' % rnum
@@ -712,6 +749,7 @@ def kml_region(mapping, vertex_text=None):
     if xge.max() < -180:
         xge = xge + 360.
     if xge.min() < -180 or xge.max() > 180:
+        # cannot deal with this case easily
         print('+++ kml_region spans date line, might not display properly')
     print('+++ final xge = ',xge)
 


### PR DESCRIPTION
`kmltools.py` can be used to plot flagregions, extents of topo/dtopo files, gauge locations, transects, etc. on Google Earth, but doesn't always work well unless the longitude(s) are entirely in the range -180 <= x <= 180, which can be impossible if the computational domains crosses the dateline in the Pacific.  I was reminded of this recently when modeling the Kamchatka event with a domain having 140 <= x <= 210, in which case a flagregion around Maui might have longitude limits 203 <= x <= 204.  With the original kmltools this region displays ok, but clicking on it does not pop up the expected text box giving the flagregion parameters.  With the new version, these x values would be replaced by -157 <= x <= -156 in the location of the box, while still giving the original  setrun values 203 <= x <= 204 in the text box that now pops up properly.  Gauges in Hawaii also now show up properly, whereas before they did not show up at all sometimes.

So things now work better for boxes that are entirely above 180 or below -180.  Boxes spanning the dateline are still a problem: If each x value is mapped to a value between -180 and 180 then the box get drawn the wrong way around the earth and omits rather than includes the dateline.  I'm not sure how to fix this other than splitting such boxes into two pieces.  Fixing arbitrary polygons made with `kmltools.poly2kml` would be even harder, but doesn't seem worth worrying about for our applications.

This is a known issue with Google Earth and there are many discussions on the web but no simple solution I could find.
