### PR TITLE
fix bug in topotools.plot call to pcolorcells

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -1256,7 +1256,7 @@ class Topography(object):
                                                 marker=',', linewidths=(0.0,))
         else:
             plot = plottools.pcolorcells(self.X, self.Y, self.Z,
-                                         axes=axes, norm=norm, cmap=cmap)
+                                         ax=axes, norm=norm, cmap=cmap)
         if add_colorbar:
             try:
                 # this kwarg can't be passed directly:


### PR DESCRIPTION
parameter `axes` passed into `plot` is `ax` in call to `pcolorcells`