### PR TITLE
Phase F3: rename storm modules/types to met-forcing vocabulary

### DIFF
--- a/src/2d/bouss/Makefile.bouss
+++ b/src/2d/bouss/Makefile.bouss
@@ -17,9 +17,9 @@ COMMON_MODULES += \
  $(GEOLIB)/qinit_module.f90 \
  $(GEOLIB)/refinement_module.f90 \
  $(GEOLIB)/fgmax_module.f90 \
- $(GEOLIB)/surge/model_storm_module.f90 \
- $(GEOLIB)/surge/data_storm_module.f90 \
- $(GEOLIB)/surge/storm_module.f90 \
+ $(GEOLIB)/surge/parametric_met_forcing_module.f90 \
+ $(GEOLIB)/surge/gridded_met_forcing_module.f90 \
+ $(GEOLIB)/surge/met_forcing_module.f90 \
  $(GEOLIB)/gauges_module.f90 \
  $(GEOLIB)/multilayer/multilayer_module.f90 \
  $(GEOLIB)/friction_module.f90 \

--- a/src/2d/bouss/amr2.f90
+++ b/src/2d/bouss/amr2.f90
@@ -107,7 +107,7 @@ program amr2
     use topo_module, only: read_topo_settings, read_dtopo_settings
     use qinit_module, only: set_qinit
     use refinement_module, only: set_refinement
-    use storm_module, only: set_storm
+    use met_forcing_module, only: set_storm
     use friction_module, only: setup_variable_friction
     use gauges_module, only: set_gauges, num_gauges
     use regions_module, only: set_regions

--- a/src/2d/bouss/valout.f90
+++ b/src/2d/bouss/valout.f90
@@ -14,9 +14,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: timeValout, timeValoutCPU, tvoll, tvollCPU, rvoll
     use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
-    use storm_module, only: storm_specification_type, output_storm_location
-    use storm_module, only: storm_location_available
-    use storm_module, only: landfall, display_landfall_time
+    use met_forcing_module, only: storm_specification_type, output_storm_location
+    use met_forcing_module, only: storm_location_available
+    use met_forcing_module, only: landfall, display_landfall_time
 
 #ifdef HDF5
     use hdf5

--- a/src/2d/shallow/Makefile.geoclaw
+++ b/src/2d/shallow/Makefile.geoclaw
@@ -18,9 +18,9 @@ COMMON_MODULES += \
  $(GEOLIB)/refinement_module.f90 \
  $(GEOLIB)/fgout_module.f90 \
  $(GEOLIB)/fgmax_module.f90 \
- $(GEOLIB)/surge/model_storm_module.f90 \
- $(GEOLIB)/surge/data_storm_module.f90 \
- $(GEOLIB)/surge/storm_module.f90 \
+ $(GEOLIB)/surge/parametric_met_forcing_module.f90 \
+ $(GEOLIB)/surge/gridded_met_forcing_module.f90 \
+ $(GEOLIB)/surge/met_forcing_module.f90 \
  $(GEOLIB)/gauges_module.f90 \
  $(GEOLIB)/multilayer/multilayer_module.f90 \
  $(GEOLIB)/friction_module.f90 \

--- a/src/2d/shallow/amr2.f90
+++ b/src/2d/shallow/amr2.f90
@@ -98,7 +98,7 @@ program amr2
     use topo_module, only: read_topo_settings, read_dtopo_settings
     use qinit_module, only: set_qinit
     use refinement_module, only: set_refinement
-    use storm_module, only: set_storm
+    use met_forcing_module, only: set_storm
     use friction_module, only: setup_variable_friction
     use gauges_module, only: set_gauges, num_gauges
     use regions_module, only: set_regions

