### PR TITLE
Combine `buffer` and anti-meridional wrapping

### DIFF
--- a/src/python/geoclaw/data.py
+++ b/src/python/geoclaw/data.py
@@ -296,6 +296,60 @@ class TopographyData(clawpack.clawutil.data.ClawData):
             )
         return result
 
+    def _expand_wrapped_topo(self, topos, out_file):
+        """Expand cropped NetCDF topo files into wrapped descriptor entries.
+
+        A plain type-4 Topography that carries a ``crop_extent`` (domain
+        coordinates) is routed through ``TopoInspector.topo_entries()``, which
+        converts the crop to file coordinates, applies the requested
+        ``buffer`` as a coordinate margin, and -- when the crop straddles the
+        file's longitude cut (e.g. a domain crossing -180 against a
+        [-180, 180] file) -- splits it into two entries with the appropriate
+        ``lon_wrap_offset``.  Each resulting entry becomes a Topography that
+        already carries ``_netcdf_meta`` (file-coordinate crop_bounds + wrap
+        offset), so the write() loop emits it via the existing descriptor
+        branch and the antimeridian wrap is handled transparently.
+
+        Topos already carrying ``_netcdf_meta`` (produced directly by
+        topo_entries()), non-type-4 topos, and full-file type-4 topos
+        (crop_extent is None) pass through unchanged.
+        """
+        from clawpack.geoclaw.topotools import Topography
+        from clawpack.geoclaw import netcdf_utils as _ncutils
+
+        result = []
+        for topo in topos:
+            if (abs(int(getattr(topo, 'topo_type', 0) or 0)) == 4
+                    and topo.crop_extent is not None
+                    and getattr(topo, '_netcdf_meta', None) is None):
+                fname = os.path.abspath(
+                    os.path.join(os.path.dirname(out_file), topo.path))
+                with _ncutils.TopoInspector(
+                    fname,
+                    crop_bounds=tuple(topo.crop_extent),
+                    buffer=int(topo.buffer),
+                ) as _insp:
+                    entries = _insp.topo_entries()
+                for _, _, meta in entries:
+                    derived = Topography()
+                    derived.topo_type = 4
+                    derived.path = topo.path
+                    derived._netcdf_meta = meta
+                    # Crop + buffer now live in the descriptor crop_bounds
+                    # (which Fortran prioritizes over topo_crop_extent), so
+                    # leave crop_extent/buffer at their defaults.  Preserve the
+                    # remaining preprocessing attributes.
+                    derived.coarsen = topo.coarsen
+                    derived.align = topo.align
+                    derived.x_shift = topo.x_shift
+                    derived.y_shift = topo.y_shift
+                    derived.z_shift = topo.z_shift
+                    derived.negate_z = topo.negate_z
+                    result.append(derived)
+            else:
+                result.append(topo)
+        return result
+
     def _compute_priority_order(self, topos):
         """Return *topos* sorted coarsest-first (finest = highest priority last).
 
@@ -347,6 +401,7 @@ class TopographyData(clawpack.clawutil.data.ClawData):
                         description='(Type topography specification)')
         if self.test_topography == 0:
             topos = self._normalize_topofiles()
+            topos = self._expand_wrapped_topo(topos, out_file)
             topos = self._compute_priority_order(topos)
 
             # Warn if the topo files carry mismatched vertical datums: GeoClaw

--- a/src/python/geoclaw/netcdf_utils.py
+++ b/src/python/geoclaw/netcdf_utils.py
@@ -755,6 +755,13 @@ class TopoInspector(NetCDFInspector):
         …).  A ``ValueError`` is raised if no match is found.
     crop_bounds : tuple of four floats, optional
         (lon_min, lon_max, lat_min, lat_max).
+    buffer : int, optional
+        Number of extra grid points to keep as a margin around the crop
+        rectangle, matching ``Topography.buffer`` semantics.  Applied by
+        ``topo_entries()``, which converts the point count to a coordinate
+        margin (buffer x grid resolution) and bakes it into the descriptor
+        ``crop_bounds`` so no Fortran-side buffer handling is required.
+        Defaults to 0.
     assume_units : str, optional
         Explicit escape hatch for a file whose elevation variable has *no*
         ``units`` attribute.  When given (e.g. ``'m'``), that unit is assumed
@@ -771,11 +778,13 @@ class TopoInspector(NetCDFInspector):
         path: str | Path,
         var_name: Optional[str] = None,
         crop_bounds: Optional[tuple[float, float, float, float]] = None,
+        buffer: int = 0,
         assume_units: Optional[str] = None,
         skip_sanity_check: bool = False,
     ) -> None:
         super().__init__(path, crop_bounds)
         self.var_name = var_name
+        self.buffer = int(buffer)
         self.assume_units = assume_units
         self.skip_sanity_check = skip_sanity_check
 
@@ -1001,13 +1010,40 @@ class TopoInspector(NetCDFInspector):
             lon_resolution = 1e-10  # single-point file, no gap tolerance needed
         crop_lon_min, crop_lon_max, crop_lat_min, crop_lat_max = saved_crop
 
+        # Apply the requested buffer as a coordinate margin baked into the
+        # crop rectangle.  self.buffer is a grid-point count (Topography.buffer
+        # semantics); convert to degrees via the file's grid resolution.  This
+        # keeps the whole margin on the Python side -- the descriptor
+        # crop_bounds carry it and Fortran needs no buffer handling.  Longitude
+        # is clamped per-entry inside _compute_lon_entries; latitude is clamped
+        # to the file extent here.
+        max_gap = lon_resolution
+        if self.buffer:
+            lat_coords = self.ds[meta.y_name].values
+            if len(lat_coords) > 1:
+                lat_resolution = float(abs(lat_coords[1] - lat_coords[0]))
+            else:
+                lat_resolution = 0.0
+            dlon = self.buffer * lon_resolution
+            dlat = self.buffer * lat_resolution
+            crop_lon_min -= dlon
+            crop_lon_max += dlon
+            file_lat_min = float(lat_coords.min())
+            file_lat_max = float(lat_coords.max())
+            crop_lat_min = max(crop_lat_min - dlat, file_lat_min)
+            crop_lat_max = min(crop_lat_max + dlat, file_lat_max)
+            # Tolerate a buffer that overruns the physical file edge (best
+            # effort, mirroring Topography.crop() clamping buffer to array
+            # limits) rather than raising the coverage ValueError.
+            max_gap = lon_resolution * (self.buffer + 1)
+
         # The +/-360 wrap candidates only make sense for a geographic
         # longitude axis.  For a non-geographic x axis (lon_wrap is None,
         # e.g. projected meters) restrict to the identity offset so the crop
         # is taken straight from the file extent.
         entries_spec = _compute_lon_entries(
             file_lon_min, file_lon_max, crop_lon_min, crop_lon_max,
-            max_gap=lon_resolution,
+            max_gap=max_gap,
             allow_wrap=meta.lon_wrap is not None,
         )
 

--- a/tests/netcdf/test_topo_inspector.py
+++ b/tests/netcdf/test_topo_inspector.py
@@ -443,6 +443,60 @@ def test_topo_entries_near_global_gap(topo_file_factory):
     )
 
 
+def test_topo_entries_buffer_no_wrap(topo_file_factory):
+    """
+    File [-180, 180] x [-90, 90] at 1-degree spacing, crop (-90, 0, -45, 45)
+    with buffer=2: single entry, offset 0, crop_bounds grown by 2*resolution
+    (= 2 degrees) on every side.
+    """
+    path = topo_file_factory(lon_min=-180.0, lon_max=180.0, nlon=361,
+                              lat_min=-90.0, lat_max=90.0, nlat=181)
+    insp = TopoInspector(path, var_name="z",
+                             crop_bounds=(-90.0, 0.0, -45.0, 45.0), buffer=2)
+    entries = insp.topo_entries()
+    insp.close()
+
+    assert len(entries) == 1
+    meta = entries[0][2]
+    assert meta.lon_wrap_offset == pytest.approx(0.0)
+    lon0, lon1, lat0, lat1 = meta.crop_bounds
+    assert lon0 == pytest.approx(-92.0)
+    assert lon1 == pytest.approx(2.0)
+    assert lat0 == pytest.approx(-47.0)
+    assert lat1 == pytest.approx(47.0)
+
+
+def test_topo_entries_buffer_with_wrap(topo_file_factory):
+    """
+    File [-180, 180] x [-90, 90] at 1-degree spacing.  A crop that straddles
+    the dateline (-190, -170) with buffer=2 splits into two entries; the buffer
+    grows the outer edges by 2 degrees and each entry's file-coord crop_bounds
+    stay within the file extent (the ±180 edges are clamped).
+    """
+    path = topo_file_factory(lon_min=-180.0, lon_max=180.0, nlon=361,
+                              lat_min=-90.0, lat_max=90.0, nlat=181)
+    insp = TopoInspector(path, var_name="z",
+                             crop_bounds=(-190.0, -170.0, -45.0, 45.0), buffer=2)
+    entries = insp.topo_entries()
+    insp.close()
+
+    assert len(entries) == 2
+    pairs = {
+        (round(meta.crop_bounds[0], 6), round(meta.crop_bounds[1], 6),
+         meta.lon_wrap_offset)
+        for _, _, meta in entries
+    }
+    # offset 0 covers file [-180, -168] (buffered east edge -170 -> -168);
+    # offset -360 covers file [168, 180] (buffered west edge -190 -> -192,
+    # i.e. file 168), both clamped to the file extent at ±180.
+    assert (-180.0, -168.0, 0.0) in pairs
+    assert (168.0, 180.0, -360.0) in pairs
+    # Latitude buffered symmetrically, within file extent.
+    for _, _, meta in entries:
+        assert meta.crop_bounds[2] == pytest.approx(-47.0)
+        assert meta.crop_bounds[3] == pytest.approx(47.0)
+
+
 def test_topo_entries_genuine_gap_still_errors(topo_file_factory):
     """
     File [-90, 90] genuinely cannot cover domain [-200, -50]: the uncovered

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -254,6 +254,52 @@ def test_dtopo_data_netcdf_descriptor(tmp_path):
     assert read_back.dtopofiles[0].dtopo_type == 4
 
 
