### PR TITLE
suppress plot made by make_shoreline_xy

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -1716,6 +1716,7 @@ class Topography(object):
         x = self.x
         y = self.y
         Z = self.Z
+        fig = plt.figure()
         c = plt.contour(x,y,Z,[sea_level])
         # c is the level 0 contour as list of arrays, one for each segement
         # catenate these together separated by array([nan,nan]):
@@ -1723,6 +1724,7 @@ class Topography(object):
         for k in range(1,len(c.allsegs[0])):
             shoreline_xy = numpy.vstack((shoreline_xy, \
                            numpy.array([numpy.nan,numpy.nan]), c.allsegs[0][k]))
+        plt.close(fig)
         return shoreline_xy
 
 


### PR DESCRIPTION
`topotools.Topography.make_shoreline_xy` makes a contour plot only to extract the contour lines.
Close the figure so it doesn't appear when not wanted in a notebook.