### PR TITLE
Phase 2: split forcing selection into family + subtype

### DIFF
--- a/src/2d/shallow/surge/storm_module.f90
+++ b/src/2d/shallow/surge/storm_module.f90
@@ -146,6 +146,7 @@ contains
         integer, parameter :: unit = 13
         integer :: i, drag_law, rotation_override
         character(len=512) :: storm_file_path, line, wind_file_path, pressure_file_path
+        character(len=64) :: storm_family, storm_subtype
         ! integer :: num_storm_files
         ! character(len=200), allocatable, dimension(:) :: storm_files_array
         ! character(len=12) :: landfall_time
@@ -202,13 +203,19 @@ contains
             allocate(R_refine(get_value_count(line)))
             read(unit, *)
 
-            ! Storm Setup
-            read(unit, "(i2)") storm_specification_type
+            ! Met-forcing selection: explicit family + subtype tokens (written
+            ! by SurgeData.write in src/python/geoclaw/data.py).  The subtype
+            ! token is translated back to the legacy integer
+            ! storm_specification_type so the dispatch below - and the
+            ! module-level selector consumed by other files - is unchanged.
+            read(unit, *) storm_family
+            read(unit, *) storm_subtype
             read(unit, *) storm_file_path
+            storm_specification_type = forcing_spec_type(storm_subtype)
 
-            ! Only parameterized (model) storms provide a storm center/track;
-            ! gridded/data forcing (storm_specification_type < 0) has none.
-            storm_location_available = (storm_specification_type > 0)
+            ! Only parameterized (model) forcing provides a storm center/track;
+            ! gridded forcing does not.
+            storm_location_available = (trim(storm_family) == "parametric")
 
             close(unit)
 
@@ -265,6 +272,50 @@ contains
         end if
 
     end subroutine set_storm
+
+    ! ========================================================================
+    !  integer function forcing_spec_type(subtype)
+    !
+    !  Translate a canonical met-forcing subtype token (as written by the
+    !  Python SurgeData writer) into the legacy storm_specification_type
+    !  integer used by the dispatch in set_storm.  Kept in lockstep with
+    !  forcing_subtype_registry in src/python/geoclaw/data.py.
+    ! ========================================================================
+    integer function forcing_spec_type(subtype) result(spec_type)
+
+        implicit none
+        character(len=*), intent(in) :: subtype
+
+        select case (trim(subtype))
+            case ("none")
+                spec_type = 0
+            case ("holland80")
+                spec_type = 1
+            case ("holland2010")
+                spec_type = 2
+            case ("cle")
+                spec_type = 3
+            case ("slosh")
+                spec_type = 4
+            case ("rankine")
+                spec_type = 5
+            case ("modified_rankine")
+                spec_type = 6
+            case ("demaria")
+                spec_type = 7
+            case ("holland2008")
+                spec_type = 8
+            case ("willoughby")
+                spec_type = 9
+            case ("gridded")
+                spec_type = -1
+            case default
+                print *, "*** ERROR *** Unknown met-forcing subtype '",     &
+                         trim(subtype), "'."
+                stop
+        end select
+
+    end function forcing_spec_type
 
     ! ========================================================================
     !   real(kind=8) function *_wind_drag(wind_speed)

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -829,24 +829,102 @@ class QinitData(clawpack.clawutil.data.ClawData):
         self.close_data_file()
 
 
