### PR TITLE
Document met-forcing selection in SurgeData and the surge examples

### DIFF
--- a/examples/storm-surge/ike/setrun.py
+++ b/examples/storm-surge/ike/setrun.py
@@ -413,8 +413,14 @@ def setgeo(rundata, download_dir=None):
     data.wind_refine = [20.0, 40.0, 60.0]
     data.R_refine = [60.0e3, 40e3, 20e3]
 
-    # Storm parameters - Parameterized storm (Holland 1980)
-    data.storm_specification_type = 'holland80'  # (type 1)
+    # Storm parameters - Parameterized storm (Holland 1980).
+    #
+    # Preferred (explicit) selection via family + subtype:
+    #     data.storm_family = "parametric"
+    #     data.storm_subtype = "holland80"
+    # The legacy storm_specification_type below is equivalent and still
+    # supported (see the surge_data reference in the GeoClaw docs).
+    data.storm_specification_type = 'holland80'  # (parametric / holland80)
     data.storm_file = os.path.expandvars(os.path.join(os.getcwd(),
                                          'ike.storm'))
 

--- a/examples/storm-surge/isaac/README.rst
+++ b/examples/storm-surge/isaac/README.rst
@@ -1,13 +1,42 @@
 
 .. _geoclaw_examples_storm_surge_hurricane_isaac:
 
-Basic Example of Storm Surge from Hurricane Isaac
-=================================================
+Storm Surge from Hurricane Isaac (parametric and gridded forcing)
+=================================================================
 
 This example contains the data and setup for running a storm surge forecast for
-Hurricane Isaac.  The example can be run via::
+Hurricane Isaac (2012).  It doubles as a demonstration of GeoClaw's two
+meteorological-forcing families driven from the *same* ATCF best-track file
+(``bal092012.dat``).  The example can be run via::
 
     make all
 
-which should download the necessary topography and storm data, start the 
-simulation and plot the results.
+which downloads the necessary topography, writes the storm forcing file, runs
+the simulation, and plots the results.
+
+Forcing variants
+----------------
+
+The forcing is selected in ``setrun.py`` through ``rundata.surge_data``.  By
+default the example uses the **parametric** Holland 1980 model
+(``storm_specification_type = 'holland80'``), which reads the ATCF track and
+writes a compact GeoClaw storm file.
+
+To use **gridded** forcing instead, set ``storm_specification_type = 'data'``
+(equivalently, family ``"gridded"``).  Two gridded formats are supported and
+shown in ``setrun.py``:
+
+- **OWI / ASCII (NWS12)** -- a ``.PRE``/``.WIN`` pressure/wind file pair
+  (``isaac.PRE`` / ``isaac.WIN``).  This is the default gridded branch.
+- **NetCDF (NWS13)** -- a single CF-compliant ``.nc`` file of wind (``u10``,
+  ``v10``) and mean-sea-level pressure (``msl``); see :ref:`netcdf_input` for
+  the variable/coordinate conventions and automatic discovery.  Enable the
+  commented NetCDF lines in ``setrun.py`` and build with NetCDF support
+  (``-DNETCDF``).
+
+The committed ``regression_data`` covers the ``holland80`` and OWI-ASCII
+variants, and the test suite additionally exercises ERA5/NWS13 NetCDF forcing.
+
+See :ref:`quick_surge` for a step-by-step surge walkthrough, :ref:`setrun_surge`
+for the ``surge_data`` attribute reference, and :ref:`surgedata` for storm data
+sources.

--- a/examples/storm-surge/isaac/setrun.py
+++ b/examples/storm-surge/isaac/setrun.py
@@ -420,7 +420,14 @@ def setgeo(rundata, download_dir=None, storm_dir=None):
     data.wind_refine = pd.DataFrame([[20.0], [40.0], [60.0]])
     data.R_refine = xr.DataArray([60.0e3, 40e3, 20e3])
 
