### PR TITLE
Fix reST field-list formatting in fill_rad_w_other_source docstring

### DIFF
--- a/src/python/geoclaw/surge/track.py
+++ b/src/python/geoclaw/surge/track.py
@@ -1047,19 +1047,19 @@ def fill_rad_w_other_source(t, storm_targ, storm_fill, var, interp_kwargs={}):
     *storm_radius_fill* when calling *write_geoclaw*.
 
     :Input:
-    - *t* (np.datetime64) the time corresponding to
-        a missing value of *max_wind_radius* or *storm_radius*
-    - *storm_targ* (:py:class:`clawpack.geoclaw.storm.Storm`) storm
-        that has missing values you want to fill
-    - *storm_fill* (:py:class:`clawpack.geoclaw.storm.Storm`) storm
-        that has non-missing values you want to use to fill *storm_targ*
-    - *var* (str) Either 'max_wind_radius' or 'storm_radius'
-    - *interp_kwargs* (dict) Additional keywords passed to scipy's
-        interpolator.
+     - *t* (np.datetime64) the time corresponding to
+       a missing value of *max_wind_radius* or *storm_radius*
+     - *storm_targ* (:py:class:`clawpack.geoclaw.storm.Storm`) storm
+       that has missing values you want to fill
+     - *storm_fill* (:py:class:`clawpack.geoclaw.storm.Storm`) storm
+       that has non-missing values you want to use to fill *storm_targ*
+     - *var* (str) Either 'max_wind_radius' or 'storm_radius'
+     - *interp_kwargs* (dict) Additional keywords passed to scipy's
+       interpolator.
 
     :Returns:
-    - (float) value to use to fill this time point in *storm_targ*. -1
-        if still missing after using *storm_fill* to fill.
+     - (float) value to use to fill this time point in *storm_targ*. -1
+       if still missing after using *storm_fill* to fill.
 
     :Examples:
 


### PR DESCRIPTION
The :Input: and :Returns: field-list bullets were at the same indent as the field marker with no separating blank line, so docutils rendered a "Field list ends without a blank line" system message once the docstring was surfaced via autodoc.  Indent the bullets and continuation lines under the field body.  Docstring text is unchanged.

Assisted-by: claude claude-opus-4-8