### PR TITLE
Add Development Directory `dev`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ __pycache__
 
 # macOS
 *.DS_Store
+
+# Ephemeral, per-task developer scratch is kept in .plans/ (ignored via the
+# global git excludesfile, not this file). Durable, reviewable design docs live
+# in the tracked dev/design/ directory instead -- see dev/design/README.md.

--- a/dev/design/README.md
+++ b/dev/design/README.md
@@ -1,0 +1,33 @@
+# `dev/design/` — durable design docs
+
+This directory holds **tracked, durable design documents** for GeoClaw
+subsystems: roadmaps, refactor design records, and implementation plans that are
+meant to stay current and be reviewed alongside the code they describe. It
+follows the Clawpack `dev/` convention (cf. `amrclaw/dev/`, `clawutil/dev/`,
+`pyclaw/development/`) — developer-facing material that lives with the code but is
+distinct from the user-facing Sphinx docs in the separate `clawpack/doc` repo.
+
+## Two tiers — why this exists
+
+A "source of truth" living in a gitignored path is not one: it can't be reviewed,
+can't be updated in the same PR as the code, can't be `git blame`d, and can be
+lost. Several of these docs *were* lost that way (they lived in a gitignored
+`.plans/`). The split below is the fix.
+
+| Tier | Location | Tracked? | Purpose |
+|---|---|---|---|
+| **Durable design** | `dev/design/` | ✅ yes | Few, curated, owned design docs meant to stay current. |
+| **Ephemeral scratch** | `.plans/` | ❌ gitignored | Per-task, multi-author working notes; allowed to go stale; never authority. |
+
+`.plans/` is ignored via the global git excludesfile, not this repo's
+`.gitignore` — leave it that way. Do **not** move ephemeral scratch here, and do
+**not** un-ignore `.plans/`.
+
+## Keeping these current
+
+1. **Same-PR rule.** Any PR that changes a subsystem with a design doc here
+   updates that doc's status/progress in the same PR.
+2. **Verifiable status.** Prefer a "verified against commit X / PR #N" note over a
+   bare "done", so drift is visible.
+3. **Archive, don't delete.** When a doc is superseded, keep the reasoning and
+   mark it superseded rather than removing history.