+def test_topo_data_netcdf_wrap_and_buffer(tmp_path):
+    r"""A plain type-4 Topography whose crop_extent crosses the antimeridian is
+    transparently split into two wrapped descriptor entries, with the buffer
+    baked into the file-coordinate crop_bounds."""
+    pytest.importorskip("netCDF4")
+    import xarray as xr
+    import clawpack.geoclaw.topotools as topotools
+
+    # 1-degree global file so buffer=2 -> a predictable 2-degree margin.
+    lons = np.linspace(-180.0, 180.0, 361)
+    lats = np.linspace(-90.0, 90.0, 181)
+    data = np.full((lats.size, lons.size), -1000.0, dtype=np.float32)
+    ds = xr.Dataset({
+        "z": xr.DataArray(data, dims=["lat", "lon"],
+                          coords={"lon": lons, "lat": lats},
+                          attrs={"units": "m"})
+    })
+    nc_path = tmp_path / "topo.nc"
+    ds.to_netcdf(nc_path)
+
+    topo = topotools.Topography()
+    topo.path = str(nc_path)
+    topo.topo_type = 4
+    topo.crop_extent = [-190.0, -170.0, -45.0, 45.0]   # crosses -180
+    topo.buffer = 2
+
+    topo_data = clawpack.geoclaw.data.TopographyData()
+    topo_data.topofiles = [topo]
+    data_file = tmp_path / "topo.data"
+    topo_data.write(out_file=data_file)
+
+    text = _read_text(data_file)
+    # The straddling crop is split into two type-4 descriptor entries.
+    assert "2                    =: ntopofiles" in text
+    assert "lon_wrap_offset = 0.0" in text
+    assert "lon_wrap_offset = -360.0" in text
+    # Buffer (2 grid points * 1 deg) baked into the file-coord crop_bounds,
+    # clamped to the file extent at +/-180.
+    assert "crop_bounds    = -180.0 -168.0 -47.0 47.0" in text
+    assert "crop_bounds    = 168.0 180.0 -47.0 47.0" in text
+    # The crop+buffer live in the descriptor, so the preprocessing block leaves
+    # crop_extent/buffer at their zero sentinels.
+    assert "0. 0. 0. 0.   # crop_extent [x1 x2 y1 y2]" in text
+    assert "0   # buffer" in text
+
+
 @pytest.mark.python
 def test_dtopo_data_unsupported_preprocessing(tmp_path):
     r"""Unsupported dtopo preprocessing attributes fail loudly at write."""


### PR DESCRIPTION
Previously using a `buffer` for a topography file was limited to not use the `TopoInspector` functionality, notably the anti-meridional wrapping (domain cross data-line).  This modifies the code so that Python understands how to do this with a buffer.

Assisted-by: claude opus-4-8