### PR TITLE
Remove vestigial line in gauges_module.mod

### DIFF
--- a/src/2d/shallow/gauges_module.f90
+++ b/src/2d/shallow/gauges_module.f90
@@ -422,7 +422,6 @@ contains
         use geoclaw_module, only: dry_tolerance
         use geoclaw_module, only: coordinate_system, earth_radius, deg2rad
         use geoclaw_module, only: ambient_pressure
-        use met_forcing_module, only: pressure_index
 
         implicit none
 


### PR DESCRIPTION
The following import in the gauges_module is not used. Can we delete it?

**The backstory:** The recent renaming of all the meteorological forcing files breaks D-Claw because there are a few places where D-Claw relies on parts of GeoClaw that rely on these files. At present we don't use any of the met forcing functionality (maybe in the future...) 

We can fully remove most of the interdependency, EXCEPT for this line. 