### PR TITLE
Fix dt passed uninitialized to b4step2

### DIFF
--- a/src/2d/bouss/advanc_splitRev2Calls.f
+++ b/src/2d/bouss/advanc_splitRev2Calls.f
@@ -315,7 +315,7 @@ c     Call b4step2 here so that time dependent arrays can be filled properly
       locaux = node(storeaux,mptr)
       call b4step2(nghost, nx, ny, nvar, alloc(locnew),
      &             rnode(cornxlo,mptr), rnode(cornylo,mptr), hx, hy,
-     &             time, dt, naux, alloc(locaux),.true.)
+     &             time, delt, naux, alloc(locaux),.true.)
 c
       if (node(ffluxptr,mptr) .ne. 0) then
          lenbc  = 2*(nx/intratx(level-1)+ny/intraty(level-1))

--- a/src/2d/shallow/advanc.f
+++ b/src/2d/shallow/advanc.f
@@ -225,7 +225,7 @@ c     Call b4step2 here so that time dependent arrays can be filled properly
       locaux = node(storeaux,mptr)
       call b4step2(nghost, nx, ny, nvar, alloc(locnew),
      &             rnode(cornxlo,mptr), rnode(cornylo,mptr), hx, hy,
-     &             time, dt, naux, alloc(locaux), .true.)
+     &             time, delt, naux, alloc(locaux), .true.)
 c
       if (node(ffluxptr,mptr) .ne. 0) then
          lenbc  = 2*(nx/intratx(level-1)+ny/intraty(level-1))


### PR DESCRIPTION
Fix uninitialized `dt `passed to `b4step2`  in `advanc`.