### PR TITLE
Draft: Small ginit change

### DIFF
--- a/src/2d/shallow/ginit.f
+++ b/src/2d/shallow/ginit.f
@@ -36,6 +36,11 @@ c :::::::::::::::::::::::::::::::::::::::;::::::::::::::::::::
                 locaux              = igetsp(mitot*mjtot*naux)
                 ! do k = 1, mitot*mjtot*naux, naux  ! only set first component of aux to signal
                 do k = 1, mitot*mjtot*naux  ! KRB 2026/08/26 - set all components to NEEDS_TO_BE_SET rather than just aux(1)
+
+                ! NEEDS_TO_BE_SET must be consistently used across multiple routines: 
+                ! setaux: To not recompute (or persist) across gridding setaux must check 
+                !         NEEDS_TO_BE_SET before writing.  
+
                    alloc(locaux+k-1) = NEEDS_TO_BE_SET ! new system checks this val before setting
                 end do
                 

--- a/src/2d/shallow/ginit.f
+++ b/src/2d/shallow/ginit.f
@@ -34,7 +34,8 @@ c :::::::::::::::::::::::::::::::::::::::;::::::::::::::::::::
               node(store1,mptr)   = loc
               if (naux .gt. 0) then
                 locaux              = igetsp(mitot*mjtot*naux)
-                do k = 1, mitot*mjtot*naux, naux  ! only set first component of aux to signal
+                ! do k = 1, mitot*mjtot*naux, naux  ! only set first component of aux to signal
+                do k = 1, mitot*mjtot*naux  ! KRB 2026/08/26 - set all components to NEEDS_TO_BE_SET rather than just aux(1)
                    alloc(locaux+k-1) = NEEDS_TO_BE_SET ! new system checks this val before setting
                 end do
                 


### PR DESCRIPTION
In current D-Claw work we have recently found that this change is needed to allow values to persist in aux across regrinding. 

For the moment we have made this change in a D-Claw specific ginit. But if the change does not cause problems in geoclaw, perhaps it should live here. For reference, in D-Claw we are working to create a storage layer of static material to put h<drytol. We'd like this to be in aux. If this change is not made, that value of aux is set to zero every time regridding occurs. With this change we can know which parts that aux variable need to be set. 

@rjleveque @mandli @dlgeorge 