-    # Storm parameters - Parameterized storm (Holland 1980)
+    # Storm parameters - Parameterized storm (Holland 1980).
+    #
+    # Preferred (explicit) selection via family + subtype:
+    #     data.storm_family = "parametric"
+    #     data.storm_subtype = "holland80"
+    # For gridded (OWI/NetCDF) forcing use family "gridded".  The legacy
+    # storm_specification_type below is equivalent and still supported; this
+    # example keeps it because the branches further down compare against it.
     data.storm_specification_type = 'holland80'
     # data.storm_specification_type = 'data'
     data.storm_file = (storm_dir / 'isaac.storm').resolve()

--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -911,7 +911,51 @@ def resolve_forcing_subtype(value):
 
 # Storm data
 class SurgeData(clawpack.clawutil.data.ClawData):
-    r"""Data object describing storm surge related parameters"""
+    r"""Meteorological (storm) forcing parameters written to ``surge.data``.
+
+    Set as ``rundata.surge_data`` in a ``setrun.py`` and written to
+    ``surge.data``, which the Fortran ``met_forcing_module`` reads to activate
+    and configure wind/pressure forcing.  See :ref:`setrun_surge` for the
+    per-attribute reference.
+
+    :Forcing selection:
+     The forcing family and subtype are the preferred, explicit way to select a
+     model:
+
+     - ``storm_family`` -- ``"parametric"`` (an analytic model with a storm
+       center/track), ``"gridded"`` (file-backed wind/pressure fields, e.g.
+       OWI/ASCII or NetCDF), or ``"none"`` (forcing off).
+     - ``storm_subtype`` -- for a parametric family, a model name such as
+       ``"holland80"``, ``"holland2010"``, ``"cle"``, ``"slosh"``,
+       ``"rankine"``, ``"modified_rankine"``, ``"demaria"``, or
+       ``"willoughby"``; for a gridded family, ``"gridded"``.
+
+     The legacy ``storm_specification_type`` (a model-name string or the signed
+     integer code, e.g. ``"holland80"``/``1`` or ``"data"``/``-1``) remains
+     fully supported: when ``storm_family``/``storm_subtype`` are unset it is
+     resolved through :data:`forcing_subtype_registry`.  All three map to the
+     same forcing on the ``surge.data`` wire.
+
+    :Key attributes:
+     - ``wind_forcing`` / ``pressure_forcing`` (bool) -- enable the wind and
+       pressure source terms.
+     - ``drag_law`` (int) -- wind-drag law (0 none, 1 Garratt, 2 Powell).
+     - ``wind_index`` / ``pressure_index`` (int) -- 0-based ``aux`` component
+       indices for the forcing fields (Fortran indexing is +1).
+     - ``storm_time_scale`` (float) -- multiplicative scale on the storm time
+       axis (>1 slower, <1 faster).
+     - ``t_ramp_on`` / ``t_ramp_off`` (float) -- seconds over which the forcing
+       ramps on after ``t0`` and off before ``tfinal`` (0 disables).
+     - ``rotation_override`` (int/str) -- override the hemisphere-based storm
+       rotation sense.
+     - ``wind_refine`` / ``R_refine`` (list/bool) -- AMR refinement thresholds
+       on wind speed and (parametric only) distance to the storm center.
+     - ``storm_file`` (str) -- path to the storm track file or gridded
+       descriptor.
+
+    See :ref:`storm_module` for the Python storm/track object model and
+    :ref:`surgedata` for storm data sources.
+    """
 
     # Legacy name/alias -> integer mapping, derived from the canonical
     # forcing_subtype_registry above.  Retained (with the historical spellings)


### PR DESCRIPTION
Docs polish accompanying the met-forcing refactor (no behavior change):

- data.py: expand the one-line SurgeData docstring into a full reference covering the storm_family/storm_subtype selection (with the legacy storm_specification_type as the still-supported path), the source-term and aux-index controls, temporal scaling/ramps, and AMR thresholds, with cross-references to the Sphinx surge pages.
- isaac/README.rst: replace the 3-line stub with a description of the parametric (Holland 1980) and gridded (OWI/ASCII NWS12, NetCDF NWS13) forcing variants the example drives from one ATCF track.
- ike/isaac setrun.py: annotate the surge block with the preferred storm_family/storm_subtype form (comment-only; the legacy selection and its comparisons are unchanged).

Assisted-by: claude claude-opus-4-8