--- a/dev/design/README.md
+++ b/dev/design/README.md
@@ -31,3 +31,16 @@ lost. Several of these docs *were* lost that way (they lived in a gitignored
    bare "done", so drift is visible.
 3. **Archive, don't delete.** When a doc is superseded, keep the reasoning and
    mark it superseded rather than removing history.
+
+## Contents
+
+- `met\_forcing\_refactor.md` — design record for the surge→met object-model + Fortran
+  rename refactor (**\*\*complete\*\***; recovered verbatim from git).
+- `met\_forcing\_docs\_plan.md` — documentation/transition-guide/tutorial plan
+  (approved, execution deferred; recovered verbatim from git).
+- `met\_forcing\_roadmap.md` — living post-refactor roadmap (S/M/L work items;
+  reconstructed from the vault mirror, git-verified).
+- `met\_wind\_field\_generator.md` — parametric TC wind-field generator design &
+  verification plan (**\*\*partial reconstruction\*\***; original lost, no full mirror).
+- `friction-file-plan.md` — file-based friction field input implementation plan
+  (relocated from `.plans/`).

--- a/dev/design/friction-file-plan.md
+++ b/dev/design/friction-file-plan.md
@@ -1,0 +1,161 @@
+# File-Based Friction Field Input for GeoClaw — Implementation Plan
+
+> **Provenance.** Relocated 2026-08-23 from the gitignored `.plans/friction-file-plan.md`
+> (developer scratch) into tracked `dev/design/`, unchanged in content. It was
+> never lost — this move just puts the durable design doc under version control
+> alongside the met-forcing docs. Vault project notes previously referenced it as
+> `.plans/friction_file_plan.md` (underscores); the canonical path is now
+> `dev/design/friction-file-plan.md`. Implementation status below is unchanged and
+> not re-verified against current `master` — heed its own "Verify first" section.
+
+Handoff for Claude Code. Repo: `clawpack/geoclaw` (verified against master @ `1af3d3e`, 2026-08-01). **Double-check the "Verify first" section against current master before writing code**, since call sites and list formats may have moved.
+
+## Goal
+
+Implement the long-dormant file-based variable-friction path: read a gridded Manning's $n$ field from one or more files covering limited coastal regions, fill it into `aux(friction_index)`, and fall back to the existing depth/constant Manning elsewhere. Coverage is regional (like met forcing), not global (unlike topo), so uncovered cells must degrade gracefully to the depth-based coefficient. Also ship a Python preprocessing path that turns commonly available land-cover rasters into a friction file.
+
+## Current state of the stub (precise)
+
+**Fortran — `src/2d/shallow/friction_module.f90`**
+- Documented precedence, top of file: `file > region > depth > constant`.
+- `friction_file_type` derived type exists: `num_cells(2)`, `lower(2)`, `upper(2)`, `dx(2)`, `no_data_value`, `data(:,:)`.
+- `setup_variable_friction` reads `friction.data`, parses `num_friction_regions` + regions (works), then reads `num_friction_files`, and for each prints `*** WARNING *** File based friction specification unimplemented.` and calls the stub reader.
+  - **Bug:** inside the file loop it does `friction_files = read_friction_file(...)` (assigns scalar result to the whole array). Must be `friction_files(m) = ...`.
+- `set_friction_field` applies the region path (depth-break lookup inside each rectangle), then `if (num_friction_files > 0) stop "*** ERROR *** File based friction specification not implemented."`. No interpolation of `file%data` onto aux exists.
+  - **Bug/limitation:** depth-break comparison uses `aux(1,i,j) - sea_level` with an inline comment that `sea_level is not set properly here, just a test case`. Revisit while touching this routine.
+- `read_friction_file` parses a header for `file_type` 2/3 (`num_cells(1)`, `num_cells(2)`, `lower(1)`, `lower(2)`, `dx(1)`, `no_data_value`) but every data-read branch is a commented-out port of the topo reader falling through to `stop`. `file_type` 1 (xyz) also stops. Header is GeoClaw topotype-3 minus `dy` (it sets `dx(2)=dx(1)`).
+
+**Fortran — consumers / call sites**
+- `set_friction_field` is called from `src/2d/shallow/setaux.f90:220` (and `src/2d/shallow/multilayer/setaux.f90:209`), *after* topo is cell-integrated into `aux(1)`. Runs at grid init and every regrid, so friction is static-filled there. **Both setaux paths need the fix.**
+- `setup_variable_friction()` is called once at startup from `src/2d/shallow/amr2.f90` (and `src/2d/bouss/amr2.f90`).
+- `friction_index` is consumed in `src/2d/shallow/src2.f90:101` and `src/2d/shallow/src1d.f90:63`.
+
+**The precedence gap (important).** In `src2.f90` the friction source term does:
+```fortran
+if (.not. variable_friction) then
+    do nman = num_manning, 1, -1                 ! depth-based
+        if (aux(1,i,j) < manning_break(nman)) coeff = manning_coefficient(nman)
+    enddo
+else
+    coeff = aux(friction_index,i,j)              ! variable: aux is the ONLY source
+endif
+```
+When `variable_friction` is on there is **no per-cell fallback** — the coefficient comes solely from `aux(friction_index)`. But `set_friction_field` fills that slot only inside regions, so today the documented `depth > constant` levels are never realized for variable friction, and uncovered cells carry 0 (frictionless). This feature is the moment to fix the whole chain (see Task 2).
+
+**Python — `src/python/geoclaw/data.py`, `FrictionData` (~line 1154)**
+- `friction_files` attribute exists; `read()` hard-codes `self.friction_files = []  # Is not supported`.
+- `write()` has a format-string bug: `self._out_file.write("'%s' %s\n " % fname)` — two specifiers, one value; raises the moment the list is non-empty. It also never writes a file_type, though Fortran reads one via `(a,i1)`.
+- `friction_index` is written as `+1` for Fortran indexing (keep).
+
+## Settled design decisions
+
+1. **Do not fork a reader.** The stub's bespoke `read_friction_file` duplicates the topo reader, which is exactly the parallel-implementation failure mode we're avoiding elsewhere. Reuse the topo gridded-field machinery in `src/2d/shallow/topo_module.f90`: `read_topo_file` (line 746), the ASCII `case(2:3)` body, the netCDF `topo_type=4` path (`read_netcdf_descriptor`, `nf90_open` @ 959), and `cellgridintegrate` for cell-averaging. A friction file is a topo-like gridded field that lands in `aux(friction_index)` and is interpreted as Manning's $n$ instead of elevation. Prefer factoring a shared gridded-field reader over copy-paste; if that refactor is too large for one pass, at minimum make the friction file format *byte-identical* to topotype 2/3/4 so `clawpack.geoclaw.topotools` writers/readers produce and consume friction files for free.
+2. **File format = topotype 2/3 (ASCII) and 4 (netCDF).** No new format. Extend the friction header to carry `dy` (drop the `dx(2)=dx(1)` assumption) so it matches topo exactly.
+3. **Store resolved Manning's $n$ per cell, not land-cover class codes.** The class→$n$ lookup is a modeling choice and lives in Python preprocessing, versioned and auditable. Fortran stays a dumb reader.
+4. **Regional coverage via no_data masking.** File overrides only where `data /= no_data_value`; elsewhere the cell keeps the region/depth/constant value. This is the "like met forcing" behavior.
+5. **Static fill at regrid** via `set_friction_field` in `setaux`. No time dependence, simpler than met forcing (a degenerate single-time gridded field).
+6. **Cell-average onto the target cell** (reuse `cellgridintegrate`), consistent with topo. Roughness is smooth relative to bathymetry, so nearest/bilinear is defensible, but cell-averaging composes with existing machinery and is the physically correct reduction of a fine $n$ field.
+
+## Verify first (double-check before implementing)
+
+- [ ] Confirm `src2.f90`/`src1d.f90` still have no per-cell fallback for `variable_friction` (drives Task 2 strategy).
+- [ ] Confirm the current `topofiles` entry format in `setrun`/`TopographyData` (currently `[topo_type, path]`) and mirror it for `friction_files` as `[friction_type, path]`. Align the `friction.data` line format with what `read_friction_file`/`setup_variable_friction` parse.
+- [ ] Confirm the `read_netcdf_descriptor` signature and the `topo.data` key=value descriptor block so the netCDF friction path can reuse it verbatim.
+- [ ] Confirm both `setaux.f90` and `multilayer/setaux.f90` should receive identical treatment.
+- [ ] Decide precedence-realization strategy (Task 2, A vs B).
+
+## Tasks
+
+### Task 1 — Fortran read path (reuse, don't fork)
+- Replace the bespoke `read_friction_file` body with a call into the shared/topo gridded reader, directing output to a friction field object rather than `aux(1)`. Support ASCII types 2/3 and netCDF type 4.
+- Fix the `friction_files(m) = ...` array-assignment bug in `setup_variable_friction`.
+- Extend `friction_file_type` (or the reused topo field type) to carry `dy` and the registration convention (cell-centered vs corner) identically to topo.
+- **Acceptance:** a topotype-3 file written by `topotools` loads into a `friction_file_type` with correct extents, `dx/dy`, and `no_data_value`; a netCDF (type 4) file loads equivalently.
+
+### Task 2 — Precedence + interpolation in `set_friction_field`
+Realize the full chain by seeding every cell, then overriding:
+```text
+for each cell (i,j) incl. ghosts:      ! aux(1)=topo already set by setaux
+    coeff = depth_based_manning(aux(1,i,j))         ! (1) constant/depth from geoclaw_module
+    if cell in friction_region r:                    ! (2) region override
+        coeff = region_depth_break(r, aux(1,i,j))
+    for each friction_file f covering (x,y), finest last:   ! (3) file override, highest priority
+        v = cellgridintegrate/interp(f, cell)
+        if v /= f%no_data_value: coeff = v
+    aux(friction_index,i,j) = coeff
+```
+- Pull `manning_break`/`manning_coefficient`/`num_manning` from `geoclaw_module` to seed the depth/constant level (strategy **A**, recommended: keeps `src2.f90` untouched, fixes the current uncovered-cell gap as a side effect).
+- Strategy **B** (fallback, lower effort): leave `set_friction_field` region-only, and in `src2.f90`/`src1d.f90` treat a sentinel `aux(friction_index)` (e.g. `<= 0`) as "use depth-based." More invasive to the hot loop; only if A proves awkward. Flag the choice for review.
+- Apply the same fix in `multilayer/setaux.f90`'s path.
+- Resolve the `sea_level` concern in the depth-break comparison while here.
+- **Acceptance:** see Task 5 regression.
+
+### Task 3 — Python `FrictionData`
+- `write()`: emit each entry as `[friction_type, path]` mirroring `topofiles`; fix the format string; write the abspath resolved relative to `out_file`'s directory (existing intent).
+- `read()`: parse `num_friction_files` and the entries instead of hard-coding empty.
+- Add a short `setrun` usage example:
+```python
+fdata = rundata.friction_data
+fdata.variable_friction = True
+fdata.friction_index    = 3
+fdata.friction_regions.append([lower, upper, depths, coeffs])   # existing
+fdata.friction_files.append([3, 'friction_manning.tt3'])        # NEW: [friction_type, path]
+```
+- **Acceptance:** round-trip `write()`→`read()` reproduces `friction_files`; generated `friction.data` parses in `setup_variable_friction`.
+
+### Task 4 — Python preprocessing: land-cover → friction file
+New helper (e.g. `src/python/geoclaw/friction_tools.py`, or extend `topotools`). Optional deps `rasterio` (+ `rasterio.warp`, `rasterio.features`) or `rioxarray`/`geocube`; guard imports so core GeoClaw doesn't require them.
+
+Pipeline (categorical-correct):
+1. Read source raster/vector via GDAL/rasterio (COG/GeoTIFF/IMG/HDF; rasterize vector sources).
+2. Reproject to lon/lat (EPSG:4326, GeoClaw grid) with **nearest** at native resolution (never bilinear on class codes).
+3. Apply a two-stage, versioned lookup: `dataset_code → semantic_class → n`.
+4. Area-average $n$ from native resolution to the target friction-tile resolution (mesh-scale averaging; the ADCIRC toolchain approach).
+5. Write a topotype-3 or netCDF-4 friction file via the existing `Topography` writer.
+
+Ship per-dataset legend crosswalks (NLCD-16, WorldCover-11, C-CAP, CORINE-44) plus one semantic-class→$n$ table.
+- **Acceptance:** a small synthetic classified raster maps to a known $n$ field; a partial-coverage tile writes with `no_data` outside the classified footprint.
+
+### Task 5 — Tests + example
+- Fortran regression on a small domain with one friction tile partially covering it. Assert: (a) covered cells get the file $n$; (b) uncovered cells get the depth-based $n$, **not 0**; (c) `no_data` cells inside the tile fall to region/depth. Compare `aux(friction_index)` against an analytic expected field. Add to the geoclaw regression suite.
+- Python unit test for Task 4 on a synthetic raster.
+- Add an `examples/` case (storm-surge or tsunami) that ships a friction file end to end.
+
+## Data sources the Python path should ingest (reference)
+
+Format collapses to a few GDAL-readable families; the real work is CRS + class coding + raster/vector, not container parsing.
+
+| Source | Container | CRS | Res | Classes |
+|---|---|---|---|---|
+| NLCD (Annual C1) | COG GeoTIFF | Albers/WGS84 | 30 m | 16-class Anderson II (+ RAT sidecar) |
+| NOAA C-CAP (regional / 1 m) | GeoTIFF/IMG | Albers | 30 m, 1 m | ~25 coastal (+ RAT) |
+| ESA WorldCover | COG GeoTIFF, 3°×3° tiles | EPSG:4326 | 10 m | 11-class (+ classes CSV) |
+| Copernicus GLC (CGLS-LC100) | GeoTIFF | EPSG:4326 | 100 m | 23-class + fractional bands |
+| CORINE (CLC) | GeoPackage/GDB **vector** or 100 m raster | ETRS89-LAEA 3035 | 100 m | 44-class |
+| ESRI 10 m (Impact Observatory) | COG GeoTIFF, STAC | UTM/tile | 10 m | 9-class |
+| MODIS MCD12Q1 | HDF-EOS (HDF4), or GeoTIFF via AppEEARS | Sinusoidal | 500 m | IGBP/UMD/PFT |
+| NWI (wetlands) | GDB/shapefile/GPKG **vector** | various | vector | Cowardin |
+| EMODnet Seabed Substrate / usSEABED (offshore) | **vector** / point CSV | 4326/3035 | vector | Folk grain-size |
+
+Offshore friction is essentially unconstrained; use a constant open-water $n \approx 0.02\text{–}0.025$ and let the depth-based fallback carry the water column. That is why the file only needs to cover coastal tiles.
+
+### Representative class → Manning's $n$ (surge/tsunami literature)
+| Class | $n$ |
+|---|---|
+| Open water | 0.02 – 0.025 |
+| Developed low→high | 0.05 – 0.15 |
+| Forest (decid/evergreen) | 0.10 – 0.16 |
+| Wetland / marsh | 0.045 – 0.07 |
+| Cultivated / pasture | 0.035 – 0.05 |
+| Barren | 0.025 |
+
+Values are a starting table; keep them in the versioned lookup, not in code, so they can be swapped/cited (cf. Bunya et al. 2010, Mattocks & Forbes, Chow 1959).
+
+## Out of scope
+- Overland **wind reduction** (ADCIRC's `z0` / surface-canopy fields). GeoClaw's surge wind drag isn't keyed off land roughness; that's a separate aux field and a separate feature. Do not fold it into the bottom-friction file.
+- Time-varying friction (morphodynamic roughness). Static only.
+
+## How comparable codes do it (context)
+- **ADCIRC:** `mannings_n_at_sea_floor` nodal attribute in `fort.13`; resolved $n$ computed offline by mesh-scale averaging a land-cover raster; negative-$n$ sentinel = fall back to depth-based Cd (our no_data mask is the gridded analog).
+- **HEC-RAS 2D / TUFLOW / LISFLOOD-FP:** land-cover raster + lookup → gridded $n$ aligned to the DEM. Closest analog to this design.
+- **Delft3D-FM:** trachytopes (class fractions → combined roughness); more than we need for a static $n$ field.

--- a/dev/design/met_forcing_docs_plan.md
+++ b/dev/design/met_forcing_docs_plan.md
@@ -1,0 +1,102 @@
+# Met-Forcing Documentation, Transition Guide & Tutorial — Plan
+
+> **Provenance.** Recovered verbatim 2026-08-23 from the git blob at
+> `590312ef^:met_forcing_docs_plan.md` — the last tracked revision before commit
+> `590312ef` moved it into the gitignored `.plans/`, from which it was later lost
+> off disk. This is the recovered original, unchanged. Status reflects
+> 2026-07-25; execution was deferred and remains open.
+
+**Status (2026-07-25):** Approved, execution deferred until the code work is fully
+wrapped up. Companion to `met_forcing_refactor.md`. The refactor code is merged
+(Phase 0/1/F1, Phase 2 = PR #710, F3 = PR #711, plus the lockstep `clawpack/riemann`
+rename PR).
+
+## Context
+
+The met-forcing refactor reorganized GeoClaw storm forcing under a
+**meteorological forcing** umbrella and added gridded netCDF met forcing. The
+user-facing docs did not keep up. This effort (a) updates the sparse surge docs,
+(b) adds a transition / "what's new" guide advertising the new capabilities and
+easing migration, and (c) adds a capability tutorial notebook.
+
+**Assessment of current docs.** GeoClaw's Sphinx docs live in the separate
+`clawpack/doc` repo (`doc/doc/*.rst`, reST-only — no nbsphinx/MyST). The surge
+cluster is thin:
+- `quick_surge.rst` — a labeled stub (steps 2–7 empty, a dead link).
+- New object model (`surge/track.py`, `parametric.py`, `gridded.py`, `tools.py`)
+  and `SurgeData`'s new `storm_family`/`storm_subtype`, `t_ramp_on/off`,
+  `rotation_override` — good docstrings/comments in code, **zero Sphinx surfacing**.
+- `storm_module.rst` (lone surge autodoc page) is **orphaned** from the toctree;
+  broken `:ref:` targets (`_storm_module`, `_surge_module`).
+- `setrun_geoclaw.rst` surge section documents only the legacy integer
+  `storm_specification_type` (−1..3); omits the newer attributes.
+- Strong gridded-forcing content is **buried** in the general `netcdf.rst`.
+- `examples/storm-surge/isaac/README.rst` is 3 stale lines despite its OWI/netCDF role.
+
+**Decisions locked:** transition/"what's new" guide → new Sphinx surge page in
+`clawpack/doc`; tutorial → notebook in `clawpack/apps` (`apps/notebooks/geoclaw/`),
+covering **both** parametric and gridded netCDF forcing.
+
+## Work item A — `clawpack/geoclaw` (docstrings & examples)
+- `src/python/geoclaw/data.py`: expand the one-line `SurgeData` docstring into a
+  full class docstring (attributes; `storm_family`/`storm_subtype` selection with
+  `storm_specification_type` as the retained legacy path) so autodoc renders well.
+- `examples/storm-surge/isaac/README.rst`: rewrite to describe the Holland /
+  OWI-ASCII / netCDF (ERA5, NWS13) variants it exercises.
+- Lightly annotate the `ike`/`isaac` `setrun.py` surge blocks to show the new
+  `storm_family`/`storm_subtype` form (legacy string still works — do not break
+  isaac's `== 'holland80'` comparisons).
+- Reuse `clawpack.geoclaw.surge.plot` (`surgeplot`) helpers; do not rewrite plotting.
+
+## Work item B — `clawpack/doc` (Sphinx surge cluster overhaul) — centerpiece
+All under `doc/doc/`:
+- Rewrite `quick_surge.rst` into a real quick start (end-to-end parametric Holland
+  via the `ike` example, then a gridded pointer); drop the dead link and WIP warning.
+- Update `setrun_geoclaw.rst` "Storm Specification Data": add `storm_family`/
+  `storm_subtype`, `t_ramp_on`/`t_ramp_off`, `rotation_override`; reframe
+  `storm_specification_type` as the supported legacy selector mapping to family/subtype.
+- Add autodoc pages for `surge.track`, `surge.parametric`, `surge.gridded`,
+  `surge.tools`, and `SurgeData`; wire them and the orphaned `storm_module.rst`
+  into the `geoclaw.rst` toctree (model on dtopotools/fgmax_tools pages).
+- Fix the broken `:ref:` targets (`_storm_module`, `_surge_module`).
+- Surface gridded met forcing into the surge cluster (dedicated
+  `gridded_met_forcing.rst` or promote the `netcdf.rst` section) so it is discoverable.
+- New "What's new in met forcing" + migration page (`met_forcing_whatsnew.rst`) in
+  the surge cluster + toctree. Advertises the object model
+  (`Track`/`StormTrack`/`ParametricMetForcing`/`GriddedMetForcing`), explicit
+  `family`+`subtype` selection, gridded netCDF forcing, temporal ramps. Migration
+  notes: legacy `storm_specification_type` still works; the Fortran
+  `storm_module` → `met_forcing_module` rename affects only user code that `use`s it
+  (Python `setrun.py` unaffected). Source prose from `met_forcing_refactor.md` §7/§9.
+
+## Work item C — `clawpack/apps` tutorial notebook (stretch)
+- New `apps/notebooks/geoclaw/met_forcing_tutorial.ipynb`, complementing the existing
+  `katrina/katrina.ipynb` and `data_derived_storms.ipynb`.
+- Follow the `nbtools` convention (`clawpack.clawutil.nbtools.make_exe` /
+  `make_output_and_plots`), as in `examples/tsunami/eta_init_force_dry/run_geoclaw.ipynb`:
+  markdown intro (+ gallery link, version note), then
+  - **Parametric:** read an ATCF track (`Storm.read(file_format="ATCF")`), write the
+    GeoClaw file, build+run, plot wind/pressure/surface + gauges via `surgeplot`.
+  - **Gridded netCDF:** build a small CF `u10`/`v10`/`msl` dataset (mirroring
+    `tests/regression/met_forcing/`), write the `.storm` descriptor
+    (`write(file_format="data")`), build with `-DNETCDF`, run, plot.
+- The apps Makefile renders via `jupyter nbconvert --to html --execute` (1200 s
+  timeout), so the notebook is executed at render time — it must run top-to-bottom,
+  including a netCDF-enabled `xgeoclaw` for the gridded part.
+- Add a gallery link in `doc/gallery/notebooks.rst` to the rendered HTML.
+
+## Sequencing & PRs
+Three coordinated PRs (one per repo):
+1. `geoclaw` docstring/README/setrun polish (A).
+2. `doc` surge-cluster overhaul + what's-new page (B) — centerpiece.
+3. `apps` tutorial notebook (C) + `doc/gallery` link.
+
+## Verification
+- **doc build:** `cd $CLAW/doc/doc && make html` — new autodoc pages import against
+  the installed `clawpack.geoclaw`; no new Sphinx warnings; broken `:ref:`s resolve;
+  new pages appear in the nav.
+- **geoclaw examples:** `ike`/`isaac` still `make all` and pass `test_ike.py` /
+  `test_isaac.py` after the setrun annotations (legacy selection unchanged).
+- **notebook:** `make met_forcing_tutorial.html -f $CLAW/apps/notebooks/Makefile`
+  executes end-to-end (needs a `-DNETCDF` build); review the rendered figures.
+  Not CI-executed; the tested surrogate remains `tests/regression/met_forcing/`.

--- a/dev/design/met_forcing_refactor.md
+++ b/dev/design/met_forcing_refactor.md
@@ -1,0 +1,292 @@
+# Refactor of GeoClaw Meteorological Forcing Support
+
+> **Provenance.** Recovered verbatim 2026-08-23 from the git blob at
+> `590312ef^:met_forcing_refactor.md` — the last tracked revision before commit
+> `590312ef` ("Untrack met-forcing planning notes; move to .plans/") moved it into
+> the gitignored `.plans/`, from which it was later lost off disk. This is the
+> recovered original, not a reconstruction. The body is unchanged except for one
+> post-recovery correction, marked `[correction 2026-08-23]`: §5's `Track.t`
+> description is updated to `datetime64` to match the amendment already present in
+> §4/§6 and the shipped code (`met/track.py` stores `self.t` as `datetime64[s]`).
+> Status/PR claims below were verified against the geoclaw merge history
+> (PR #706/#707/#708/#710/#711, all merged by 2026-07-25); the "lockstep
+> `clawpack/riemann` rename PR" is cross-repo and not independently verified here.
+
+**Status:** Complete — all phases merged (2026-07-25). Phase 0 (verification
+baseline, PR #706), Phase 1 (Python object model, #707), Phase F1 (center-assumption
+guard, #708), Phase 2 (config family/subtype split, #710), and Phase F3 (Fortran
+module/type rename, #711), plus the lockstep `clawpack/riemann` rename PR. The
+Fortran modules/types are now `met_forcing_module` / `parametric_met_forcing_module`
+/ `gridded_met_forcing_module` and `parametric_met_forcing_type` /
+`gridded_met_forcing_type`. Remaining work is documentation (see
+`met_forcing_docs_plan.md`).
+**Scope:** `clawpack/geoclaw` storm forcing (Python `surge/` package and the Fortran modules listed above; formerly `storm_module` / `model_storm_module` / `data_storm_module`).
+**Prerequisite:** netCDF met forcing capabilities are merged. This refactor branches off that state.
+
+This note consolidates the prior design notes (Design Note Draft, Python API Design, Fortran Interface Evolution, Fortran Capability Map, Storm Module Inventory, Target Python capability map) into a single repository-facing document, and adds a development sequence, a verification strategy, and an explicit accounting of the seams where this work can affect general (non-storm) GeoClaw functionality.
+
+---
+
+## 1. Motivation
+
+GeoClaw's storm support has grown to serve several distinct roles under one abstraction: parameterized tropical cyclone forcing, gridded meteorological forcing from external datasets, ingestion of many track and event formats, and newer applications that need atmospheric forcing but are not storm-centered (extratropical cyclones, meteo-tsunamis, asteroid-impact atmospheric forcing). As a result the term **storm** now overloads at least four ideas: a physical event with track metadata, a parameterized forcing model, a generic meteorological forcing source, and a descriptor for gridded external data.
+
+The goal is to reorganize the code around the broader concept of **meteorological forcing**, with storms retained as one important subtype rather than the umbrella. This clarifies which capability a user is invoking, removes latent bugs that come from assuming every forcing source behaves like a storm, and gives a clean extension point for non-TC forcing.
+
+---
+
+## 2. Terminology (locked)
+
+- **Meteorological forcing** ("met forcing"): the umbrella concept. Any source of wind and/or pressure forcing, parameterized or gridded. Concise code identifiers (`MetForcing`, `set_met_forcing`) are preferred over verbose ones.
+- **Track**: an evolving spatial reference (center over time) for a feature.
+- **StormTrack**: a track carrying storm-specific metadata. Supports both tropical and extratropical systems; it does not assume tropical-only semantics.
+- **Parameterized forcing**: forcing generated from a compact set of evolving parameters.
+- **Gridded forcing**: forcing read from external field datasets.
+- **storm**: retained only as a subtype/specialization within met forcing, never as the umbrella.
+
+---
+
+## 3. Conceptual model
+
+Four layers.
+
+1. **Meteorological forcing** (umbrella). Owns forcing activation/timing, scaling, optional windowing/ramping, dispatch/orchestration, and the extension point for non-storm applications.
+2. **Event/track data**. Center location over time, intensity-like parameters, classification where relevant. Does not own gridded dataset descriptors, file mappings, or variable mappings.
+3. **Parameterized meteorological forcing**. Forcing from a compact evolving description: Holland family, CLE, SLOSH, Rankine variants, deMaria, Willoughby, and future ETC or idealized parameterizations. References a track/event object; does not require all parameterized forcing to reduce to one storm representation.
+4. **Gridded meteorological forcing**. File-backed wind/pressure fields: OWI/ASCII, NetCDF, future reanalysis or model products. Owns file paths, variable/dimension mapping, interpolation metadata, and dataset access details.
+
+---
+
+## 4. Locked design decisions
+
+- Umbrella concept is **meteorological forcing**; `storm` is a subtype only.
+- **Track / StormTrack** split; `StormTrack` inherits `Track`. `center` is the spatial field name.
+- **ParametricMetForcing / GriddedMetForcing** as the two forcing families.
+- **`Storm` is a compatibility wrapper over `ParametricMetForcing` only.** It does not wrap `GriddedMetForcing`; the gridded path is newer and has no legacy user base to protect.
+- Core objects are **NumPy structure-of-arrays**; no pandas/xarray dependency in the core model (gridded may use xarray internally).
+- **Time representation:** ~~Python `datetime` is canonical on the `Track` layer (sparse, event-like)~~ **[amended in §6 — the track axis uses `datetime64`, uniform with the gridded axis]**; `GriddedMetForcing` holds its time axis as a native `datetime64` array (dense, CF-backed). Conversion happens only at the Fortran write boundary. See Section 6.
+- **`time_offset`** is Python to Fortran conversion metadata only. Python remains datetime-aware; Fortran does not. It lives on the forcing/writer boundary, not on the bare track.
+- **Asymmetric I/O is a design principle:** ingest broadly (many track/data formats), emit narrowly (only GeoClaw-consumable forcing formats). The apparent read/write symmetry in the current API is not a real requirement.
+- **Python parametric models are not a prerequisite.** The current Python Holland/CLE/`construct_fields` methods are stubs; the real implementations live in Fortran. Python parametric implementations are future work, not part of this refactor.
+- **Fortran: semantic clarification first, physical renames last.** Preserve the current logical split; improve naming/docs; rename modules and types only after the Python concepts and compatibility strategy are stable.
+- **window / ramp_width** are implemented gridded-first, with the interface left flexible enough to support them on the parameterized path later.
+
+---
+
+## 5. Python target object model
+
+New modules alongside the existing `storm.py`, introduced additively.
+
+### `Track` (`track.py`)
+Generic evolving feature with a spatial center over time.
+- `t`: `numpy.datetime64` array of times &nbsp;*[correction 2026-08-23: was "sequence of Python `datetime`"; the shipped track axis is `datetime64`, per the §6 amendment]*
+- `center`: `(n, 2)` array of `(lon, lat)`; for a TC this is the eye, for other systems the central point (e.g. pressure minimum)
+- optional metadata: `name`, `id`, `event`
+- SoA layout, NumPy-backed.
+
+### `StormTrack(Track)`
+Storm-specific track metadata.
+- `max_wind_speed`, `max_wind_radius`, `central_pressure`, `storm_radius`
+- optional: `classification`, `basin`, `wind_speeds` (format-specific; optional)
+- Supports TC and ETC; not tropical-only.
+
+### `ParametricMetForcing` (`parametric.py`)
+Forcing from a parameterized model.
+- `track`: a `Track` or `StormTrack` (does not duplicate track data; multiple models may share one track)
+- `model`: identifier, e.g. `"holland80"`, `"holland2010"`
+- model-specific configuration
+- `write_geoclaw(...)` produces the compact GeoClaw parametric forcing file.
+
+### `GriddedMetForcing` (`gridded.py`)
+Forcing from external field datasets.
+- `file_paths`, format metadata, variable/dimension mappings, interpolation metadata
+- forcing controls: `window`, `ramp_width`, `window_type` (optional)
+- `write_data(...)` produces the gridded forcing descriptor.
+- Variable/dimension mapping is reader-specific (primarily netCDF), must be communicated to Fortran, is user-customizable in Python, and is ideally resolved internally by discovery. Discovery currently lives in `netcdf_utils.py`.
+- May use xarray internally.
+
+### `Storm` (compatibility wrapper)
+- Wraps a `ParametricMetForcing`. Provides `read(...)`, `write(...)`, and compatibility accessors.
+- Not the canonical internal model. Transitional only. Does not wrap gridded forcing.
+
+### API relationships
+```
+Track
+  StormTrack(Track)
+
+ParametricMetForcing  -> holds Track / StormTrack
+GriddedMetForcing     -> holds dataset metadata
+Storm                 -> compatibility wrapper over ParametricMetForcing
+```
+
+### Reader / writer layer
+Readers and writers are separated from the domain objects.
+- Track readers return `StormTrack`: `read_atcf`, `read_hurdat`, `read_ibtracs`, `read_jma`, `read_tcvitals` (and `read_imd` if ever implemented).
+- Parameterized: `read_geoclaw(...) -> ParametricMetForcing` (with an associated `StormTrack` view where the contents support it); `write_geoclaw(...)`.
+- Gridded: `read_data(...) -> GriddedMetForcing`; `write_data(...)`.
+- Primary write surface is only `write_geoclaw` and `write_data`. Track-format writers (ATCF/HURDAT/JMA/IMD/TCVITALS) are not primary supported outputs.
+
+### Utilities
+- `category(...)` becomes a `StormTrack` helper (categorization is storm-specific).
+- `plot(...)` moves to a `Track`/`StormTrack` helper.
+- `fill_rad_w_other_source(...)` is a track/data-cleaning utility (important for IBTrACS + ATCF workflows).
+- `make_multi_structure(...)` moves to a separate `tools/` (workflow) namespace, with an import shim for compatibility.
+- `construct_fields` and the Python Holland/CLE methods are removed from the object surface. A future `parametric` evaluator module can take a `StormTrack` and output wind/pressure on a space-time grid, mirroring the Fortran, but that is future work.
+- `available_models()` splits into Fortran-supported vs Python-supported, both clearly labeled.
+
+---
+
+## 6. Data representation and the datetime question
+
+> **Amendment (Phase 1):** the track axis uses `numpy.datetime64`, uniform with
+> the gridded field axis. The track axis is already `datetime64` today, so
+> keeping it is behavior-neutral and avoids conversion glue; `Storm.t` and
+> `Track.t` remain `datetime64` arrays. This supersedes the "Python `datetime`
+> canonical on the track" decision described in the rest of this section, which
+> is retained below for historical context.
+
+The instinct toward `numpy.datetime64` (because most netCDF forcing carries it) and the locked decision to use Python `datetime` are not in conflict once the two time axes are separated.
+
+- The **track axis** is sparse and event-like (hundreds of points), where calendar semantics and readability matter. Keep scalar Python `datetime` canonical here.
+- The **gridded field axis** is dense and CF-backed (thousands of steps), where `datetime64` is the efficient, lossless representation given CF units. Keep `datetime64` arrays native on `GriddedMetForcing`.
+- Conversion happens only at the write boundary into Fortran, carried by `time_offset`. The Fortran side never needs datetime awareness.
+
+The "locked" datetime decision governs the track layer; it was never intended to bind the gridded field axis.
+
+---
+
+## 7. Fortran target
+
+The Fortran side already has the structural split we want (top-level dispatcher, parameterized implementation, gridded implementation). The work is renaming, interface clarification, and reducing overloaded terminology, not a new architecture. Semantic clarification comes first; physical renames come last.
+
+### Module and type names (preferred, applied in the rename phase)
+
+| Current | Target | Role |
+|---|---|---|
+| `storm_module` | `met_forcing_module` | top-level interface and dispatch |
+| `model_storm_module` | `parametric_met_forcing_module` | parameterized forcing implementation |
+| `data_storm_module` | `gridded_met_forcing_module` | gridded forcing implementation |
+| `model_storm_type` | `parametric_met_forcing_type` | parameterized forcing state and model context |
+| `data_storm_type` | `gridded_met_forcing_type` | gridded forcing dataset container |
+
+No heavyweight top-level `met_forcing_type` unless a real need emerges; the dispatcher module is sufficient.
+
+### Top-level procedures
+`set_met_forcing`, `set_met_forcing_fields`. The top-level module owns shared forcing controls: wind/pressure toggles, drag law, AMR refinement thresholds. Helpers: `set_parametric_forcing`, `set_gridded_forcing`, `set_parametric_fields`, `set_gridded_fields`.
+
+### Forcing selection semantics
+Replace the overloaded `storm_specification_type` with an explicit split:
+- **family:** `parametric`, `gridded`
+- **parametric subtype:** `holland80`, `holland2008`, `holland2010`, `cle`, `slosh`, `rankine`, `modified_rankine`, `demaria`, `willoughby`
+- **gridded subtype:** `owi_ascii`, `netcdf`
+
+The legacy signed-integer encoding stays on the `surge.data` wire as an alias during transition so current Fortran keeps reading it (see Section 9, seam 4).
+
+### Center / location abstraction
+Do not require a universal storm-location abstraction at the top level. Parameterized forcing may provide `track_center` / `track_direction`; gridded forcing has no required center API. This assumption is a real source of current bugs on the gridded path and is addressed early (see Section 9, seam 2, and the Phase F1 note in Section 10).
+
+### Fortran capability alignment (summary)
+
+| Module | Alignment | Action |
+|---|---|---|
+| `storm_module` | strong structure, weak naming | keep structure; rename later; rethink `output_storm_location` |
+| `model_storm_module` | strong; richer model support than Python exposes | keep; rename later; later split track/state from model identity |
+| `data_storm_module` | strong; already clearly gridded | keep; rename later; do not force a center abstraction here |
+
+---
+
+## 8. Python capability triage (from the inventory)
+
+**Keep and migrate early (Phase 1):** `Storm` wrapper; `read()`/`write()` dispatch; core track fields (`t`, `eye_location`/`center`, `max_wind_speed`, `max_wind_radius`, `central_pressure`, `storm_radius`); `time_offset`; `read_geoclaw`, `read_atcf`, `read_hurdat`, `read_ibtracs`, `read_data`; `write_geoclaw`, `write_data`; `fill_rad_w_other_source`; `make_multi_structure` (to tools/). `window` and `ramp_width` stay visible.
+
+**Keep, de-emphasize (Phase 2):** `name`, `basin`, `ID`, `classification`, `event`; `wind_speeds` (format-specific, optional); `scaling`, `window_type`; `plot`, `category`; `available_formats()`, `available_models()` (split registries).
+
+**Deprecate or stop advertising:** track-format writers (`write_atcf/hurdat/jma/imd/tcvitals`); Python `construct_fields` and Holland/CLE stubs as if functional. `read_imd` is a stub today; decide deprecate-now vs documented future-work placeholder.
+
+---
+
+## 9. General-functionality seams (must not break)
+
+The maintainer owns storm forcing, so the automated verification gate carries the entire "nothing breaks" burden that a reviewer would otherwise share. That makes Phase 0 load-bearing. Characterization tests on `storm.py` I/O only prove the storm module reproduces its own outputs; they say nothing about the integration seams where forcing touches the rest of GeoClaw. Those seams are the general-functionality risk and each decision that would change them must be flagged, not made locally.
+
+1. **Aux array contract.** Storm forcing owns aux slots for wind `(u, v)` and pressure, populated each step and consumed by `setaux`, `b4step2` (`set_storm_fields` / `set_met_forcing_fields`), `src2` (pressure-gradient and wind-drag source terms), output (`fort.a`), aux interpolation on regrid, and restart. **Invariant: aux count, component ordering, and indices unchanged.** Any unavoidable change is a flagged decision, not a local one.
+
+2. **AMR refinement via storm center.** `flag2refine2` in the surge apps refines on distance-to-center (`R_refine`) alongside `wind_refine`. Optionalizing `storm_location` for the gridded case is therefore not free: it forces a decision about the gridded-forcing refinement criterion when there is no center (wind-speed threshold only, forcing-window bounding box, or other). This changes AMR behavior, which is general functionality. Pick it deliberately and flag it; do not let it fall out of the code.
+
+   > **Decision (Phase F1):** gridded/no-center forcing refines on the
+   > `wind_refine` wind-speed thresholds only; the distance-to-center `R_refine`
+   > loop requires an eye and does not apply. This formalizes the pre-F1
+   > behavior (`R_refine` was already inert for data storms because
+   > `storm_location` returned `rinfinity`), so it is behavior-neutral. F1 makes
+   > it intentional via a `storm_location_available` predicate (true iff
+   > `storm_specification_type > 0`) that guards `flag2refine2` (R_refine),
+   > `src2` (sector wind-drag angle → `phi = 0` when centerless), and `valout`
+   > (`fort.track` is written for parameterized storms only).
+
+3. **`src2` coupling.** Wind drag law selection and pressure forcing enter the momentum source terms alongside Manning friction. The drag pointer is a shared forcing control; if its selection or the source-term ordering moves, `src2` output moves. Every surge run is sensitive to this.
+
+4. **`surge.data` format and `SurgeData` writer, in lockstep.** The `storm_specification_type` integer encoding lives on this wire. The Python writer and the Fortran reader change together or not at all. Keeping the legacy encoding as an alias is what protects this during the config split.
+
+5. **`SurgeData` public surface and import paths.** Every surge `setrun.py` sets `SurgeData` attributes, and import paths (`from clawpack.geoclaw.surge.storm import Storm`, the `SurgeData` location) are themselves a compatibility contract. Module splits must keep those paths importable via shims. Treat the `SurgeData` surface and import paths as first-class must-keep, alongside the `Storm` class.
+
+6. **Rename blast radius.** Every `use storm_module` / `use model_storm_module` / `use data_storm_module` site across the whole tree breaks on the rename, not just files under `surge/`. Enumerate them up front so the radius is known rather than discovered at link time.
+
+7. **Non-shallow variants.** Verify whether multilayer SWE surge (different aux layout) and the Boussinesq path consume the storm aux contract. If either reads storm aux, the aux-contract invariant in seam 1 must hold for them too.
+
+---
+
+## 10. Development plan
+
+### Phase 0 — verification harness (before any refactor)
+Convert "best-effort compatibility" from a stance into a gate.
+- **Contract audit** first: grep every `use` of the three Fortran modules tree-wide and every import of `SurgeData` and `clawpack.geoclaw.surge.storm`; report the current aux index/count contract and every routine that reads it (`setaux`, `b4step2`, `src2`, `flag2refine2`, output, restart); confirm whether multilayer and bouss consume it.
+- **Python characterization tests:** snapshot object state from `read_geoclaw`, `read_atcf`, `read_hurdat`, `read_ibtracs`, `read_data`; golden-file the bytes from `write_geoclaw` and `write_data`, on a small fixture set. Assert identity through the entire refactor.
+- **Fortran end-to-end regression:** one parametric (Holland 1980) and one gridded (netCDF) case that dumps the forcing aux arrays on a fixed grid at a few times, asserted bit- or tolerance-identical pre/post. The *Implement analytical storm surge specs* work is the natural verification oracle here and doubles as the guard on the gridded path.
+- **Two-sided "nothing broke" check:**
+  - a non-surge GeoClaw example (a tsunami/dtopo case) whose `fort.q`, gauges, and fgmax are asserted **byte-identical across every refactor commit** (storm work must have zero effect on it; the moment this canary moves, shared code has been touched);
+  - the full surge example suite, with gauge/fgmax diffs held identical for the cases that should be preserved.
+
+**Gate:** audit reported, baseline green, before any production code changes.
+
+### Phase 1 — Python conceptual split (one PR, additive then swap)
+Introduce `Track`/`StormTrack`/`ParametricMetForcing`/`GriddedMetForcing` alongside `Storm`; port readers to produce them; move `read_geoclaw -> ParametricMetForcing`, `read_data -> GriddedMetForcing`; put `write_geoclaw`/`write_data` on the objects with `time_offset` at the write boundary; reimplement `Storm` as a thin wrapper over `ParametricMetForcing`; preserve the must-keep surface and import paths via shims; demote stub writers and Python parametric stubs; split `available_models()`. Gate on the full Phase 0 suite.
+
+### Phase 2 — config semantics (Python-first)
+Replace the overloaded `storm_specification_type` at the API level with explicit `family` + `subtype`. Keep the legacy signed-integer encoding on the `surge.data` wire as an alias so current Fortran keeps reading it and `setrun.py` workflows do not break.
+
+### Phase F1 — Fortran center-assumption fix (independent, early)
+Guard/optionalize `storm_location` / `output_storm_location` so the gridded path no longer assumes a center. This is a real latent-bug fix, independent of the renames, and it de-risks gridded (ETC) runs. It carries the general AMR decision in seam 2, which must be surfaced and chosen here rather than at implementation time. Ships as its own small PR; changes no other logic and renames nothing.
+
+### Phase F2 / F3 — Fortran interface split, then physical rename (last)
+Split `storm_specification_type` into family+subtype at the Fortran config read (F2), then rename modules and types to the met-forcing vocabulary (F3). The rename is deliberately last and is required to be provably behavior-neutral: the end-to-end regressions and the non-surge canary must be identical across it, so any post-rename regression is definitionally not the rename.
+
+### Phase 3+ — future work (not prerequisites)
+Python-side parametric model implementations (a `StormTrack` to (wind, pressure) evaluator mirroring Fortran); ETC-specific parametric forcing on the non-tropical `StormTrack` path; Fortran track/state type separation. *Rework TC Geometry Estimates* (Kimball/Mulekar, Chavas radius; Emanuel/Tuleya precip) plugs in here as new parametric subtypes and radius-fill logic, riding on the clean parametric interface.
+
+---
+
+## 11. PR structure and rationale
+
+Four separate PRs, in order: (1) Python split, (2) Fortran center-assumption fix, (3) config family/subtype split, (4) Fortran rename.
+
+The reason is blast-radius isolation and bisectability, not review process. If a surge example regresses, `git bisect` should land on one conceptual change (the split, the config, or the rename) rather than a single commit that did all three. The rename PR in particular must be behavior-neutral, so isolating it means any post-rename regression is definitionally not the rename. Because the automated gate carries the full "nothing breaks" burden here, keeping the changes separable is what makes a regression attributable and cheap to revert.
+
+---
+
+## 12. Project gating
+
+- **Model Alaskan ETCs:** the motivating case for the generalization, but not on the refactor's critical path. Its unblock was the netCDF merge (done) plus Derecho/`batch`. The refactor proceeds on its own branch without gating Alaska, provided Phase 0 guards the gridded path and Phase F1 lands the center-assumption fix (which helps it).
+- **Model ETC Storm Surge:** gated on Derecho/`batch`; orthogonal to this refactor. Nothing here touches that path.
+- **Run simulations for Atlantic risk assessment:** cares about `write_geoclaw` and Holland stability at scale; protected by Phase 0 characterization and the Phase 1 wrapper. Benefits later from Phase 3 Python parametric work and TC geometry.
+- **Rework TC Geometry Estimates:** future parametric subtypes, not refactor structure; does not block this work.
+
+---
+
+## 13. Open questions (mostly settled; implementation-level)
+
+- Exact target class names where still ambiguous (`Track` vs `TrackData`, `MetForcing` vs `BaseMetForcing`).
+- New forcing file extensions/naming to distinguish parameterized forcing files from gridded descriptor files (a user-facing clarification opportunity).
+- Degree of shared concrete base implementation for common forcing controls.
+- `read_imd`: deprecate now or keep as a documented future-work placeholder.
+- The gridded-forcing AMR refinement criterion (seam 2): the one genuinely general decision buried in Phase F1; decide it explicitly and early.
+- Timing of Python object deprecations and file-naming transitions, weighed against test and documentation impact.

--- a/dev/design/met_forcing_roadmap.md
+++ b/dev/design/met_forcing_roadmap.md
@@ -1,0 +1,291 @@
+# Meteorological Forcing — Post-Refactor Roadmap
+
+> **Provenance.** Reconstructed 2026-08-23 from the Obsidian vault mirror
+> *"Met Forcing Post-Refactor Roadmap"* (last synced 2026-07-30) + git history +
+> merged code. The original `.plans/met_forcing_roadmap.md` was never tracked in
+> git (unlike `met_forcing_refactor.md` / `met_forcing_docs_plan.md`, which were
+> recovered verbatim from a blob), so the vault mirror is the only source; this is
+> a reconstruction, not a recovered original. Every merged-status / PR claim below
+> was verified against the geoclaw merge history: S1 = PR #715, S2 = PR #716,
+> OWI/ASCII off-by-one = PR #717, Decision 1→B (met package) = PR #724 /
+> commit `f39c0937` — all merged to `clawpack/master` by 2026-07-30. Obsidian
+> `[[wikilinks]]` in the mirror have been rendered as plain text and `.plans/`
+> paths repointed to `dev/design/`. Lines marked `VERIFY:` are not confirmed
+> against code.
+
+*Status: living document. Companion to the completed `met_forcing_refactor.md`
+(object-model + Fortran rename) and `met_forcing_docs_plan.md` (documentation).*
+
+**Progress (2026-07-30):** S1 (Fortran `met_*` de-prefix, PR #715), S2 (Python
+OWI WIN/PRE reader/writer, PR #716) + the OWI/ASCII off-by-one fix (PR #717),
+**Decision 1 → B** (the `clawpack.geoclaw.met` package + `surge` deprecation shim +
+`MetData`/`rundata.met_data` aliases), and the **naming/docs conformance**
+follow-up (geoclaw examples/tests + clawutil `met_data` + Sphinx docs) are all
+merged to `clawpack/master`. **Next up: S3** (track-reader harvest), then the
+**M1 parametric generator** — now set up as a tracked project, currently pinned.
+
+## Context
+
+The met-forcing refactor is merged to `clawpack/master`. The object model is now
+met-generic (`Track` / `StormTrack` / `ParametricMetForcing` /
+`GriddedMetForcing`), the Fortran modules are renamed
+(`met_forcing_module` / `parametric_met_forcing_module` /
+`gridded_met_forcing_module`), and the Sphinx/tutorial documentation is done.
+
+This roadmap triages the *next* wave of work: finishing the "surge → met"
+naming transition, trimming verbose Fortran names, adding meteorological-format
+support (OWI, richer track readers), and a Python wind-field generator
+(the parametric family now; the USACE/Chow solver later).
+
+**Guiding principle (from the 2026-07 audit):** GeoClaw's recurring failure mode
+is *forking a parallel implementation and letting it drift*. Every item below
+favors **extending the one merged object model** over introducing a second one.
+
+**Kernel-territory note:** the wind/pressure models (M1's parametric family —
+Holland, CLE, … — and the L2 Chow PBL PDE solver) are numerical kernel code. Any
+wind model must be verified with a real check (Python↔Fortran field equivalence,
+gradient-wind far-field balance, stationary-storm symmetry, or a match to
+published Chow/SLOSH output), not a plausible-looking run.
+
+---
+
+## Decision 1 — Python "surge" → "met" naming  ✅ DONE (Option B, merged 2026-07-30)
+
+**Option B shipped:** `met/` is now the real package (implementation moved from
+`surge/`); `surge/` is a thin `DeprecationWarning` shim; `MetData = SurgeData` in
+`clawpack.geoclaw.data`; `rundata.met_data` aliases `surge_data` (clawutil);
+examples/tests and the Sphinx docs conform to the `met` name. The `surge.data`
+wire filename and the `Storm` class name are unchanged. The full rename (Option C
+— `SurgeData`→`MetData`, `surge.data`→`met` wire, dir/label renames) remains the
+eventual major-version end state, tracked as **L1**. Option table kept below for
+history.
+
+Contract surface a rename touches: package path `clawpack.geoclaw.surge`
+(imported by community `setrun.py`); the `Storm` class; `SurgeData` +
+`rundata.surge_data` (the attr is registered in **clawutil**, a separate repo);
+the `surge.data` filename (**cross-language contract** with `met_forcing_module`);
+and Sphinx labels `surgedata` / `quick_surge` / `setrun_surge` (doc repo).
+
+| Option | End state | Consequences | Effort |
+|---|---|---|---|
+| **A. Docstrings/comments only** | `surge/` stays; wording reframed | Zero API/wire/build/downstream churn; does **not** fix the core inconsistency (met objects inside a `surge` package). | S |
+| **B. Add `met` aliases, deprecate `surge` (RECOMMENDED)** | Canonical `clawpack.geoclaw.met` re-exports the model; `surge` becomes a `DeprecationWarning` shim; optional `MetData = SurgeData` + accept `rundata.met_data` | New users get clean naming; **no forced downstream break**; `surge.data` wire + Fortran untouched; clawutil change only if `met_data` attr wanted. Two names coexist for a deprecation cycle. | M |
+| **C. Full rename to `met`** | `surge`→`met`, `SurgeData`→`MetData`, `surge.data`→`met` wire, `surge_data`→`met_data` | Cleanest, fully coherent; **breaks every community `setrun.py`**; needs coordinated geoclaw + clawutil + doc release + Fortran wire change. | L (multi-repo) |
+
+**Recommendation: B now, C as the eventual major-version end state.** B resolves
+the packaging inconsistency without breaking the storm-surge user base, and sets
+up C as the deprecation-cycle endpoint. Keep the class name `Storm` (it *is* a
+storm). Keep the `surge.data` filename for now (cross-language + cross-repo cost
+not yet justified). Internal docstring/comment reframing (A) is absorbed into B.
+
+---
+
+## Decision 2 — Fortran `met_*` de-prefix  ✅ DONE
+
+The only redundant prefixing was four public names + one subroutine inside
+`gridded_met_forcing_module.f90` (a module whose name already says `met_forcing`),
+none referenced by any external `use` site: `has_met_crop`→`has_crop`,
+`met_crop_extent`→`crop_extent`, `met_x_shift`/`met_y_shift`→`x_shift`/`y_shift`
+(now an exact match to the topo/dtopo names they parallel), subroutine
+`met_crop_indices`→`crop_indices`. Stale pre-rename `.o` files removed. The module
+*names* themselves are unchanged.
+
+*Verified behavior-neutral:* the gridded netCDF + Holland aux regression tests
+pass against existing goldens (`rtol=1e-14/atol=1e-8`, no `GEOCLAW_REGEN`).
+Delivered on branch `met-deprefix-gridded`.
+
+---
+
+## Work items
+
+### SHORT TERM
+
+- **S1. Fortran `met_*` de-prefix** — ✅ done (Decision 2).
+
+- **S2. OWI (Oceanweather WIN/PRE) reader/writer — ✅ DONE (PR #716).**
+  Rewrote the orphaned `surge/data_storms.py` into a clean field reader/writer
+  (`read_owi` / `write_owi` / `read_owi_start_time` + the `OWIData` dataclass; SI
+  in memory, mbar/f10.4 on disk), registered it in `meson.build`, and added thin
+  `GriddedMetForcing.from_owi` / `to_owi` helpers. Tests: object round-trip +
+  real-`isaac` sample reads in `test_met_objects.py`, plus a format-1 gridded
+  regression case in `tests/regression/met_forcing/`. Documented the f10.4
+  precision limit.
+  - **OWI/ASCII coordinate off-by-one — ✅ FIXED (PR #717).** The Fortran OWI
+    reader placed grid point *i* at `sw + i*d` instead of `sw + (i-1)*d`, shifting
+    the whole grid one cell NE and disagreeing with the NetCDF path. Proven with a
+    new OWI-vs-NetCDF equivalence regression test (failed pre-fix by ~1535 Pa),
+    fixed, and the `aux_owi` + isaac `owi_ascii` gauge goldens regenerated. Note:
+    `test_isaac.py`'s OWI coordinate reconstruction was updated to match.
+
+- **S3. Harvest low-risk track-reader improvements** into `met/track.py`
+  (do **not** adopt a parallel `CycloneDataset` object model): quadrant wind-radii
+  (`r34/r50/r64` × NE/SE/SW/NW), `Basin`/`StormStatus` enums + standardization
+  maps, and an IBTrACS netCDF path if the current reader is CSV-only. Port ideas,
+  re-verify against real files, keep `StormTrack` as the single home.
+
+- **S4. Parametric geometry reconstruction (missing-data filling).** Restore and
+  modernize the old code's "basic reconstruction from statistical and physical
+  data" for the recurring pain of **missing storm geometry** in commonly-available
+  best tracks (ATCF/HURDAT/IBTrACS): no radius of maximum winds (RMW), no
+  outer/last-closed-isobar radius (ROCI), or only one of max-wind-speed /
+  central-pressure. Today the readers mark these `-1`/`NaN`, warn, and refuse to
+  fill physically — the only automatic default is a flat constant
+  (`storm_radius = 500 km`, `met/parametric.py:150`). This item adds **opt-in,
+  explicit** estimator functions with the **existing `fill_dict` signature**
+  `fn(t, storm) -> value (SI)`, so they drop straight into
+  `ParametricMetForcing.write_geoclaw(fill_dict=...)` and compose with the existing
+  `fill_rad_w_other_source` time-interpolator (`met/track.py:1035`). **No new
+  object model, no Fortran, no wire change** (extend, don't fork). The default
+  write path stays warn/skip — nothing is silently reconstructed. New module
+  `met/reconstruction.py`; optional `default_fill_dict(track, models={...})`
+  convenience assembler. Estimator families (each cites its paper; **maintainer
+  confirms coefficients & provenance**):
+  - **Wind–pressure relationship** — fill `max_wind_speed` ↔ `central_pressure`:
+    Knaff & Zehr (2007) (recommended; operational standard), alt Atkinson &
+    Holliday (1977). *WPR is the essential companion not in the reference note —
+    flagged for sign-off.*
+  - **RMW from intensity + latitude** — fill `max_wind_radius`: Willoughby et al.
+    (2006) (recommended), alts Kimball & Mulekar (2004) / Carrasco et al. (2014),
+    optional Vickery & Wadhera (2008) for Holland-B-consistent RMW.
+  - **Outer/storm radius (ROCI) from environment** — replace the 500 km constant:
+    Chavas et al. (2016), with a **climatological fallback** so it degrades to a
+    physically-motivated default when environment (SST/outflow) is unknown.
+
+  *Not numerical-kernel code* — empirical regressions from cited papers, not
+  solver/Riemann/limiter math, so it does not hit the kernel STOP rule; coefficient
+  choices remain the maintainer's. **Verification = reproduce the published
+  relationship**, not a manufactured PDE: match published reference values
+  (Willoughby RMW at documented `Vmax`/lat; Knaff–Zehr WPR table) to tolerance;
+  physical invariants (RMW↓ with `Vmax`, deeper `dp`⇒higher `Vmax`, positivity/SI,
+  latitude direction); distributional check vs observed IBTrACS/EBTRK; and a
+  sparse-ATCF (RMW/ROCI stripped) → `fill_dict` → `write_geoclaw` round-trip
+  yielding a runnable 7-column storm file with all fields finite
+  (`tests/test_met_objects.py`). Opt-in ⇒ existing aux + bowl-slosh goldens stay
+  byte-identical (no `GEOCLAW_REGEN`). Sequence **after S3** (can also draw on the
+  harvested quadrant radii / basin) and as a **companion feeding M1** (the
+  generator consumes complete parameter sets). Reference note (TC-radius section):
+  *Rework TC Geometry Estimates* (vault project note).
+
+### MEDIUM TERM
+
+- **M1. Parametric-family offline wind-field generator (Python).** Turn a
+  `StormTrack` + parameterization into gridded wind/pressure fields in Python and
+  write netCDF (and/or OWI) that `GriddedMetForcing` already consumes — no
+  live-solver changes, no new Fortran family. Fills the `met/storm.py`
+  `holland_1980`/`holland_2010`/`cle_2015`/`construct_fields` stubs; adds
+  `ParametricMetForcing.to_gridded(...)`. Phasing (G1–G5): **Holland-1980**
+  (matches the existing `aux_holland80.txt` golden) → Holland-2010/2008 →
+  **CLE15** (ODE solve; heaviest kernel; cross-check vs the Fortran CLE *and*
+  `EmilioEchevarria/tcwindfields` CLE15, MIT — reference only, not vendored).
+  **Verification is the point** (see the discipline note below). *Kernel territory
+  — the model numerics are implemented/verified by the maintainer.* The **Chow**
+  USACE PBL wind solver is the harder sub-case, deferred to L2 (nested
+  telescoping-grid iterative solver: advection + diffusion + surface drag +
+  pressure-gradient + implicit Coriolis; verify vs gradient-wind far-field,
+  stationary-storm symmetry, published Chow output).
+  - **Status: designed, tracked, pinned (not started).** Durable design +
+    Fortran-fidelity spec + verification plan: `dev/design/met_wind_field_generator.md`.
+    Tracked as an Obsidian project (currently pinned):
+    *Implement parametric TC wind-field generator* — this roadmap remains the
+    technical index; the project note tracks resumption.
+  - **Sibling: see M3** (analytic/idealized forcing) — both add new parametric
+    subtypes via the same registration path and share the Python↔Fortran
+    field-equivalence verification harness.
+
+- **M2. `StormTrack.to_xarray()` / CF netCDF track I/O** — a single canonical
+  serialization for tracks (idea harvested from the artifact's CF schema), giving
+  multi-storm datasets a home *inside* `StormTrack` rather than a rival class.
+  Delivered alongside M1's gridding layer (recommend the same CF schema as
+  `create_era5_storm_file`/`create_nws13_storm_file`).
+
+- **M3. Analytic / idealized meteorological forcing (new parametric subtypes).**
+  Closed-form pressure + wind evaluated **per cell, live in Fortran** — new
+  `ParametricMetForcing` subtypes on a **generic `Track`** (a moving front), not
+  gridded and not a new family. Primary motivation: meteotsunami modeling
+  (issue #694; the hydrocoast/Miyashita `meteotsunami` fork) generalized to a
+  reusable idealized-forcing capability. Fields: closed-form pressure with
+  along-track shape Φ (sine/hat/morlet/gaussian/jump) × cross-track apodization
+  Ψ⊥ × temporal ramp R(t); **wind first-class** (`none`/`geostrophic`/`gradient`).
+  Integration = the **same subtype path as M1's models**: register in
+  `data.py` `forcing_subtype_registry` (`("parametric", <new int>)`) +
+  `forcing_spec_type`/`set_storm` case → new `set_analytic_fields` in
+  `parametric_met_forcing_module.f90`; mimics the `test_topography` analytic
+  bathymetry pattern (`topo_module.f90` ~L375). Source coupling (src2
+  pressure-gradient + wind-drag) is **untouched** — kernel-territory note applies.
+  **Verification is a strength:** analytic ocean response — **Proudman resonance**
+  (moving pressure jump over constant depth) and **Greenspan edge waves** — gives
+  end-to-end *manufactured-solution* tests, and the Python↔Fortran
+  field-equivalence harness (shared with M1) covers the field evaluator itself.
+  Deliverable: a Proudman moving-jump canonical example + regression/CI. Open
+  design decisions (see the spec): subtypes-vs-sibling-family, wind-coupling
+  formulation, the moving-front AMR criterion (**seam 2**), and subtype naming +
+  legacy signed-int alias on the `surge.data` wire. Full spec:
+  *Analytic Met Forcing Plan* (vault note); tracked project (status **active**,
+  GeoClaw-Users'-Workshop-2026 target):
+  *Implement analytical meteorological forcing for GeoClaw*.
+  **Sibling to M1** — both are new parametric subtypes sharing the
+  subtype-registration path and the verification harness.
+
+### LONG TERM
+
+- **L1. Full `met` rename** (Decision 1, Option C) at a GeoClaw major version once
+  B's deprecation cycle has run — coordinated with clawutil + doc repos.
+- **L2. Chow PBL wind solver** — first as the Python generator's hardest sub-case
+  (offline, per M1), then as a native Fortran forcing family *only if* verification
+  shows the live-solver cost is warranted. Explicit kernel work.
+- **L3. De-duplicate track readers** — retire scattered prototype readers once
+  S3/M2 land.
+- **L4. TC precipitation estimation (placeholder — separate scoping).** The second
+  half of the *Rework TC Geometry Estimates* reference note: estimate rainfall
+  from a parametric storm — from vertical velocity (Emanuel et al. 2006, Zhu et al.
+  2013, Lu et al. 2018, Gori et al. 2022) or from the empirical TC-precip↔radii
+  relationship (Tuleya et al. 2007, Mudd et al. 2017). A **distinct, larger
+  capability** than S4's geometry filling: it needs a rainfall forcing field plus
+  overland-flow coupling that does not exist yet. Listed here only so the reference
+  note's precip thread is not lost; scope separately before committing.
+
+---
+
+## Suggested sequencing
+
+1. **S1** — ✅ done (PR #715).
+2. **S2** (OWI reader/writer) + off-by-one fix — ✅ done (PR #716 / #717).
+3. **Decision 1 → B** (met package + `surge` shim + `MetData`/`met_data`) +
+   naming/docs conformance (examples/tests + clawutil + Sphinx) — ✅ done.
+4. **S3** (track-reader harvest) — **NEXT**.
+5. **S4 — parametric geometry reconstruction** (opt-in missing-data filling).
+   After S3 (can use harvested quadrant radii / basin) and a **companion to M1**
+   (feeds it complete parameter sets); pure Python, opt-in, low-risk.
+6. **M1 — parametric-family Python generator** (the substantive new capability;
+   designed, tracked as a project, currently pinned). Recommended **after S3** so
+   it is authored against the richest `StormTrack`, but it can start independently
+   if appetite comes first. Chow is the harder sub-case → **L2**.
+7. **M3 — analytic / idealized forcing** — the currently **active** analytic thread
+   (Workshop-2026 target), **independent of S3 and M1** (it uses a generic `Track`,
+   not the enriched `StormTrack`), so it can proceed now / in parallel. Sibling to
+   M1; shares the subtype-registration path + verification harness.
+8. **M2 / L1 / L2 / L3 / L4** as evidence and appetite allow.
+
+## Verification discipline (all items)
+
+Behavior-neutral changes must keep the met-forcing aux goldens and bowl-slosh
+canary byte-identical (no `GEOCLAW_REGEN`). New capabilities add their own
+regression cases under `tests/regression/met_forcing/` and/or object tests in
+`tests/test_met_objects.py`. Cross-repo changes (clawutil / riemann / doc) are
+called out explicitly and merged in lockstep.
+
+**Parametric generator = verification engine (M1).** A faithful Python parametric
+generator must reproduce the Fortran forcing-aux goldens (e.g. `aux_holland80.txt`)
+on the same grid/frames/storm — a Python↔Fortran equivalence test that makes the
+two implementations *mutually verifying* and is the path to retiring the hand-rolled
+analytic-vortex fixtures (`_netcdf_forcing`/`_owi_forcing`). **Anti-circularity
+rule:** the equivalence golden always comes from the independent Fortran path, never
+regenerated from the generator, so it never grades its own output.
+
+**Analytic forcing = end-to-end manufactured solutions (M3).** The analytic
+subtypes add *closed-form ocean-response* checks — Proudman resonance (known
+amplification as `c → √(gh)`) and Greenspan edge-wave amplification — that verify
+the full forcing→SWE coupling, not just the field. Their per-cell field evaluator
+reuses M1's Python↔Fortran field-equivalence harness (same anti-circularity rule).
+Together M1 and M3 give the met-forcing subsystem both field-level and
+system-level manufactured verification.

--- a/dev/design/met_wind_field_generator.md
+++ b/dev/design/met_wind_field_generator.md
@@ -1,0 +1,111 @@
+# Parametric TC Wind-Field Generator — Design & Verification Plan
+
+> **Provenance — PARTIAL RECONSTRUCTION.** Rebuilt 2026-08-23. The original
+> `.plans/met_wind_field_generator.md` was **never tracked in git and has no full
+> vault mirror** — only a summary survives in the vault project note *"Implement
+> parametric TC wind-field generator"* (last reviewed 2026-07-30). This file is a
+> skeleton assembled from that project note, the M1 entry in
+> `dev/design/met_forcing_roadmap.md`, and the current code stubs; it is **not the
+> original document** and is known to be incomplete. Sections reconstructed from
+> the summary are marked; anything not confirmed against code is `VERIFY:`.
+> Code anchors below were confirmed present at reconstruction time. **Kernel
+> territory:** the wind/pressure model numerics are implemented and verified by
+> the maintainer — this doc scopes and plans, it does not supply kernel code.
+
+## Status (from the project note, 2026-07-30)
+
+Design + verification plan complete; the enabling surge→met refactor is merged to
+`clawpack/master`. Implementation is **pinned (not started)**. Decision made:
+build a **native** Python parametric wind-field generator in
+`clawpack.geoclaw.met` (Option A), verified against the Fortran `aux` fields — use
+`EmilioEchevarria/tcwindfields` (MIT) only as an independent cross-check, not
+vendored. Immediate next decision: when to start phase G1 (Holland-1980 kernel)
+and lock the first-model scope.
+
+## Goal
+
+Turn a `StormTrack` + a parametric model into gridded wind/pressure fields **in
+Python**, and write netCDF (and/or OWI) that `GriddedMetForcing` already consumes
+— no live-solver changes, no new Fortran forcing family. This makes the parametric
+family available offline and, crucially, makes the Python and Fortran evaluators
+**mutually verifying**.
+
+## Code anchors (confirmed 2026-08-23)
+
+Python stubs to fill (module-level functions in `met/storm.py`):
+- `construct_fields(storm, r, t, model="holland_1980")` — `met/storm.py:447`
+- `holland_1980(storm, r, t)` — `met/storm.py:457`
+- `holland_2010(storm, r, t)` — `met/storm.py:463`
+- `cle_2015(storm, r, t)` — `met/storm.py:469`
+
+Proposed new API (does **not** exist yet — `VERIFY:` when built):
+- `ParametricMetForcing.to_gridded(...)` on `met/parametric.py` (no such method at
+  reconstruction time; `parametric.py` currently exposes `write_geoclaw` at :118
+  and the 500 km `storm_radius` default fill at :150).
+
+Fortran fidelity oracle — the per-cell field evaluators the Python generator must
+reproduce, in `src/2d/shallow/surge/parametric_met_forcing_module.f90`:
+- `set_holland_1980_fields` (:607), `set_holland_2008_fields` (:679),
+  `set_holland_2010_fields` (:754), `set_CLE_fields` (:843), `set_SLOSH_fields`
+  (:1208). *(Note: `met/storm.py` has no `holland_2008` stub, though the Fortran
+  side implements `set_holland_2008_fields` — the Python phasing skips 2008 or
+  reaches it via 2010; `VERIFY:` the intended first-pass scope.)*
+
+## Phasing (G1–G5, from the roadmap M1 entry)
+
+1. **G1 — Holland-1980.** First model; must match the existing
+   `tests/regression/met_forcing/regression_data/aux_holland80.txt` golden.
+2. **G2/G3 — Holland-2010 / Holland-2008.**
+3. **G4/G5 — CLE15** (Chavas–Lin–Emanuel 2015): an ODE solve, the heaviest kernel;
+   cross-check against the Fortran `set_CLE_fields` *and* the MIT `tcwindfields`
+   CLE15 (reference only).
+
+The **Chow** USACE PBL wind solver is the harder sub-case and is **deferred to
+roadmap L2** (nested telescoping-grid iterative solver; verify vs gradient-wind
+far-field, stationary-storm symmetry, published Chow output).
+
+## Verification plan (the point of the exercise)
+
+- **Python↔Fortran field equivalence** is the primary check: the Python generator
+  must reproduce the Fortran forcing-aux goldens (e.g. `aux_holland80.txt`) on the
+  same grid / frames / storm. Proposed tolerance (from the project note):
+  `rtol ≈ 1e-9 / atol ≈ 1e-6` cross-language. `VERIFY:` tolerance against a real run.
+- **Anti-circularity rule:** the equivalence golden always comes from the
+  independent Fortran path, never regenerated from the Python generator — the
+  generator never grades its own output.
+- **Physical invariants:** gradient-wind far-field balance; stationary-storm
+  symmetry; positivity / SI units.
+- This harness is **shared with roadmap M3** (analytic/idealized forcing), which
+  additionally supplies end-to-end manufactured ocean-response checks (Proudman
+  resonance, Greenspan edge waves).
+
+## Open questions (from the project note)
+
+- First-pass model scope: Holland-1980 → CLE15 only, or also Holland-2010/2008 in
+  between? (CLE15 is the heaviest kernel.)
+- Is the Chow PBL solver part of this project or a separate follow-on (roadmap L2)?
+- `StormTrack.to_xarray()` CF schema — match `create_era5_storm_file` /
+  `create_nws13_storm_file`? (leaning yes)
+- Gate the generator behind a soft `xarray` import? (xarray is already a
+  netcdf/test dep.)
+- Python↔Fortran equivalence tolerance target (proposed `rtol≈1e-9 / atol≈1e-6`).
+- Timeline / appetite / who owns the kernel numerics.
+
+## References
+
+- Met-forcing roadmap (M1 / M2 / L2): `dev/design/met_forcing_roadmap.md`
+- Fortran source of truth:
+  `src/2d/shallow/surge/parametric_met_forcing_module.f90`,
+  `met_forcing_module.f90`, `geoclaw_module.f90`
+- Python home / stubs to fill: `src/python/geoclaw/met/storm.py`
+  (`holland_1980` / `holland_2010` / `cle_2015` / `construct_fields`),
+  `met/parametric.py`
+- Verification oracle: `tests/regression/met_forcing/`
+  (`regression_data/aux_holland80.txt`)
+- External reference impl (MIT, cross-check only):
+  https://github.com/EmilioEchevarria/tcwindfields
+- Papers: Holland (1980); Holland, Belanger & Fritz (2010); Powell/Holland (2008);
+  Chavas, Lin & Emanuel (2015); Emanuel & Rotunno (2011)
+- Vault project note (tracks resumption): *Implement parametric TC wind-field
+  generator*; sibling analytic thread: *Implement analytical meteorological forcing
+  for GeoClaw*.


### PR DESCRIPTION
Adding a `dev` directory to geoclaw so that it can hold the usual things that the `dev` directories do, but also as a tracked place for design documents such as roadmaps, refactor design records, and implementation plans that are meant to be in parallel and reviewed alongside commits and PRs when needed.