### PR TITLE
Lazy hyperslab read for NetCDF topography (topo_type=4)

### DIFF
--- a/src/python/geoclaw/topotools.py
+++ b/src/python/geoclaw/topotools.py
@@ -91,6 +91,45 @@ def determine_topo_type(path, default=None):
     return topo_type
 
 
+def _netcdf_window_indices(coords, lo, hi, margin, n, stride=1):
+    r"""Half-open index window ``[i0, i1)`` into 1-D monotonic *coords*.
+
+    Used by :meth:`Topography.read` to push a ``crop_extent`` down to the
+    NetCDF read so only the needed hyperslab is loaded from disk (rather than
+    materializing a whole global variable and cropping afterward).
+
+    :Input:
+     - *coords* (ndarray) - 1-D coordinate array, monotonic ascending **or**
+       descending (as stored in the file).
+     - *lo*, *hi* (float) - requested inclusive coordinate bounds.
+     - *margin* (int) - extra points to keep on each side so that a subsequent
+       :meth:`Topography.crop` still has every point it needs (its own buffer
+       plus the ``coarsen`` alignment search).
+     - *n* (int) - length of *coords*.
+     - *stride* (int) - read stride; the low index is snapped **down** to a
+       multiple of *stride* so the strided sub-window shares the same phase as
+       striding the full array, keeping the sampled grid identical.
+
+    Returns ``(0, n)`` (the full range) when the interval does not overlap
+    *coords*, mirroring ``crop()``'s fall-back of leaving the array uncropped
+    when the filter region misses the topography.
+    """
+    # A monotonic array clipped to [lo, hi] yields a contiguous True block for
+    # either sort order, so first/last True index bound the window.
+    mask = (coords >= lo) & (coords <= hi)
+    idx = numpy.nonzero(mask)[0]
+    if idx.size == 0:
+        return 0, n
+    i0 = max(0, int(idx[0]) - margin)
+    i1 = min(n, int(idx[-1]) + margin + 1)
+    # Snap the low index down to a multiple of stride so coords[i0:i1:stride]
+    # is a phase-aligned subset of coords[::stride].
+    i0 -= i0 % stride
+    if i1 <= i0:
+        return 0, n
+    return i0, i1
+
+
 def create_topo_func(loc,verbose=False):
     """
     Given a 1-dimensional topography profile specfied by a set of (x,z)
@@ -853,13 +892,12 @@ class Topography(object):
                     # attributes (informational only; no transformation).
                     self.datum = extract_datum(ds[_var_name].attrs, ds.attrs)
 
-                    # Load coordinate 1-D arrays
-                    _lon_vals = numpy.asarray(
-                        ds[_x_name].values[::stride[0]], dtype=float
-                    )
-                    _lat_vals = numpy.asarray(
-                        ds[_y_name].values[::stride[1]], dtype=float
-                    )
+                    # Load the 1-D coordinate arrays in full: these are
+                    # O(nx)+O(ny) (a few MB even for a global grid), unlike the
+                    # O(nx*ny) elevation variable.  Kept in file order for now;
+                    # any N→S flip is applied below after windowing.
+                    _lon_full = numpy.asarray(ds[_x_name].values, dtype=float)
+                    _lat_full = numpy.asarray(ds[_y_name].values, dtype=float)
 
                     # Load variable, squeezing singleton non-spatial dims
                     _da = ds[_var_name]
@@ -876,11 +914,41 @@ class Topography(object):
                                 )
 
                     # Transpose to (lat, lon) = (y, x) order expected by
-                    # Topography, then apply stride
+                    # Topography.
                     _da = _da.transpose(_y_name, _x_name)
-                    _z_vals = numpy.asarray(
-                        _da.values[::stride[1], ::stride[0]], dtype=float
-                    )
+
+                    # Push both `stride` and `crop_extent` down to xarray's lazy
+                    # indexing so the NetCDF backend reads ONLY the requested
+                    # hyperslab.  Otherwise `_da.values` materializes the whole
+                    # variable (a global DEM is many GB, and CF fill decoding
+                    # promotes it to float), which is prohibitively slow and can
+                    # exhaust memory even when the caller asked for a small
+                    # subset.  The crop window is computed on the cheap 1-D
+                    # coordinate arrays and expanded by a margin so the post-read
+                    # crop() below still reproduces its exact bounds/buffer/
+                    # align/coarsen result on the in-memory sub-window.
+                    _nx = _lon_full.size
+                    _ny = _lat_full.size
+                    if self.crop_extent is not None:
+                        _x1, _x2, _y1, _y2 = self.crop_extent
+                        _margin = (int(self.buffer) + 1) * max(int(self.coarsen), 1)
+                        _i0, _i1 = _netcdf_window_indices(
+                            _lon_full, _x1, _x2, _margin, _nx, stride[0]
+                        )
+                        _j0, _j1 = _netcdf_window_indices(
+                            _lat_full, _y1, _y2, _margin, _ny, stride[1]
+                        )
+                    else:
+                        _i0, _i1 = 0, _nx
+                        _j0, _j1 = 0, _ny
+
+                    _da = _da.isel({
+                        _y_name: slice(_j0, _j1, stride[1]),
+                        _x_name: slice(_i0, _i1, stride[0]),
+                    })
+                    _z_vals = numpy.asarray(_da.values, dtype=float)
+                    _lon_vals = _lon_full[_i0:_i1:stride[0]]
+                    _lat_vals = _lat_full[_j0:_j1:stride[1]]
 
                     # Flip to S→N (y increasing) if file stores N→S
                     if not _meta.y_increasing:

--- a/tests/test_topotools_preprocessing.py
+++ b/tests/test_topotools_preprocessing.py
@@ -1042,3 +1042,179 @@ def test_backward_compat_mixed_formats(tmp_path, tt2_path):
     assert raw.count("topo_path") == 3
     # The dict's crop_extent [0,5,0,5] appears (not all-zero sentinel)
     assert "0 5" in raw or "0. 5." in raw or "0.0 5.0" in raw
+
+
+# ===========================================================================
+# Group 8 — crop_extent / stride pushdown to the NetCDF read (type 4)
+#
+# A large global NetCDF must not be fully materialized when only a subset is
+# requested.  read() pushes both `stride` and a `crop_extent`-derived index
+# window down to xarray's lazy indexing so the backend reads only that
+# hyperslab.  The window is a *superset* of what the post-read crop() selects,
+# so the visible result must be byte-identical to reading the whole file and
+# cropping in memory.  These tests pin that equivalence (the correctness
+# contract) and guard that a bounded window is actually used (the perf/memory
+# contract).  End-to-end memory/time on a real 7 GB global DEM was confirmed
+# manually (a strided read that previously OOM'd now returns in ~0.1 s).
+# ===========================================================================
+
+@pytest.mark.netcdf
+def test_crop_pushdown_matches_full_read(nc_topo_path):
+    """crop_extent applied during read == full read then crop() in memory."""
+    pytest.importorskip("xarray")
+    path, _, _ = nc_topo_path
+    crop = [2.0, 7.0, 3.0, 8.0]
+
+    ref = Topography()
+    ref.read(path, topo_type=4)
+    ref = ref.crop(filter_region=crop)
+
+    t = Topography()
+    t.crop_extent = crop
+    t.read(path, topo_type=4)
+
+    np.testing.assert_array_equal(t.x, ref.x)
+    np.testing.assert_array_equal(t.y, ref.y)
+    np.testing.assert_array_equal(t.Z, ref.Z)
+
+
+@pytest.mark.netcdf
+def test_crop_pushdown_with_buffer_matches_full_read(nc_topo_path):
+    """buffer is preserved: the pushed-down window is a superset of crop()'s."""
+    pytest.importorskip("xarray")
+    path, _, _ = nc_topo_path
+    crop = [3.0, 7.0, 3.0, 7.0]
+
+    ref = Topography()
+    ref.read(path, topo_type=4)
+    ref = ref.crop(filter_region=crop, buffer=1)
+
+    t = Topography()
+    t.crop_extent = crop
+    t.buffer = 1
+    t.read(path, topo_type=4)
+
+    np.testing.assert_array_equal(t.x, ref.x)
+    np.testing.assert_array_equal(t.y, ref.y)
+    np.testing.assert_array_equal(t.Z, ref.Z)
+
+
+@pytest.mark.netcdf
+def test_crop_pushdown_with_coarsen_align_matches_full_read(nc_topo_path):
+    """coarsen + align survive the pushdown unchanged."""
+    pytest.importorskip("xarray")
+    path, _, _ = nc_topo_path
+    crop = [2.0, 7.0, 3.0, 8.0]
+
+    ref = Topography()
+    ref.read(path, topo_type=4)
+    ref = ref.crop(filter_region=crop, coarsen=2, align=(0.0, 0.0))
+
+    t = Topography()
+    t.crop_extent = crop
+    t.coarsen = 2
+    t.align = (0.0, 0.0)
+    t.read(path, topo_type=4)
+
+    np.testing.assert_array_equal(t.x, ref.x)
+    np.testing.assert_array_equal(t.y, ref.y)
+    np.testing.assert_array_equal(t.Z, ref.Z)
+
+
+@pytest.mark.netcdf
+@pytest.mark.parametrize("buffer", [0, 1])
+def test_crop_pushdown_with_stride_matches_full_read(nc_topo_path, buffer):
+    """stride + crop_extent: the strided sub-window stays phase-aligned with
+    striding the full array (the low index is snapped to a multiple of stride),
+    so the result matches full-strided-then-cropped.  buffer=1 forces an odd
+    raw low index, exercising the snap."""
+    pytest.importorskip("xarray")
+    path, _, _ = nc_topo_path
+    crop = [3.0, 8.0, 3.0, 8.0]
+
+    ref = Topography()
+    ref.read(path, topo_type=4, stride=[2, 2])
+    ref = ref.crop(filter_region=crop, buffer=buffer)
+
+    t = Topography()
+    t.crop_extent = crop
+    t.buffer = buffer
+    t.read(path, topo_type=4, stride=[2, 2])
+
+    np.testing.assert_array_equal(t.x, ref.x)
+    np.testing.assert_array_equal(t.y, ref.y)
+    np.testing.assert_array_equal(t.Z, ref.Z)
+
+
+@pytest.mark.netcdf
+@pytest.mark.parametrize("s2n", [True, False], ids=["S→N", "N→S"])
+def test_crop_pushdown_respects_storage_order(tmp_path, s2n):
+    """crop_extent pushdown matches full-read-then-crop for either lat storage
+    order, and always returns coordinates normalised S→N (y increasing).
+    (The bundled fixture flips only the coordinate on N→S, not the data, so the
+    invariant is pushdown-vs-full on the *same* file, not S→N-vs-N→S.)"""
+    pytest.importorskip("xarray")
+    pytest.importorskip("netCDF4")
+    crop = [2.0, 7.0, 3.0, 8.0]
+
+    path = _make_nc_topo(tmp_path / "ordered.nc", "lon", "lat",
+                         lat_south_to_north=s2n)
+
+    ref = Topography()
+    ref.read(str(path), topo_type=4)
+    ref = ref.crop(filter_region=crop)
+
+    t = Topography()
+    t.crop_extent = crop
+    t.read(str(path), topo_type=4)
+
+    np.testing.assert_array_equal(t.x, ref.x)
+    np.testing.assert_array_equal(t.y, ref.y)
+    np.testing.assert_array_equal(t.Z, ref.Z)
+    # Coordinates are always normalised to S→N regardless of file order.
+    assert np.all(np.diff(t.y) > 0)
+
+
+@pytest.mark.netcdf
+def test_crop_no_overlap_keeps_full_grid(nc_topo_path):
+    """A crop_extent that misses the file leaves the array uncropped, matching
+    crop()'s own fall-back (does not crash or return an empty grid)."""
+    pytest.importorskip("xarray")
+    path, _, _ = nc_topo_path
+
+    ref = Topography()
+    ref.read(path, topo_type=4)
+
+    t = Topography()
+    t.crop_extent = [100.0, 200.0, 100.0, 200.0]
+    t.read(path, topo_type=4)
+
+    np.testing.assert_array_equal(t.Z, ref.Z)
+
+
+@pytest.mark.netcdf
+def test_crop_pushdown_reads_bounded_window(nc_topo_path, monkeypatch):
+    """Regression tripwire: a crop_extent read must compute (and therefore read)
+    a strict sub-window on each axis, not the whole axis.  If someone reverts to
+    materializing the full variable and cropping afterward, this fails."""
+    pytest.importorskip("xarray")
+    path, _, _ = nc_topo_path
+
+    calls = []
+    orig = topotools._netcdf_window_indices
+
+    def _spy(coords, lo, hi, margin, n, stride=1):
+        result = orig(coords, lo, hi, margin, n, stride)
+        calls.append((result, n))
+        return result
+
+    monkeypatch.setattr(topotools, "_netcdf_window_indices", _spy)
+
+    t = Topography()
+    t.crop_extent = [3.0, 6.0, 3.0, 6.0]
+    t.read(path, topo_type=4)
+
+    assert calls, "crop_extent read did not use the window pushdown"
+    for (i0, i1), n in calls:
+        assert 0 <= i0 < i1 <= n
+        assert (i1 - i0) < n, "window spans the whole axis (no pushdown)"