--- a/src/2d/shallow/b4step2.f90
+++ b/src/2d/shallow/b4step2.f90
@@ -27,7 +27,7 @@ subroutine b4step2(mbc, mx, my, meqn, q, xlower, ylower, dx, dy, t, dt,        &
     use amr_module, only: xperdom,yperdom,spheredom,NEEDS_TO_BE_SET
     use amr_module, only: outunit
 
-    use storm_module, only: set_storm_fields
+    use met_forcing_module, only: set_storm_fields
 
     implicit none
 

--- a/src/2d/shallow/flag2refine2.f90
+++ b/src/2d/shallow/flag2refine2.f90
@@ -27,9 +27,9 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
     use geoclaw_module, only: spherical_distance, coordinate_system
 
 
-    use storm_module, only: storm_specification_type, wind_refine, R_refine
-    use storm_module, only: storm_location, wind_forcing, wind_index, wind_refine
-    use storm_module, only: storm_location_available
+    use met_forcing_module, only: storm_specification_type, wind_refine, R_refine
+    use met_forcing_module, only: storm_location, wind_forcing, wind_index, wind_refine
+    use met_forcing_module, only: storm_location_available
 
     use regions_module, only: num_regions, regions
     use refinement_module, only: wave_tolerance, speed_tolerance

--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -422,7 +422,7 @@ contains
         use geoclaw_module, only: dry_tolerance
         use geoclaw_module, only: coordinate_system, earth_radius, deg2rad
         use geoclaw_module, only: ambient_pressure
-        use storm_module, only: pressure_index
+        use met_forcing_module, only: pressure_index
 
         implicit none
 

--- a/src/2d/shallow/multilayer/Makefile.multilayer
+++ b/src/2d/shallow/multilayer/Makefile.multilayer
@@ -29,9 +29,9 @@ COMMON_MODULES += \
 COMMON_MODULES += \
   $(GEOLIB)/utility_module.f90 \
   $(GEOLIB)/geoclaw_module.f90 \
-  $(GEOLIB)/surge/model_storm_module.f90 \
-  $(GEOLIB)/surge/data_storm_module.f90 \
-  $(GEOLIB)/surge/storm_module.f90 \
+  $(GEOLIB)/surge/parametric_met_forcing_module.f90 \
+  $(GEOLIB)/surge/gridded_met_forcing_module.f90 \
+  $(GEOLIB)/surge/met_forcing_module.f90 \
   $(GEOLIB)/multilayer/multilayer_module.f90 \
   $(GEOLIB)/multilayer/gauges_module.f90 \
   $(GEOLIB)/topo_module.f90 \

--- a/src/2d/shallow/multilayer/b4step2.f90
+++ b/src/2d/shallow/multilayer/b4step2.f90
@@ -24,7 +24,7 @@ subroutine b4step2(mbc, mx, my, meqn, q, xlower, ylower, dx, dy, t, dt,        &
     use topo_module, only: aux_finalized
     use topo_module, only: xlowdtopo,xhidtopo,ylowdtopo,yhidtopo
 
-    use storm_module, only: set_storm_fields
+    use met_forcing_module, only: set_storm_fields
 
     use multilayer_module, only: num_layers, KAPPA_UNIT, dry_tolerance
     use multilayer_module, only: check_richardson, richardson_tolerance

--- a/src/2d/shallow/multilayer/flag2refine2.f90
+++ b/src/2d/shallow/multilayer/flag2refine2.f90
@@ -27,9 +27,9 @@ subroutine flag2refine2(mx,my,mbc,mbuff,meqn,maux,xlower,ylower,dx,dy,t,level, &
     use geoclaw_module, only: spherical_distance, coordinate_system
 
 
-    use storm_module, only: storm_specification_type, wind_refine, R_refine
-    use storm_module, only: storm_location, wind_forcing, wind_index, wind_refine
-    use storm_module, only: storm_location_available
+    use met_forcing_module, only: storm_specification_type, wind_refine, R_refine
+    use met_forcing_module, only: storm_location, wind_forcing, wind_index, wind_refine
+    use met_forcing_module, only: storm_location_available
 
     use regions_module, only: num_regions, regions
     use refinement_module, only: speed_tolerance

--- a/src/2d/shallow/multilayer/multilayer_module.f90
+++ b/src/2d/shallow/multilayer/multilayer_module.f90
@@ -52,7 +52,7 @@ contains
 
         use geoclaw_module, only: GEO_PARM_UNIT, rho
         use geoclaw_module, only: geo_dry_tolerance => dry_tolerance
-        use storm_module, only: storm_specification_type
+        use met_forcing_module, only: storm_specification_type
 
         implicit none
         character(len=*), optional, intent(in) :: data_file

--- a/src/2d/shallow/multilayer/setaux.f90
+++ b/src/2d/shallow/multilayer/setaux.f90
@@ -18,8 +18,8 @@ subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux)
     use geoclaw_module, only: coordinate_system, earth_radius, deg2rad
     use geoclaw_module, only: sea_level, ambient_pressure
 
-    use storm_module, only: wind_forcing, pressure_forcing
-    use storm_module, only: wind_index, pressure_index, set_storm_fields
+    use met_forcing_module, only: wind_forcing, pressure_forcing
+    use met_forcing_module, only: wind_index, pressure_index, set_storm_fields
 
     use friction_module, only: variable_friction, friction_index
     use friction_module, only: set_friction_field

--- a/src/2d/shallow/multilayer/src2.f90
+++ b/src/2d/shallow/multilayer/src2.f90
@@ -1,10 +1,10 @@
 subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
       
-    use storm_module, only: wind_forcing, pressure_forcing
-    use storm_module, only: wind_drag
-    use storm_module, only: wind_index, pressure_index
-    use storm_module, only: storm_direction, storm_location
-    use storm_module, only: storm_location_available
+    use met_forcing_module, only: wind_forcing, pressure_forcing
+    use met_forcing_module, only: wind_drag
+    use met_forcing_module, only: wind_index, pressure_index
+    use met_forcing_module, only: storm_direction, storm_location
+    use met_forcing_module, only: storm_location_available
 
     use friction_module, only: friction_index
 

--- a/src/2d/shallow/multilayer/valout.f90
+++ b/src/2d/shallow/multilayer/valout.f90
@@ -14,9 +14,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: timeValout, timeValoutCPU, tvoll, tvollCPU, rvoll
     use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
-    use storm_module, only: storm_specification_type, output_storm_location
-    use storm_module, only: storm_location_available
-    use storm_module, only: landfall, display_landfall_time
+    use met_forcing_module, only: storm_specification_type, output_storm_location
+    use met_forcing_module, only: storm_location_available
+    use met_forcing_module, only: landfall, display_landfall_time
 
     use geoclaw_module, only: rho
     use multilayer_module, only: num_layers

--- a/src/2d/shallow/setaux.f90
+++ b/src/2d/shallow/setaux.f90
@@ -32,8 +32,8 @@ subroutine setaux(mbc,mx,my,xlow,ylow,dx,dy,maux,aux)
     use geoclaw_module, only: coordinate_system, earth_radius, deg2rad
     use geoclaw_module, only: sea_level, ambient_pressure
 
-    use storm_module, only: wind_forcing, pressure_forcing
-    use storm_module, only: wind_index, pressure_index, set_storm_fields
+    use met_forcing_module, only: wind_forcing, pressure_forcing
+    use met_forcing_module, only: wind_index, pressure_index, set_storm_fields
 
     use friction_module, only: variable_friction, friction_index
     use friction_module, only: set_friction_field

--- a/src/2d/shallow/src1d.f90
+++ b/src/2d/shallow/src1d.f90
@@ -11,9 +11,9 @@ subroutine src1d(meqn,mbc,mx1d,q1d,maux,aux1d,t,dt)
     use geoclaw_module, only: omega, coordinate_system, manning_coefficient
     use geoclaw_module, only: manning_break, num_manning, dry_tolerance, rho_air
     
-    use storm_module, only: wind_forcing, pressure_forcing, wind_drag
-    use storm_module, only: wind_index, pressure_index
-    use storm_module, only: storm_direction, storm_location
+    use met_forcing_module, only: wind_forcing, pressure_forcing, wind_drag
+    use met_forcing_module, only: wind_index, pressure_index
+    use met_forcing_module, only: storm_direction, storm_location
 
     use friction_module, only: variable_friction, friction_index
 

--- a/src/2d/shallow/src2.f90
+++ b/src/2d/shallow/src2.f90
@@ -11,10 +11,10 @@ subroutine src2(meqn,mbc,mx,my,xlower,ylower,dx,dy,q,maux,aux,t,dt)
 
     use geoclaw_module, only: speed_limit  ! used if no friction
       
-    use storm_module, only: wind_forcing, pressure_forcing, wind_drag
-    use storm_module, only: wind_index, pressure_index
-    use storm_module, only: storm_direction, storm_location
-    use storm_module, only: storm_location_available
+    use met_forcing_module, only: wind_forcing, pressure_forcing, wind_drag
+    use met_forcing_module, only: wind_index, pressure_index
+    use met_forcing_module, only: storm_direction, storm_location
+    use met_forcing_module, only: storm_location_available
 
     use friction_module, only: variable_friction, friction_index
 

--- a/src/2d/shallow/surge/gridded_met_forcing_module.f90
+++ b/src/2d/shallow/surge/gridded_met_forcing_module.f90
@@ -1,5 +1,5 @@
 ! ==============================================================================
-! data_storm_module
+! gridded_met_forcing_module
 !
 ! Module contains routines for constructing a wind and pressure field based on a
 ! provided set of data files.
@@ -10,7 +10,7 @@
 !  license
 !                     http://www.opensource.org/licenses/
 ! ==============================================================================
-module data_storm_module
+module gridded_met_forcing_module
 
     implicit none
     save
@@ -19,7 +19,7 @@ module data_storm_module
     logical, private :: DEBUG = .false.
 
     ! Model storm type definition
-    type data_storm_type
+    type gridded_met_forcing_type
 
         ! Total number of wind/pressure fields
         ! integer :: num_casts
@@ -41,7 +41,7 @@ module data_storm_module
         ! Paths to data
         character(len=512), allocatable :: paths(:)
 
-    end type data_storm_type
+    end type gridded_met_forcing_type
 
     integer, private :: last_storm_index
 
@@ -91,7 +91,7 @@ contains
 
         ! Subroutine I/O
         character(len=*), optional :: storm_data_path
-        type(data_storm_type), intent(inout) :: storm
+        type(gridded_met_forcing_type), intent(inout) :: storm
         integer, intent(in) :: storm_spec_type, log_unit
 
         ! General data
@@ -668,7 +668,7 @@ contains
         implicit none
 
         ! Input arguments
-        type(data_storm_type) :: storm
+        type(gridded_met_forcing_type) :: storm
         character(len=*), intent(in) :: wind_file, pressure_file
         integer, intent(in) :: mx_full, my_full, mt, i0, j0, mx, my
         integer, intent(in) :: seconds_from_offset
@@ -725,7 +725,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t
-        type(data_storm_type), intent(in) :: storm
+        type(gridded_met_forcing_type), intent(in) :: storm
 
         ! Locals
         real(kind=8) :: t0,t1
@@ -782,7 +782,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t
-        type(data_storm_type), intent(inout) :: storm
+        type(gridded_met_forcing_type), intent(inout) :: storm
 
         ! Output
         real(kind=8) :: location(2)
@@ -800,7 +800,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t
-        type(data_storm_type), intent(in) :: storm
+        type(gridded_met_forcing_type), intent(in) :: storm
 
         stop "Storm direction for data storms is not supported."
 
@@ -822,7 +822,7 @@ contains
         real(kind=8), intent(in) :: xlower, ylower, dx, dy, t
 
         ! Storm descrption
-        type(data_storm_type), intent(inout) :: storm
+        type(gridded_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and pressure field
         integer, intent(in) :: wind_index, pressure_index
@@ -908,7 +908,7 @@ contains
         implicit none
         integer, intent(in) :: maux, mbc, mx, my
         real(kind=8), intent(in) :: xlower, ylower, dx, dy, t
-        type(data_storm_type), intent(inout) :: storm
+        type(gridded_met_forcing_type), intent(inout) :: storm
         integer, intent(in) :: wind_index, pressure_index
         real(kind=8), intent(inout) :: aux(maux, 1-mbc:mx+mbc, 1-mbc:my+mbc)
 
@@ -926,7 +926,7 @@ contains
         implicit none
         integer, intent(in) :: maux, mbc, mx, my
         real(kind=8), intent(in) :: xlower, ylower, dx, dy, t
-        type(data_storm_type), intent(inout) :: storm
+        type(gridded_met_forcing_type), intent(inout) :: storm
         integer, intent(in) :: wind_index, pressure_index
         real(kind=8), intent(inout) :: aux(maux, 1-mbc:mx+mbc, 1-mbc:my+mbc)
 
@@ -942,7 +942,7 @@ contains
 
         implicit none
         ! Subroutine IO
-        type(data_storm_type), intent(in) :: storm
+        type(gridded_met_forcing_type), intent(in) :: storm
         real(kind=8), intent(in) :: t
         real(kind=8), intent(inout) :: wind_u(size(storm%longitude),        &
                                               size(storm%latitude))
@@ -1001,7 +1001,7 @@ contains
         implicit none
 
         ! Subroutine I/O
-        type(data_storm_type), intent(in) :: storm
+        type(gridded_met_forcing_type), intent(in) :: storm
         real(kind=8), intent(in) :: x, y, interp_array(size(storm%longitude),  &
                                                        size(storm%latitude))
 
@@ -1066,7 +1066,7 @@ contains
     pure subroutine find_nearest(storm, x, y, lon, lat,  xidx, yidx)
         implicit none
         ! Subroutine I/O
-        type(data_storm_type), intent(in) :: storm
+        type(gridded_met_forcing_type), intent(in) :: storm
         real(kind=8), intent(in) :: x, y
         real(kind=8), intent(out) :: lon, lat
         integer, intent(out) :: xidx, yidx
@@ -1077,4 +1077,4 @@ contains
         lat = storm%latitude(yidx)
     end subroutine find_nearest
 
-end module data_storm_module
+end module gridded_met_forcing_module

--- a/src/2d/shallow/surge/met_forcing_module.f90
+++ b/src/2d/shallow/surge/met_forcing_module.f90
@@ -9,10 +9,10 @@
 !                     http://www.opensource.org/licenses/
 ! ==============================================================================
 
-module storm_module
+module met_forcing_module
 
-    use model_storm_module, only: model_storm_type, rotation
-    use data_storm_module, only: data_storm_type
+    use parametric_met_forcing_module, only: parametric_met_forcing_type, rotation
+    use gridded_met_forcing_module, only: gridded_met_forcing_type
 
     implicit none
 
@@ -53,13 +53,13 @@ module storm_module
     ! R_refine, sector-based wind drag, fort.track output) is guarded on this.
     logical :: storm_location_available = .false.
     real(kind=8) :: landfall = 0.d0
-    type(model_storm_type), save :: model_storm
-    type(data_storm_type), save :: data_storm
+    type(parametric_met_forcing_type), save :: model_storm
+    type(gridded_met_forcing_type), save :: data_storm
 
     ! Storm time scaling and temporal onset/cutoff ramp.
     ! storm_time_scale stretches (>1, slower) or compresses (<1, faster) the
     !   model-storm timeline about landfall (data storms scale internally in
-    !   data_storm_module).
+    !   gridded_met_forcing_module).
     ! t_ramp_on / t_ramp_off (seconds) smoothly turn the wind/pressure forcing
     !   on after t0 and off before tfinal using a raised-cosine taper.  Zero
     !   (default) disables the corresponding taper.  Applies to both storm
@@ -76,12 +76,12 @@ module storm_module
                                       dx, dy, t, aux, wind_index,              &
                                       pressure_index, storm)
 