+# =============================================================================
+#  Meteorological forcing selection registry
+#
+#  Single source of truth mapping the met-forcing *family* + *subtype* to the
+#  legacy signed-integer ``storm_specification_type`` encoding still carried on
+#  the ``surge.data`` wire.  See met_forcing_refactor.md Sections 7 and 9.
+#
+#  family:  "parametric" - analytic model with a storm center/track;
+#           "gridded"    - file-backed wind/pressure fields (no center);
+#           "none"       - forcing off.
+#
+#  Each parametric subtype maps to that model's historical integer code; the
+#  single gridded subtype maps to -1 and "none" to 0.  The gridded ASCII/NetCDF
+#  distinction is NOT on this wire - it lives as ``file_format`` in the .storm
+#  descriptor (see surge/gridded.py and data_storm_module.f90).
+
+# canonical subtype -> (family, legacy integer code)
+forcing_subtype_registry = {"holland80":        ("parametric",  1),
+                            "holland2008":      ("parametric",  8),
+                            "holland2010":      ("parametric",  2),
+                            "cle":              ("parametric",  3),
+                            "slosh":            ("parametric",  4),
+                            "rankine":          ("parametric",  5),
+                            "modified_rankine": ("parametric",  6),
+                            "demaria":          ("parametric",  7),
+                            "willoughby":       ("parametric",  9),
+                            "gridded":          ("gridded",    -1),
+                            "none":             ("none",        0),
+                           }
+
+# Historical / alternate spellings -> canonical subtype.  Lookups are
+# case-folded, so only spellings that differ by more than case need listing
+# here.  These keep existing setrun.py scripts working unchanged.
+forcing_subtype_aliases = {"holland08":        "holland2008",
+                           "holland10":        "holland2010",
+                           "modified-rankine": "modified_rankine",
+                           "data":             "gridded",
+                          }
+
+# Subtypes recognized by the API but not yet implemented in the Fortran forcing
+# code.  Currently empty: all nine parametric models and the gridded path have
+# working Fortran implementations.  (The previous ``storm_spec_not_implemented``
+# check compared an int against the string 'CLE' and so never fired; CLE is in
+# fact implemented in model_storm_module.f90, so nothing is blocked here.)
+forcing_not_implemented = set()
+
+# Reverse map: legacy integer code -> canonical subtype (each code is unique).
+_forcing_code_to_subtype = {code: subtype for subtype, (family, code)
+                            in forcing_subtype_registry.items()}
+
+
+def resolve_forcing_subtype(value):
+    r"""Resolve a user-supplied forcing spec to ``(family, subtype, code)``.
+
+    ``value`` may be a canonical subtype string, a historical alias, a legacy
+    integer code, or ``None`` (forcing off).  Returns the canonical family
+    string, canonical subtype string, and legacy integer code.
+    """
+    if value is None:
+        subtype = "none"
+    elif isinstance(value, str):
+        subtype = value.lower()
+        subtype = forcing_subtype_aliases.get(subtype, subtype)
+        if subtype not in forcing_subtype_registry:
+            raise ValueError(f"Unknown forcing subtype '{value}'.")
+    elif isinstance(value, (int, np.integer)):
+        if int(value) not in _forcing_code_to_subtype:
+            raise ValueError(f"Unknown forcing specification code '{value}'.")
+        subtype = _forcing_code_to_subtype[int(value)]
+    else:
+        raise TypeError(f"Unknown forcing specification '{value}'.")
+
+    if subtype in forcing_not_implemented:
+        raise NotImplementedError(f"Forcing subtype '{subtype}' is not yet "
+                                  "implemented.")
+
+    family, code = forcing_subtype_registry[subtype]
+    return family, subtype, code
+
+
 # Storm data
 class SurgeData(clawpack.clawutil.data.ClawData):
     r"""Data object describing storm surge related parameters"""
 