### PR DESCRIPTION
## Summary

Topography.read() for topo_type=4 (NetCDF) materialized the entire elevation variable before applying stride or crop_extent. Reading any subset of a large global DEM therefore loaded the whole grid into memory. This makes read() load only the requested hyperslab by pushing stride and the crop_extent window down to a single lazy xarray.isel().

## Problem

In the type-4 branch of read():

_da = _da.transpose(_y_name, _x_name)
_z_vals = numpy.asarray(_da.values[::stride[1], ::stride[0]], dtype=float)

_da.values pulls the full variable into memory first, then strides; and crop_extent is only applied afterward via the post-read crop(). Both were pure in-memory post-filters. For the 7 GB global GEBCO_2025 grid (elevation (lat: 43200, lon: 86400) int16), CF fill-value decoding also promotes the array to float, so a stride=[100, 100] request that should return a ~800 KB array instead tried to resident ~30 GB — slow enough to look like a hang, and OOM-prone.

## Fix

- New module helper _netcdf_window_indices() computes a half-open index window into the 1-D coordinate arrays (cheap: O(nx)+O(ny)) from crop_extent. It: handles ascending and descending (N→S) storage; expands by margin = (buffer + 1) * max(coarsen, 1) so the post-read crop() still has every point it needs; snaps the low index down to a multiple of stride so the strided sub-window stays phase-aligned; and falls back to (0, n) on no overlap, matching crop()'s existing behavior.
- The type-4 branch now issues one lazy _da.isel({y: slice(j0, j1, stride[1]), x: slice(i0, i1, stride[0])}) before .values, so the backend reads only that hyperslab.
- Everything after the read is unchanged; because the window is a superset of what crop() selects, the result is byte-identical to reading the whole file and cropping in memory.

No change to the Fortran descriptor path, the public API, or read()'s behavior for topo_types 1/2/3/5.

## Testing

New Group-8 tests in tests/test_topotools_preprocessing.py assert pushdown == full-read-then-crop() across: crop_extent alone; + buffer; + coarsen+align; + stride (parametrized to force the snap); S→N and N→S order; non-overlapping crop (full fallback); plus a bounded-window tripwire.

- pytest tests/test_topotools_preprocessing.py — 87 passed
- pytest tests/test_topotools.py — 30 passed
- Real 7 GB GEBCO_2025.nc: cropped stride=[100,100] ~0.01s; full-res cropped regional read ~0.19s (both previously OOM'd).

## Notes

- crop_extent is compared in the file's coordinate system, exactly as the existing post-read crop() does — longitude-wrap / domain-coordinate cases behave no worse than before.
- Unrelated & out of scope: Topography(path=...) still auto-runs a full read() in the constructor before crop_extent/stride can be set — a separate pre-existing issue for large files.  Need to use `topo = Topography(); topo.read()` sequence to avoid this.