-            use model_storm_module, only: model_storm_type
+            use parametric_met_forcing_module, only: parametric_met_forcing_type
 
             implicit none
             integer, intent(in) :: maux,mbc,mx,my
             real(kind=8), intent(in) :: xlower,ylower,dx,dy,t
-            type(model_storm_type), intent(inout) :: storm
+            type(parametric_met_forcing_type), intent(inout) :: storm
             integer, intent(in) :: wind_index, pressure_index
             real(kind=8), intent(inout) :: aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc)
         end subroutine set_model_fields_def
@@ -92,12 +92,12 @@ module storm_module
                                       dx, dy, t, aux, wind_index,           &
                                       pressure_index, storm)
 
-            use data_storm_module, only: data_storm_type
+            use gridded_met_forcing_module, only: gridded_met_forcing_type
 
             implicit none
             integer, intent(in) :: maux, mbc, mx, my
             real(kind=8), intent(in) :: xlower, ylower, dx, dy, t
-            type(data_storm_type), intent(inout) :: storm
+            type(gridded_met_forcing_type), intent(inout) :: storm
             integer, intent(in) :: wind_index, pressure_index
             real(kind=8), intent(inout) :: aux(maux,1-mbc:mx+mbc,1-mbc:my+mbc)
         end subroutine set_data_fields_def
