### PR TITLE
Phase F1: guard the storm-center assumption for gridded forcing

### DIFF
--- a/src/2d/bouss/valout.f90
+++ b/src/2d/bouss/valout.f90
@@ -15,7 +15,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
     use storm_module, only: storm_specification_type, output_storm_location
-    use storm_module, only: output_storm_location
+    use storm_module, only: storm_location_available
     use storm_module, only: landfall, display_landfall_time
 
 #ifdef HDF5
@@ -91,8 +91,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     out_aux = ((output_aux_num > 0) .and.               &
               ((.not. output_aux_onlyonce) .or. (abs(time - t0) < 1d-90)))
                 
-    ! Output storm track if needed
-    if (storm_specification_type /= 0) then
+    ! Output storm track if needed (parameterized storms only; gridded/data
+    ! forcing has no center to write).
+    if (storm_location_available) then
         call output_storm_location(time)
     end if
 

--- a/src/2d/shallow/flag2refine2.f90
+++ b/src/2d/shallow/flag2refine2.f90
@@ -29,6 +29,7 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
 
     use storm_module, only: storm_specification_type, wind_refine, R_refine
     use storm_module, only: storm_location, wind_forcing, wind_index, wind_refine
+    use storm_module, only: storm_location_available
 
     use regions_module, only: num_regions, regions
     use refinement_module, only: wave_tolerance, speed_tolerance
@@ -96,9 +97,10 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
             endif
 
             ! ************* Storm Based Refinement ****************
-            ! Check to see if we are some specified distance from the eye of
-            ! the storm and refine if we are
-            if (storm_specification_type /= 0) then
+            ! Distance-to-center (R_refine) refinement requires a storm center,
+            ! which only parameterized storms provide.  Gridded/data forcing
+            ! has no center and refines on wind speed alone
+            if (storm_location_available) then
                 R_eye = storm_location(t)
                 do m=1,min(size(R_refine), mxnest)
                     if (coordinate_system == 2) then
@@ -106,23 +108,23 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
                     else
                         ds = sqrt((x_c - R_eye(1))**2 + (y_c - R_eye(2))**2)
                     end if
-                    
+
                     if (ds < R_refine(m) .and. level <= m) then
                         amrflags(i,j) = DOFLAG
                         cycle x_loop
                     endif
                 enddo
-                
-                ! Refine based on wind speed
-                if (wind_forcing) then
-                    wind_speed = sqrt(aux(wind_index,i,j)**2 + aux(wind_index+1,i,j)**2)
-                    do m=1,min(size(wind_refine), mxnest)
-                        if ((wind_speed > wind_refine(m)) .and. (level <= m)) then
-                            amrflags(i,j) = DOFLAG
-                            cycle x_loop
-                        endif
-                    enddo
-                endif
+            endif
+
+            ! Refine based on wind speed (works with or without a storm center)
+            if (wind_forcing) then
+                wind_speed = sqrt(aux(wind_index,i,j)**2 + aux(wind_index+1,i,j)**2)
+                do m=1,min(size(wind_refine), mxnest)
+                    if ((wind_speed > wind_refine(m)) .and. (level <= m)) then
+                        amrflags(i,j) = DOFLAG
+                        cycle x_loop
+                    endif
+                enddo
             endif
 
             ! ********* criteria applied only to wet cells:

--- a/src/2d/shallow/multilayer/flag2refine2.f90
+++ b/src/2d/shallow/multilayer/flag2refine2.f90
@@ -29,6 +29,7 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
 
     use storm_module, only: storm_specification_type, wind_refine, R_refine
     use storm_module, only: storm_location, wind_forcing, wind_index, wind_refine
+    use storm_module, only: storm_location_available
 
     use regions_module, only: num_regions, regions
     use refinement_module, only: speed_tolerance
@@ -77,9 +78,10 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
             endif
 
             ! ************* Storm Based Refinement ****************
-            ! Check to see if we are some specified distance from the eye of
-            ! the storm and refine if we are
-            if (storm_specification_type /= 0) then
+            ! Distance-to-center (R_refine) refinement requires a storm center,
+            ! which only parameterized storms provide.  Gridded/data forcing
+            ! has no center and refines on wind speed alone
+            if (storm_location_available) then
                 R_eye = storm_location(t)
                 do m=1, min(size(R_refine), mxnest)
                     if (coordinate_system == 2) then
@@ -87,23 +89,23 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
                     else
                         ds = sqrt((x_c - R_eye(1))**2 + (y_c - R_eye(2))**2)
                     end if
-                    
+
                     if (ds < R_refine(m) .and. level <= m) then
                         amrflags(i,j) = DOFLAG
                         cycle x_loop
                     endif
                 enddo