-    # Provide some mapping between model names and integers
-    storm_spec_dict_mapping = {"data": -1,
-                               None: 0,
-                               'holland80': 1,
-                               'holland08': 8,
-                               'holland10': 2,
-                               'cle': 3,
-                               'slosh': 4,
-                               'rankine': 5,
-                               'modified-rankine': 6,
-                               'DeMaria': 7,
-                               'willoughby': 9,
+    # Legacy name/alias -> integer mapping, derived from the canonical
+    # forcing_subtype_registry above.  Retained (with the historical spellings)
+    # as a backwards-compatibility view; new code should prefer
+    # storm_family/storm_subtype and resolve_forcing_subtype().
+    storm_spec_dict_mapping = {None: 0,
+                               **{sub: code for sub, (fam, code)
+                                  in forcing_subtype_registry.items()},
+                               **{alias: forcing_subtype_registry[canon][1]
+                                  for alias, canon
+                                  in forcing_subtype_aliases.items()},
                               }
-    storm_spec_not_implemented = ['CLE']
+    storm_spec_not_implemented = forcing_not_implemented
 
     def __init__(self):
         super(SurgeData, self).__init__()
@@ -875,9 +953,18 @@ class SurgeData(clawpack.clawutil.data.ClawData):
         self.add_attribute('wind_refine', [20.0,40.0,60.0])
         self.add_attribute('R_refine', [60.0e3, 40e3, 20e3])
 
-        # Storm parameters
+        # Storm / met-forcing selection.
+        #
+        # Preferred API: storm_family ("parametric" | "gridded" | "none") plus
+        # storm_subtype (a model name for parametric, "gridded" for gridded).
+        # These default to None; when unset, write() falls back to the legacy
+        # storm_specification_type (string or integer), which is retained as a
+        # plain stored attribute for backwards compatibility.  See the
+        # forcing_subtype_registry above and met_forcing_refactor.md Section 7.
+        self.add_attribute('storm_family', None)
+        self.add_attribute('storm_subtype', None)
         self.add_attribute('storm_type', None)  # Backwards compatibility
-        self.add_attribute('storm_specification_type', 0) # Type of parameterized storm
+        self.add_attribute('storm_specification_type', 0) # Legacy selection
         self.add_attribute("storm_file", None) # File containing data
 
     def read(self, path: Path=Path("surge.data"), force: bool=False):
@@ -912,10 +999,14 @@ class SurgeData(clawpack.clawutil.data.ClawData):
             self.R_refine = self._parse_value(data_file.readline().split("=:")[0])
             # data_file.readline()
 
-            # Storm specification
-            self.storm_specification_type = int(data_file.readline().split("=:")[0])
+            # Storm / met-forcing selection (family + subtype tokens).
+            self.storm_family = data_file.readline().split("=:")[0].strip()[1:-1]
+            self.storm_subtype = data_file.readline().split("=:")[0].strip()[1:-1]
+            # Populate the legacy integer selector for backwards compatibility.
+            _, _, self.storm_specification_type = \
+                resolve_forcing_subtype(self.storm_subtype)
             line = data_file.readline().split("=:")[0]
-            if line[0] == "'":
+            if line.strip()[0] == "'":
                 self.storm_file = line.strip()[1:-1]
             else:
                 raise IOError("Error reading storm file name.")
@@ -977,28 +1068,34 @@ class SurgeData(clawpack.clawutil.data.ClawData):
             self.R_refine = [self.R_refine]
         self.data_write('R_refine', description='(Wind speed refinement criteria)')
 
-        # Storm specification
-        # Handle deprecated member value
-        if self.storm_type is not None:
-            self.storm_specification_type = self.storm_type
-        # Turn value into integer descriptor
-        if isinstance(self.storm_specification_type, int):
-            spec_type = self.storm_specification_type
-        elif isinstance(self.storm_specification_type, str):
-            if self.storm_specification_type.lower() in self.storm_spec_dict_mapping.keys():
-                spec_type = self.storm_spec_dict_mapping[self.storm_specification_type.lower()]
-            else:
-                raise TypeError(f"Unknown storm specification type" +
-                                f" '{self.storm_specification_type}' provided.")
+        # Storm / met-forcing selection.
+        #
+        # Resolve to a canonical (family, subtype) pair.  The preferred inputs
+        # are storm_family/storm_subtype; when unset we fall back to the legacy
+        # storm_specification_type (or the deprecated storm_type alias), which
+        # may be a name, an alias, or an integer code.
+        if self.storm_family is not None or self.storm_subtype is not None:
+            # storm_subtype is authoritative; family is validated for
+            # consistency if the caller also supplied it.
+            if self.storm_subtype is None:
+                raise ValueError("storm_family set without storm_subtype.")
+            family, subtype, _ = resolve_forcing_subtype(self.storm_subtype)
+            if (self.storm_family is not None
+                    and self.storm_family.lower() != family):
+                raise ValueError(
+                    f"storm_family '{self.storm_family}' is inconsistent with "
+                    f"storm_subtype '{self.storm_subtype}' (family {family}).")
         else:
-            raise TypeError(f"Unknown storm specification type" +
-                            f" '{self.storm_specification_type}' provided.")
-        # Check to see if spec type is in supported formats
-        if spec_type in self.storm_spec_not_implemented:
-            raise NotImplementedError(f"'{spec_type}' has not been implemented.")
-        # Write out values
-        self.data_write(name="storm_specification_type", value=spec_type,
-                        description="(Storm specification)")
+            legacy = self.storm_type if self.storm_type is not None \
+                else self.storm_specification_type
+            family, subtype, _ = resolve_forcing_subtype(legacy)
+
+        # Write the explicit family/subtype tokens (quoted single words, read
+        # list-directed by the Fortran side; see storm_module.f90).
+        self.data_write(name="storm_family", value=family,
+                        description="(Forcing family: parametric | gridded | none)")
+        self.data_write(name="storm_subtype", value=subtype,
+                        description="(Forcing subtype / parametric model)")
         self.data_write(name="storm_file", description='(Path to storm data)')
 
         self.close_data_file()

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -312,9 +312,57 @@ def test_surge_data_roundtrip(tmp_path):
     expected_spec = clawpack.geoclaw.data.SurgeData.storm_spec_dict_mapping["data"]
     assert read_surge_data.storm_specification_type == expected_spec
     assert read_surge_data.storm_file == surge_data.storm_file
+    # Legacy "data" resolves to the gridded family on the new wire.
+    assert read_surge_data.storm_family == "gridded"
+    assert read_surge_data.storm_subtype == "gridded"
 
     text = _read_text(data_file)
     assert "synthetic.storm" in text
+
+
+@pytest.mark.python
+def test_surge_forcing_family_subtype(tmp_path):
+    r"""family/subtype API, legacy aliases, and the fixed lookup bugs."""
+    data = clawpack.geoclaw.data
+
+    # Registry / alias resolution, including the previously-broken 'DeMaria'
+    # case-mismatch and the hyphen/underscore + holland08/10 spellings.
+    assert data.resolve_forcing_subtype("holland80") == ("parametric", "holland80", 1)
+    assert data.resolve_forcing_subtype("DeMaria") == ("parametric", "demaria", 7)
+    assert data.resolve_forcing_subtype("modified-rankine") == \
+        ("parametric", "modified_rankine", 6)
+    assert data.resolve_forcing_subtype("holland08") == ("parametric", "holland2008", 8)
+    assert data.resolve_forcing_subtype("data") == ("gridded", "gridded", -1)
+    assert data.resolve_forcing_subtype(None) == ("none", "none", 0)
+    assert data.resolve_forcing_subtype(-1) == ("gridded", "gridded", -1)
+
+    # New family/subtype API round-trips and populates the legacy selector.
+    surge_data = data.SurgeData()
+    surge_data.storm_family = "parametric"
+    surge_data.storm_subtype = "holland2010"
+    surge_data.storm_file = "b.storm"
+    out = tmp_path / "surge.data"
+    surge_data.write(out_file=out)
+
+    read_back = data.SurgeData()
+    read_back.read(out)
+    assert read_back.storm_family == "parametric"
+    assert read_back.storm_subtype == "holland2010"
+    assert read_back.storm_specification_type == 2
+    assert read_back.storm_file == "b.storm"
+
+    # Explicit tokens are on the wire; the raw integer selector is not.
+    text = _read_text(out)
+    assert "storm_family" in text and "storm_subtype" in text
+    assert "'parametric'" in text and "'holland2010'" in text
+
+    # An inconsistent family/subtype pair is rejected at write time.
+    bad = data.SurgeData()
+    bad.storm_family = "gridded"
+    bad.storm_subtype = "holland80"
+    bad.storm_file = "x"
+    with pytest.raises(ValueError, match="inconsistent"):
+        bad.write(out_file=tmp_path / "bad.data")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replace the overloaded integer storm_specification_type with an explicit storm_family (parametric | gridded | none) + storm_subtype at the Python API and on the surge.data wire, updating the Fortran reader in lockstep.

- data.py: add a single canonical forcing_subtype_registry (subtype -> (family, legacy int)) with an alias table and resolve_forcing_subtype(); storm_spec_dict_mapping now derives from it. Fix the case-mismatch that made 'demaria' unreachable and drop the dead ['CLE'] not-implemented check (CLE is implemented in Fortran). Add storm_family/storm_subtype attributes; keep storm_specification_type as a plain stored attribute for backwards compatibility. write()/read() use the new two-token wire.
- storm_module.f90: read the family + subtype tokens and translate the subtype back to the legacy storm_specification_type integer via a new forcing_spec_type() helper, leaving the existing dispatch unchanged; derive storm_location_available from the parametric family.
- test_data.py: extend the SurgeData round-trip and add family/subtype and alias-resolution coverage.

Behavior-neutral on the forcing physics (the surge.data text changes by design): met_forcing aux, ike, isaac, and the bowl-slosh canary all reproduce their goldens with no regeneration.

Assisted-by: claude claude-opus-4-8