@@ -121,19 +121,19 @@ contains
     ! ========================================================================
     subroutine set_storm(data_file)
 
-        use model_storm_module, only: set_model_storm => set_storm
-        use model_storm_module, only: set_holland_1980_fields
-        use model_storm_module, only: set_holland_2008_fields
-        use model_storm_module, only: set_holland_2010_fields
-        use model_storm_module, only: set_CLE_fields
-        use model_storm_module, only: set_SLOSH_fields
-        use model_storm_module, only: set_rankine_fields
-        use model_storm_module, only: set_modified_rankine_fields
-        use model_storm_module, only: set_deMaria_fields
-        use model_storm_module, only: set_willoughby_fields
+        use parametric_met_forcing_module, only: set_model_storm => set_storm
+        use parametric_met_forcing_module, only: set_holland_1980_fields
+        use parametric_met_forcing_module, only: set_holland_2008_fields
+        use parametric_met_forcing_module, only: set_holland_2010_fields
+        use parametric_met_forcing_module, only: set_CLE_fields
+        use parametric_met_forcing_module, only: set_SLOSH_fields
+        use parametric_met_forcing_module, only: set_rankine_fields
+        use parametric_met_forcing_module, only: set_modified_rankine_fields
+        use parametric_met_forcing_module, only: set_deMaria_fields
+        use parametric_met_forcing_module, only: set_willoughby_fields
 