-                
-                ! Refine based on wind speed
-                if (wind_forcing) then
-                    wind_speed = sqrt(aux(wind_index,i,j)**2 + aux(wind_index+1,i,j)**2)
-                    do m=1, min(size(wind_refine), mxnest)
-                        if ((wind_speed > wind_refine(m)) .and. (level <= m)) then
-                            amrflags(i,j) = DOFLAG
-                            cycle x_loop
-                        endif
-                    enddo
-                endif
+            endif
+
+            ! Refine based on wind speed (works with or without a storm center)
+            if (wind_forcing) then
+                wind_speed = sqrt(aux(wind_index,i,j)**2 + aux(wind_index+1,i,j)**2)
+                do m=1, min(size(wind_refine), mxnest)
+                    if ((wind_speed > wind_refine(m)) .and. (level <= m)) then
+                        amrflags(i,j) = DOFLAG
+                        cycle x_loop
+                    endif
+                enddo
             endif
 
             ! ********* criteria applied only to wet cells:

--- a/src/2d/shallow/multilayer/src2.f90
+++ b/src/2d/shallow/multilayer/src2.f90
@@ -4,6 +4,7 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     use storm_module, only: wind_drag
     use storm_module, only: wind_index, pressure_index
     use storm_module, only: storm_direction, storm_location
+    use storm_module, only: storm_location_available
 
     use friction_module, only: friction_index
 
@@ -150,19 +151,28 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     if (wind_forcing) then
         ! Force only the top layer of water, assumes top most layer is last
         ! to go dry
-        ! Need storm location and direction for sector based wind drag
-        sloc = storm_location(t)
-        theta = storm_direction(t)
+        ! Sector-based wind drag needs the storm center/direction, which only
+        ! parameterized storms provide.  Gridded/data forcing has no center;
+        ! use phi = 0 (Garratt drag ignores the angle; Powell falls back to a
+        ! fixed sector).
+        if (storm_location_available) then
+            sloc = storm_location(t)
+            theta = storm_direction(t)
+        endif
         do j=1,my
             yc = ylower + (j - 0.5d0) * dy
             do i=1,mx
                 xc = xlower + (i - 0.5d0) * dx
                 if (q(1,i,j) / rho(1) > dry_tolerance(1)) then
-                    psi = atan2(yc - sloc(2), xc - sloc(1))
-                    if (theta > psi) then
-                        phi = (2.d0 * pi - theta + psi) * RAD2DEG
+                    if (storm_location_available) then
+                        psi = atan2(yc - sloc(2), xc - sloc(1))
+                        if (theta > psi) then
+                            phi = (2.d0 * pi - theta + psi) * RAD2DEG
+                        else
+                            phi = (psi - theta) * RAD2DEG
+                        endif
                     else
-                        phi = (psi - theta) * RAD2DEG 
+                        phi = 0.d0
                     endif
                     wind_speed = sqrt(aux(wind_index,i,j)**2        &
                                     + aux(wind_index+1,i,j)**2)

--- a/src/2d/shallow/multilayer/valout.f90
+++ b/src/2d/shallow/multilayer/valout.f90
@@ -15,7 +15,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
     use storm_module, only: storm_specification_type, output_storm_location
-    use storm_module, only: output_storm_location
+    use storm_module, only: storm_location_available
     use storm_module, only: landfall, display_landfall_time
 
     use geoclaw_module, only: rho
@@ -95,8 +95,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     out_aux = ((output_aux_num > 0) .and.               &
               ((.not. output_aux_onlyonce) .or. (abs(time - t0) < 1d-90)))
 
-    ! Output storm track if needed
-    if (storm_specification_type /= 0) then
+    ! Output storm track if needed (parameterized storms only; gridded/data
+    ! forcing has no center to write).
+    if (storm_location_available) then
         call output_storm_location(time)
     end if
 

--- a/src/2d/shallow/src2.f90
+++ b/src/2d/shallow/src2.f90
@@ -14,6 +14,7 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
     use storm_module, only: wind_forcing, pressure_forcing, wind_drag
     use storm_module, only: wind_index, pressure_index
     use storm_module, only: storm_direction, storm_location
+    use storm_module, only: storm_location_available
 
     use friction_module, only: variable_friction, friction_index
 
@@ -177,19 +178,28 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
 
     ! wind -----------------------------------------------------------
     if (wind_forcing) then