-        use data_storm_module, only: set_data_storm => set_storm
-        use data_storm_module, only: set_ascii_fields, set_netcdf_fields
+        use gridded_met_forcing_module, only: set_data_storm => set_storm
+        use gridded_met_forcing_module, only: set_ascii_fields, set_netcdf_fields
 
         use utility_module, only: get_value_count
 
@@ -467,8 +467,8 @@ contains
 
         use amr_module, only: rinfinity
 
-        use model_storm_module, only: model_location => storm_location
-        use data_storm_module, only: data_location => storm_location
+        use parametric_met_forcing_module, only: model_location => storm_location
+        use gridded_met_forcing_module, only: data_location => storm_location
 
         implicit none
 
@@ -494,8 +494,8 @@ contains
     real(kind=8) function storm_direction(t) result(theta)
 
         use amr_module, only: rinfinity
-        use model_storm_module, only: model_direction => storm_direction
-        use data_storm_module, only: data_direction => storm_direction
+        use parametric_met_forcing_module, only: model_direction => storm_direction
+        use gridded_met_forcing_module, only: data_direction => storm_direction
 
         implicit none
 
@@ -538,7 +538,7 @@ contains
                                   pressure_index, model_storm)
         end if
         if (storm_specification_type < 0) then
-            ! Data storms apply storm_time_scale internally (data_storm_module).
+            ! Data storms apply storm_time_scale internally (gridded_met_forcing_module).
             call set_data_fields(maux,mbc,mx,my, &
                                  xlower,ylower,dx,dy,t,aux, wind_index, &
                                  pressure_index, data_storm)
@@ -563,7 +563,7 @@ contains
     !  Ramps from 0 at t0 up to 1 at t0 + t_ramp_on (onset), and from 1 down
     !  to 0 over [tfinal - t_ramp_off, tfinal] (cutoff).  A zero width
     !  disables that side (multiplier 1).  Same raised-cosine shape as the
-    !  spatial met edge ramp in data_storm_module.
+    !  spatial met edge ramp in gridded_met_forcing_module.
     ! ========================================================================
     real(kind=8) function temporal_ramp(t) result(ramp_t)
 
@@ -627,4 +627,4 @@ contains
         rotation = .false.
     end function S_rotation
     
-end module storm_module
+end module met_forcing_module

--- a/src/2d/shallow/surge/parametric_met_forcing_module.f90
+++ b/src/2d/shallow/surge/parametric_met_forcing_module.f90
@@ -1,5 +1,5 @@
 ! ==============================================================================
-! model_storm_module
+! parametric_met_forcing_module
 !
 ! Module contains routines for constructing a wind and pressure field based on
 ! the a parameterized model of the wind and pressure fields.
@@ -10,7 +10,7 @@
 !  license
 !                     http://www.opensource.org/licenses/
 ! ==============================================================================
-module model_storm_module
+module parametric_met_forcing_module
 
     implicit none
     save