-        ! Need storm location and direction for sector based wind drag
-        sloc = storm_location(t)
-        theta = storm_direction(t)
+        ! Sector-based wind drag needs the storm center/direction, which only
+        ! parameterized storms provide.  Gridded/data forcing has no center;
+        ! use phi = 0 (Garratt drag ignores the angle; Powell falls back to a
+        ! fixed sector).
+        if (storm_location_available) then
+            sloc = storm_location(t)
+            theta = storm_direction(t)
+        endif
         do j=1,my
             yc = ylower + (j - 0.5d0) * dy
             do i=1,mx
                 xc = xlower + (i - 0.5d0) * dx
                 if (q(1,i,j) > dry_tolerance) then
-                    psi = atan2(yc - sloc(2), xc - sloc(1))
-                    if (theta > psi) then
-                        phi = (2.d0 * pi - theta + psi) * RAD2DEG
+                    if (storm_location_available) then
+                        psi = atan2(yc - sloc(2), xc - sloc(1))
+                        if (theta > psi) then
+                            phi = (2.d0 * pi - theta + psi) * RAD2DEG
+                        else
+                            phi = (psi - theta) * RAD2DEG
+                        endif
                     else
-                        phi = (psi - theta) * RAD2DEG 
+                        phi = 0.d0
                     endif
                     wind_speed = sqrt(aux(wind_index,i,j)**2        &
                                     + aux(wind_index+1,i,j)**2)

--- a/src/2d/shallow/surge/storm_module.f90
+++ b/src/2d/shallow/surge/storm_module.f90
@@ -46,6 +46,12 @@ module storm_module
 
     ! Storm object
     integer :: storm_specification_type
+
+    ! Whether the active forcing provides a storm center/track.  Only
+    ! parameterized storms (storm_specification_type > 0) have an analytic
+    ! eye; gridded/data forcing does not.  Center-consuming code (AMR
+    ! R_refine, sector-based wind drag, fort.track output) is guarded on this.
+    logical :: storm_location_available = .false.
     real(kind=8) :: landfall = 0.d0
     type(model_storm_type), save :: model_storm
     type(data_storm_type), save :: data_storm
@@ -199,6 +205,10 @@ contains
             ! Storm Setup
             read(unit, "(i2)") storm_specification_type
             read(unit, *) storm_file_path
+
+            ! Only parameterized (model) storms provide a storm center/track;
+            ! gridded/data forcing (storm_specification_type < 0) has none.
+            storm_location_available = (storm_specification_type > 0)
 
             close(unit)
 

--- a/src/2d/shallow/valout.f90
+++ b/src/2d/shallow/valout.f90
@@ -15,7 +15,7 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
     use storm_module, only: storm_specification_type, output_storm_location
-    use storm_module, only: output_storm_location
+    use storm_module, only: storm_location_available
     use storm_module, only: landfall, display_landfall_time
 
 #ifdef HDF5
@@ -91,8 +91,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     out_aux = ((output_aux_num > 0) .and.               &
               ((.not. output_aux_onlyonce) .or. (abs(time - t0) < 1d-90)))
                 
-    ! Output storm track if needed
-    if (storm_specification_type /= 0) then
+    ! Output storm track if needed (parameterized storms only; gridded/data
+    ! forcing has no center to write).
+    if (storm_location_available) then
         call output_storm_location(time)
     end if
 

--- a/tests/regression/met_forcing/setrun.py
+++ b/tests/regression/met_forcing/setrun.py
@@ -17,7 +17,8 @@ from clawpack.clawutil import data
 
 
 def setrun(claw_pkg="geoclaw", forcing="holland80", topo_path=None,
-           storm_path=None):
+           storm_path=None, amr_levels_max=1, wind_refine=False,
+           R_refine=False):
 
     assert claw_pkg.lower() == "geoclaw", "Expected claw_pkg = 'geoclaw'"
 