@@ -19,7 +19,7 @@ module model_storm_module
     logical, private :: DEBUG = .false.
 
     ! Model storm type definition
-    type model_storm_type
+    type parametric_met_forcing_type
         ! Fore/hindcast size and current position
         integer :: num_casts
 
@@ -49,7 +49,7 @@ module model_storm_module
         ! Approximate pressure change of storm, approximated using first order differences
         real(kind=8), allocatable :: central_pressure_change(:)
 
-    end type model_storm_type
+    end type parametric_met_forcing_type
 
     ! How to deterimine which way a storm should be made to spin
     ! The default defers simply to assuming y is a latitude
@@ -94,7 +94,7 @@ contains
 
         ! Subroutine I/O
         character(len=*), optional :: storm_data_path
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
         integer, intent(in) :: storm_spec_type, log_unit
 
         ! Local storage
@@ -222,7 +222,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t
-        type(model_storm_type), intent(in out) :: storm
+        type(parametric_met_forcing_type), intent(in out) :: storm
 
         ! Output
         real(kind=8) :: location(2)
@@ -245,7 +245,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t
-        type(model_storm_type), intent(in) :: storm
+        type(parametric_met_forcing_type), intent(in) :: storm
 
         ! Locals
         real(kind=8) :: junk(7), velocity(2)
@@ -281,7 +281,7 @@ contains
     ! ==========================================================================
     !  storm_index(t,storm)
     !    Finds the index of the next storm data point
-    !    This duplicates data_storm_module:storm_index
+    !    This duplicates gridded_met_forcing_module:storm_index
     ! ==========================================================================
     integer pure function storm_index(t, storm) result(index)
 
@@ -289,7 +289,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t
-        type(model_storm_type), intent(in) :: storm
+        type(parametric_met_forcing_type), intent(in) :: storm
 
         ! Locals
         real(kind=8) :: t0,t1
@@ -353,7 +353,7 @@ contains
 
         ! Input
         real(kind=8), intent(in) :: t                 ! Current time
-        type(model_storm_type), intent(in) :: storm   ! Storm
+        type(parametric_met_forcing_type), intent(in) :: storm   ! Storm
 
         ! Output
         real(kind=8), intent(out) :: location(2), velocity(2)
@@ -619,7 +619,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -691,7 +691,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -768,7 +768,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -856,7 +856,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(in out) :: storm
+        type(parametric_met_forcing_type), intent(in out) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -1221,7 +1221,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -1300,7 +1300,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -1376,7 +1376,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -1466,7 +1466,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -1538,7 +1538,7 @@ contains
 
         ! Storm description, need in out here since we may update the storm
         ! if at next time point
-        type(model_storm_type), intent(inout) :: storm
+        type(parametric_met_forcing_type), intent(inout) :: storm
 
         ! Array storing wind and presure field
         integer, intent(in) :: wind_index, pressure_index
@@ -1608,4 +1608,4 @@ contains
         enddo
 
     end subroutine set_willoughby_fields
-end module model_storm_module
+end module parametric_met_forcing_module

--- a/src/2d/shallow/tick.f
+++ b/src/2d/shallow/tick.f
@@ -12,7 +12,7 @@ c
       use gauges_module, only: setbestsrc, num_gauges
       use gauges_module, only: print_gauges_and_reset_nextLoc
 
-      use storm_module, only: landfall, display_landfall_time
+      use met_forcing_module, only: landfall, display_landfall_time
       use fgmax_module, only: FG_num_fgrids, FG_fgrids, fgrid
       use fgout_module, only: FGOUT_num_grids, FGOUT_fgrids,
      &                         fgout_write,fgout_grid, FGOUT_ttol

--- a/src/2d/shallow/valout.f90
+++ b/src/2d/shallow/valout.f90
@@ -14,9 +14,9 @@ subroutine valout(level_begin, level_end, time, num_eqn, num_aux)
     use amr_module, only: timeValout, timeValoutCPU, tvoll, tvollCPU, rvoll
     use amr_module, only: timeTick, tick_clock_start, t0, timeTickCPU
 
-    use storm_module, only: storm_specification_type, output_storm_location
-    use storm_module, only: storm_location_available
-    use storm_module, only: landfall, display_landfall_time
+    use met_forcing_module, only: storm_specification_type, output_storm_location
+    use met_forcing_module, only: storm_location_available
+    use met_forcing_module, only: landfall, display_landfall_time
 
 #ifdef HDF5
     use hdf5

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -843,7 +843,7 @@ class QinitData(clawpack.clawutil.data.ClawData):
 #  Each parametric subtype maps to that model's historical integer code; the
 #  single gridded subtype maps to -1 and "none" to 0.  The gridded ASCII/NetCDF
 #  distinction is NOT on this wire - it lives as ``file_format`` in the .storm
-#  descriptor (see surge/gridded.py and data_storm_module.f90).
+#  descriptor (see surge/gridded.py and gridded_met_forcing_module.f90).
 
 # canonical subtype -> (family, legacy integer code)
 forcing_subtype_registry = {"holland80":        ("parametric",  1),
@@ -872,7 +872,7 @@ forcing_subtype_aliases = {"holland08":        "holland2008",
 # code.  Currently empty: all nine parametric models and the gridded path have
 # working Fortran implementations.  (The previous ``storm_spec_not_implemented``
 # check compared an int against the string 'CLE' and so never fired; CLE is in
-# fact implemented in model_storm_module.f90, so nothing is blocked here.)
+# fact implemented in parametric_met_forcing_module.f90, so nothing is blocked here.)
 forcing_not_implemented = set()
 
 # Reverse map: legacy integer code -> canonical subtype (each code is unique).
@@ -1091,7 +1091,7 @@ class SurgeData(clawpack.clawutil.data.ClawData):
             family, subtype, _ = resolve_forcing_subtype(legacy)
 
         # Write the explicit family/subtype tokens (quoted single words, read
-        # list-directed by the Fortran side; see storm_module.f90).
+        # list-directed by the Fortran side; see met_forcing_module.f90).
         self.data_write(name="storm_family", value=family,
                         description="(Forcing family: parametric | gridded | none)")
         self.data_write(name="storm_subtype", value=subtype,


### PR DESCRIPTION
Final step of the meteorological-forcing refactor: rename the Fortran modules and derived types from the overloaded 'storm' vocabulary to the met-forcing vocabulary.  Pure, behavior-neutral rename - no logic changes.

- storm_module        -> met_forcing_module
- model_storm_module  -> parametric_met_forcing_module
- data_storm_module   -> gridded_met_forcing_module
- model_storm_type    -> parametric_met_forcing_type
- data_storm_type     -> gridded_met_forcing_type

Renames the three surge source files to match, swaps all 17 in-repo 'use storm_module' sites (shallow, multilayer, bouss) and the three build Makefiles, and updates stale Fortran-filename references in the data.py comments.  Internal procedure/variable names are intentionally left unchanged (a later cleanup).

The GeoClaw Riemann solvers in clawpack/riemann consume this module for the pressure term; they are renamed in a lockstep riemann PR clawpack/riemann#191.  Neither repo builds without the other, so the two PRs must merge together.

Verified behavior-neutral with no golden regeneration: met_forcing aux (byte-identical), ike, isaac, and the bowl-slosh canary all reproduce their goldens; shallow and multilayer builds link.  (The bouss link is covered by CI; local PETSc was unavailable.)

Assisted-by: claude claude-opus-4-8