@@ -76,16 +77,17 @@ def setrun(claw_pkg="geoclaw", forcing="holland80", topo_path=None,
     clawdata.bc_lower[1] = "extrap"
     clawdata.bc_upper[1] = "extrap"
 
-    # --- AMR OFF (single fixed grid) ---
+    # --- AMR (single fixed grid by default; F1 test drives amr_levels_max=2) ---
     amrdata = rundata.amrdata
-    amrdata.amr_levels_max = 1
+    amrdata.amr_levels_max = amr_levels_max
     amrdata.refinement_ratios_x = [2]
     amrdata.refinement_ratios_y = [2]
     amrdata.refinement_ratios_t = [2]
     amrdata.aux_type = ["center", "capacity", "yleft",
                         "center", "center", "center", "center"]
     amrdata.flag_richardson = False
-    amrdata.flag2refine = False
+    # Use flag2refine2 (wind/R_refine criteria) when refining.
+    amrdata.flag2refine = (amr_levels_max > 1)
     amrdata.verbosity_regrid = 0
 
     # --- GeoClaw geometry / topo ---
@@ -109,8 +111,8 @@ def setrun(claw_pkg="geoclaw", forcing="holland80", topo_path=None,
     surge_data.wind_index = 4          # 0-based -> Fortran 5 (wind_u), 6 (wind_v)
     surge_data.pressure_index = 6      # 0-based -> Fortran 7 (pressure)
     surge_data.display_landfall_time = False
-    surge_data.wind_refine = False
-    surge_data.R_refine = False
+    surge_data.wind_refine = wind_refine
+    surge_data.R_refine = R_refine
     if forcing == "data":
         surge_data.storm_specification_type = "data"
     else:

--- a/tests/regression/met_forcing/test_met_forcing_aux.py
+++ b/tests/regression/met_forcing/test_met_forcing_aux.py
@@ -231,5 +231,55 @@ def test_netcdf_forcing_aux(tmp_path):
     _check_aux(_run_case(tmp_path, "data"), "data")
 
 
+@pytest.mark.regression
+@pytest.mark.storm
+@pytest.mark.netcdf
+def test_gridded_no_center_amr(tmp_path):
+    """Phase F1: gridded (no-center) forcing with AMR on must run without
+    assuming a storm center, refine on wind (R_refine is inert without a
+    center), and write no fort.track.
+
+    This is the behavioral guard for the center-assumption fix: pre-F1 this run
+    emitted a bogus fort.track full of ``rinfinity`` rows; post-F1 it emits
+    none, and refinement is driven purely by ``wind_refine``.
+    """
+    pytest.importorskip("xarray")
+    pytest.importorskip("netCDF4")
+    make_vars = _netcdf_build_vars()
+    if make_vars is None:
+        pytest.skip("NetCDF (nf-config/nc-config) unavailable; gridded end-to-"
+                    "end is covered by the isaac suite.")
+
+    topo_path = tmp_path / "flat.tt3"
+    _flat_topo(topo_path)
+    nc_path = tmp_path / "met.nc"
+    storm_path = tmp_path / "met.storm"
+    _netcdf_forcing(nc_path, storm_path)
+
+    runner = gtest.GeoClawTestRunner(tmp_path, test_path=testdir)
+    # amr_levels_max=2 with a low wind threshold so the vortex triggers
+    # refinement; R_refine is set but must stay inert (no storm center).
+    runner.set_data(forcing="data", topo_path=str(topo_path),
+                    storm_path=str(storm_path), amr_levels_max=2,
+                    wind_refine=[8.0], R_refine=[100.0e3])
+    runner.write_data()
+    runner.build_executable(make_vars=make_vars)
+    runner.run_code()
+
+    # (a) The run completed (a centerless data-storm center lookup would STOP
+    #     the program) and produced the final output frame.
+    sol = solution.Solution(OUTPUT_FRAMES[-1], path=runner.temp_path,
+                            read_aux=True)
+
+    # (b) Refinement occurred and is wind-driven: R_refine is inert without a
+    #     center, so more than the single base grid means wind_refine fired.
+    assert len(sol.states) > 1, (
+        "expected wind-driven AMR refinement (>1 grid) for gridded forcing")
+
+    # (c) The center-assumption fix: gridded forcing writes no fort.track.
+    assert not (Path(runner.temp_path) / "fort.track").exists(), (
+        "gridded (no-center) forcing must not emit a fort.track")
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
Several Fortran routines assumed every storm has an analytic eye by consuming storm_location()/storm_direction(), which return a rinfinity sentinel for gridded/data storms. Add a storm_location_available predicate (true only for parameterized storms, storm_specification_type > 0), set in set_storm, and guard the center-consuming sites on it:

- flag2refine2 (single + multilayer): the distance-to-center R_refine loop runs only when a center exists; wind_refine speed-threshold refinement runs under wind_forcing. Gridded forcing refines on wind speed only.
- src2 (single + multilayer): the sector wind-drag angle is computed only when a center exists, else phi = 0 (Garratt drag ignores it; Powell falls back to a fixed sector).
- valout (single + multilayer + bouss): fort.track is written for parameterized storms only, so gridded runs no longer emit rinfinity rows.

Behavior-neutral: parameterized storms are unchanged, and existing gridded cases (Garratt drag, already-inert R_refine) stay byte-identical — canary, ike, isaac, and the forcing-aux regressions pass with no golden regeneration. Adds a gridded AMR-on regression asserting the centerless run refines on wind and writes no fort.track. Contained to the geoclaw tree (no clawpack/riemann references).

Co-Authored-By: Claude Opus 4.8 (1M context)