### PR TITLE
Met: Add multi-storm HURDAT2 parsing and bulk IBTrACS/ATCF iteration

### DIFF
--- a/dev/design/met_forcing_roadmap.md
+++ b/dev/design/met_forcing_roadmap.md
@@ -32,9 +32,12 @@ runnable storm file at all**: `read_hurdat`/`read_ibtracs` mark missing radii `-
 while `write_geoclaw` tests only `np.isnan`, so `fill_dict` never fires and `-1` is
 written verbatim (a regression against v5.9.0, whose writer checked `== -1`).
 **That is now also done** (S4-prerequisite, below): the missing-value contract is
-unified on NaN and `test_storm_io[ibtracs]` is no longer `xfail`. Next is
-multi-storm ingestion (**S5**, new — both archives ship one file per basin and
-`read_hurdat` is single-storm-only), then S3 proper and S4.
+unified on NaN and `test_storm_io[ibtracs]` is no longer `xfail`. **Multi-storm
+ingestion is also done** (**S5**, new — `iter_hurdat` / `iter_ibtracs` /
+`iter_atcf` plus `catalog_*` indices). Next is **S3 proper** (quadrant radii,
+`Basin`/`StormStatus` enums, the remaining `<U1` truncations), then **S4**
+(`met/reconstruction.py` — needed because RMW is observed at only 55% of North
+Atlantic 1980-2025 track points and never by HURDAT2).
 
 ## Context
 
@@ -267,6 +270,73 @@ Delivered on branch `met-deprefix-gridded`.
   harvested quadrant radii / basin) and as a **companion feeding M1** (the
   generator consumes complete parameter sets). Reference note (TC-radius section):
   *Rework TC Geometry Estimates* (vault project note).
+
+- **S5. Multi-storm archive ingestion — ✅ DONE (PR #NNN, verified against
+  `25ec8abc`).** HURDAT2 and IBTrACS both distribute *one file per basin holding
+  every storm on record* (2,004 Atlantic storms / 55,605 records; 2,298 IBTrACS
+  NA storms), so driving an ensemble means walking a file, not opening one per
+  storm. Previously `read_hurdat` assumed a single storm per file and **crashed**
+  on a real archive — it read the next storm's header as a data line and fed
+  `"AL092008"` to `np.datetime64` — while `read_ibtracs` re-scanned the file for
+  every storm.
+  - **API: module-level generators, no collection class.** `iter_hurdat`,
+    `iter_ibtracs` and `iter_atcf` yield `StormTrack`s; `catalog_hurdat` /
+    `catalog_ibtracs` return a `pandas.DataFrame` index (id, name, season, basin,
+    record count, time span, peak wind) so a driver can decide what to run before
+    running it. A DataFrame index is what an ensemble driver actually needs; a
+    `TrackCollection` would have been the parallel object model this roadmap
+    warns against. **S5/M2 boundary:** M2 (`to_xarray()` / CF track I/O) is
+    *serialization of our tracks*; S5 is *ingestion of foreign archives*. They
+    compose — once M2 lands the multi-storm container is
+    `xr.concat(t.to_xarray() for t in iter_*(...))` — and M2 need not re-solve
+    ingestion.
+  - **One parser per format.** `read_hurdat` gained `storm_id` / `name` / `year`
+    selectors and is now built on the same `_hurdat_blocks` framing as
+    `iter_hurdat`; `read_ibtracs` keeps its signature and is built on the same
+    `_select_ibtracs_storm` + `_track_from_ibtracs` as `iter_ibtracs`;
+    `make_multi_structure` is a thin wrapper over `iter_atcf` (which stages
+    through a temp dir instead of littering the cwd) and its test passes
+    unmodified. The verification is therefore *path equivalence* — bulk and
+    single-storm reads produce identical objects — rather than two goldens that
+    could drift.
+  - **Record-count conservation** is the primary HURDAT2 integrity check: each
+    header declares how many records follow, so declared totals must equal what
+    parsed *and* the number of data lines in the file. Verified over the whole
+    Atlantic archive (55,605 both ways). A header claiming more records than
+    follow now raises with the line number instead of absorbing the next storm.
+  - `iter_ibtracs(skip_invalid=True)` is load-bearing, not a convenience:
+    **57 of 741** North Atlantic 1980-2025 storms have no time at which both a
+    wind and a pressure were reported (`NoDataError`), and one of them must not
+    abort a basin sweep. Measured throughput: 684 tracks in 8.8 s (13 ms/storm);
+    `catalog_ibtracs` over the same selection takes 0.2 s.
+  - Reader-correctness fixes that were **inseparable from rewriting the HURDAT2
+    parser**, and so landed here rather than in S3: `ID` held the header's
+    *record count* (`"06"`) and now holds the ATCF-style id (`"AL082008"`) — the
+    count is what frames the block; `basin` was the raw `"AL"` where `read_atcf`
+    gives `"Atlantic"`; and `classification`/`event` were `<U1`-truncated
+    (`"LO"` → `"L"`, colliding with the landfall event code) because the arrays
+    are allocated in the rewritten parser. One golden regenerated:
+    `characterization/read_hurdat.json`, a three-field diff. **S3 retains** the
+    quadrant radii, the `Basin`/`StormStatus` enums, the same `<U1` fix for
+    `read_jma`/`read_tcvitals`, and the `plot` swath masking.
+  - Also shared rather than duplicated: `_IBTRACS_AGENCY_PREF`, previously a
+    mutable default argument on `read_ibtracs`, so the reader and the iterator
+    cannot drift.
+  - **Coverage gap stated plainly:** the bundled fixtures are a single-storm
+    HURDAT2 excerpt and a stripped single-storm IBTrACS slice (no `quadrant`
+    dim, no `season`, only `wmo_*`/`usa_*` agencies). Offline tests synthesize
+    multi-storm files by relabeling those, which cannot exercise differing
+    agencies, basin crossings or real invalid storms. The only test of real
+    heterogeneity is `test_full_basin_sweep`
+    (`@pytest.mark.remote @pytest.mark.slow`, driven by
+    `GEOCLAW_TRACK_ARCHIVES`), which also cross-checks HURDAT2 against IBTrACS
+    for Ike — the same storm from two independent archives through two
+    independent readers agrees on eye position to 0.11 deg. Either commit a small
+    real multi-storm NA slice, or accept that offline coverage is structural
+    only.
+  - *Note for whoever writes NaN-bearing test comparisons:* `_storm_state`
+    dictionaries cannot be compared with `==`, because `nan != nan`. Compare
+    `_dumps(...)` text, as the characterization tests do.
 
 ### MEDIUM TERM
 

--- a/src/python/geoclaw/met/__init__.py
+++ b/src/python/geoclaw/met/__init__.py
@@ -21,6 +21,9 @@ avoid a hard ``matplotlib`` dependency for non-plotting use.
 from clawpack.geoclaw.met.storm import (  # noqa: F401
     Storm, construct_fields, available_formats, available_models)
 from clawpack.geoclaw.met.track import Track, StormTrack  # noqa: F401
+from clawpack.geoclaw.met.track import (  # noqa: F401
+    iter_hurdat, iter_ibtracs, catalog_hurdat, catalog_ibtracs)
+from clawpack.geoclaw.met.tools import iter_atcf  # noqa: F401
 from clawpack.geoclaw.met.parametric import ParametricMetForcing  # noqa: F401
 from clawpack.geoclaw.met.gridded import GriddedMetForcing  # noqa: F401
 from clawpack.geoclaw.met.data_storms import OWIData  # noqa: F401
@@ -28,6 +31,8 @@ from clawpack.geoclaw.data import SurgeData, MetData  # noqa: F401
 
 __all__ = [
     'Storm', 'Track', 'StormTrack',
+    'iter_atcf', 'iter_hurdat', 'iter_ibtracs',
+    'catalog_hurdat', 'catalog_ibtracs',
     'ParametricMetForcing', 'GriddedMetForcing', 'OWIData',
     'SurgeData', 'MetData',
     'construct_fields', 'available_formats', 'available_models',

--- a/src/python/geoclaw/met/storm.py
+++ b/src/python/geoclaw/met/storm.py
@@ -504,7 +504,10 @@ def available_models():
 
 # ``make_multi_structure`` moved to the workflow-tools namespace; kept
 # importable here for backwards compatibility.
-from clawpack.geoclaw.met.tools import make_multi_structure  # noqa: E402,F401
+from clawpack.geoclaw.met.tools import (  # noqa: E402,F401
+    make_multi_structure, iter_atcf)
+from clawpack.geoclaw.met.track import (  # noqa: E402,F401
+    iter_hurdat, iter_ibtracs, catalog_hurdat, catalog_ibtracs)
 
 
 if __name__ == '__main__':

--- a/src/python/geoclaw/met/tools.py
+++ b/src/python/geoclaw/met/tools.py
@@ -3,14 +3,61 @@
 r"""Workflow tools for meteorological-forcing / storm data.
 
 This module hosts higher-level workflow helpers that operate on storm files but
-are not part of the core object model.  Currently it provides
-``make_multi_structure`` for splitting a multi-track ATCF file into individual
-``Storm`` objects.  ``storm.py`` keeps an import shim so the historical import
-path continues to work.
+are not part of the core object model.  It provides ``iter_atcf`` for walking a
+multi-track ATCF file in memory and ``make_multi_structure`` for the older
+split-to-disk workflow (now a thin wrapper over ``iter_atcf``).  ``storm.py``
+keeps an import shim so the historical import path continues to work.
 """
 
 import os
+import tempfile
 from collections import OrderedDict
+
+
+def _group_atcf_records(path):
+    r"""Group an ATCF file's records by storm identity, in first-seen order.
+
+    Identity is basin + cyclone number (the first two comma-separated fields of
+    a b-deck record, e.g. ``AL`` and ``09``).  ``read_atcf`` splits on commas
+    and strips, so this matches that.
+    """
+    storm_records = OrderedDict()
+    with open(path, 'r') as data_file:
+        for line in data_file:
+            fields = line.split(",")
+            if len(fields) < 2:
+                continue
+            storm_id = fields[0].strip() + fields[1].strip()
+            storm_records.setdefault(storm_id, []).append(line)
+    return storm_records
+
+
+def iter_atcf(path):
+    r"""Iterate the storms in a multi-storm ATCF file, without writing to disk.
+
+    The in-memory counterpart to :func:`make_multi_structure`, and the companion
+    of ``met.track.iter_hurdat`` / ``iter_ibtracs`` for the other two archive
+    formats.
+
+    :Input:
+     - *path* (path-like) - the (possibly multi-storm) ATCF file to read.
+
+    :Output:
+     - Generator of ``(storm_id, Storm)`` pairs, where *storm_id* is basin plus
+       cyclone number (e.g. ``"AL09"``), in the order the storms first appear.
+
+    ``read_atcf`` takes a path rather than an open handle, so each storm's
+    records are staged through a temporary file that is removed immediately
+    afterwards; nothing is left in the working directory.
+    """
+    from clawpack.geoclaw.met.storm import Storm
+
+    for storm_id, records in _group_atcf_records(path).items():
+        with tempfile.TemporaryDirectory() as scratch:
+            storm_path = os.path.join(scratch, "%s.storm" % storm_id)
+            with open(storm_path, 'w') as out_file:
+                out_file.writelines(records)
+            yield storm_id, Storm(path=storm_path, file_format="ATCF")
 
 
 def make_multi_structure(path, output_dir="Clipped_ATCFs"):
@@ -21,6 +68,9 @@ def make_multi_structure(path, output_dir="Clipped_ATCFs"):
     b-deck record, e.g. ``AL`` and ``09``).  This groups the records by that
     identity, writes each storm's records to its own file under *output_dir*,
     and reads them back as :class:`Storm` objects.
+
+    Use :func:`iter_atcf` instead when the per-storm files are not wanted; this
+    function exists for the workflow where they are.
 
     :Input:
      - *path* (path-like) - the multi-storm ATCF file to split.
@@ -36,20 +86,9 @@ def make_multi_structure(path, output_dir="Clipped_ATCFs"):
 
     os.makedirs(output_dir, exist_ok=True)
 
-    # Group records by storm identity (basin + cyclone number).  read_atcf
-    # splits on commas and strips, so we match that here.
-    storm_records = OrderedDict()
-    with open(path, 'r') as data_file:
-        for line in data_file:
-            fields = line.split(",")
-            if len(fields) < 2:
-                continue
-            storm_id = fields[0].strip() + fields[1].strip()
-            storm_records.setdefault(storm_id, []).append(line)
-
     # Write each storm's records to its own file and read it back as a Storm.
     storms = OrderedDict()
-    for storm_id, records in storm_records.items():
+    for storm_id, records in _group_atcf_records(path).items():
         storm_path = os.path.join(output_dir, "%s.storm" % storm_id)
         with open(storm_path, 'w') as out_file:
             out_file.writelines(records)

--- a/src/python/geoclaw/met/track.py
+++ b/src/python/geoclaw/met/track.py
@@ -16,6 +16,7 @@ uniform with the gridded field axis (see ``met_forcing_refactor.md`` Section
 """
 
 import datetime
+import re
 import warnings
 
 import numpy as np
@@ -119,6 +120,15 @@ HURDAT_SENTINELS = (-99.0, -999.0, -9999.0)
 
 # NCEP tcvitals uses -99/-999 in the same role.
 TCVITALS_SENTINELS = (-99.0, -999.0)
+
+
+# Default order in which agencies are consulted for IBTrACS intensity fields
+# when the `wmo_*` variable is missing and neither `wmo_agency` nor `usa_agency`
+# names a provider.  Shared by StormTrack.read_ibtracs and iter_ibtracs so the
+# two cannot drift apart.
+_IBTRACS_AGENCY_PREF = ('wmo', 'usa', 'tokyo', 'newdelhi', 'reunion', 'bom',
+                        'nadi', 'wellington', 'cma', 'hko', 'ds824', 'td9636',
+                        'td9635', 'neumann', 'mlc')
 
 
 def _sentinel_to_nan(value, sentinels):
@@ -372,13 +382,16 @@ class StormTrack(Track):
         return self
 
     @classmethod
-    def read_hurdat(cls, path, verbose=False):
-        r"""Read in HURDAT formatted storm file
+    def read_hurdat(cls, path, verbose=False, storm_id=None, name=None,
+                    year=None):
+        r"""Read a HURDAT2 formatted storm file.
 
-        This is the current version of HURDAT data available (HURDAT 2).  Note
-        that this assumes there is only one storm in the file (includes the
-        header information though).  Future features will be added that will allow for
-        a file to be read with multiple storms defined.
+        This is the current version of HURDAT data available (HURDAT 2).  The
+        archives NOAA/AOML distributes hold *every* storm in a basin in one file
+        (~2000 storms for the Atlantic, 1851-present), so pass a selector to pick
+        one; a file containing a single storm needs no selector.  Use
+        :func:`iter_hurdat` to walk every storm, or :func:`catalog_hurdat` for an
+        index of what a file contains.
 
         For more details on the HURDAT format and getting data see
 
@@ -387,84 +400,36 @@ class StormTrack(Track):
         :Input:
          - *path* (string) Path to the file to be read.
          - *verbose* (bool) Output more info regarding reading.
+         - *storm_id* (string) ATCF-style id to select, e.g. ``"AL092008"``.
+         - *name* (string) Storm name to select, e.g. ``"IKE"``
+           (case-insensitive).
+         - *year* (int) Season to select; combine with *name* when a name has
+           been reused across seasons.
 
         :Raises:
-         - *ValueError* If the method cannot find the name/year matching the
-           storm or they are not provided when *single_storm == False* then a
-           value error is risen.
+         - *ValueError* If no storm matches the selector, or if the file holds
+           more than one storm and no selector narrows it to exactly one.
         """
-        self = cls()
+        matches = [(header, lines) for (header, lines) in _hurdat_blocks(path)
+                   if _hurdat_selected(header, storm_id, name, year, None)]
 
-        with open(path, 'r') as hurdat_file:
-            # Extract header
-            data = [value.strip() for value in
-                    hurdat_file.readline().split(',')]
-            self.basin = data[0][:2]
-            self.name = data[1]
-            self.ID = data[2]
+        if not matches:
+            raise ValueError(
+                f"No storm in {path} matches "
+                f"storm_id={storm_id!r}, name={name!r}, year={year!r}.")
+        if len(matches) > 1:
+            found = ", ".join(f"{h['storm_id']} ({h['name']})"
+                              for h in [m[0] for m in matches[:5]])
+            raise ValueError(
+                f"{len(matches)} storms in {path} match "
+                f"storm_id={storm_id!r}, name={name!r}, year={year!r} "
+                f"(e.g. {found}). Narrow the selection, or use iter_hurdat() to "
+                f"read them all.")
 
-            # Store rest of data
-            data_block = hurdat_file.readlines()
+        header, lines = matches[0]
+        self = _track_from_hurdat_block(cls, header, lines, verbose=verbose)
 
-        num_lines = len(data_block)
-
-        # Parse data block
-        self.t = np.empty(num_lines, dtype="datetime64[s]")
-        self.event = np.empty(num_lines, dtype=str)
-        self.classification = np.empty(num_lines, dtype=str)
-        self.eye_location = np.empty((num_lines, 2))
-        self.max_wind_speed = np.empty(num_lines)
-        self.central_pressure = np.empty(num_lines)
-        self.max_wind_radius = np.empty(num_lines)
-        self.storm_radius = np.empty(num_lines)
-
-        for (i, line) in enumerate(data_block):
-            if len(line) == 0:
-                break
-            data = [value.strip() for value in line.split(",")]
-
-            # Create time from YYYYMMDD and HHMM fields
-            self.t[i] = np.datetime64(
-                f"{data[0][:4]}"
-                f"-{data[0][4:6]}"
-                f"-{data[0][6:8]}"
-                f"T{data[1][:2]}:{data[1][2:]}"
-            )
-
-            # If an event is occuring record it.  If landfall then use as an
-            # offset.   Note that if there are multiple landfalls the last one
-            # is used as the offset
-            if len(data[2].strip()) > 0:
-                self.event[i] = data[2].strip()
-                if self.event[i].upper() == "L":
-                    self.time_offset = self.t[i]
-
-            # Classification, note that this is not the category of the storm
-            self.classification[i] = data[3]
-
-            # Parse eye location
-            if data[4][-1] == "N":
-                self.eye_location[i, 1] = float(data[4][0:-1])
-            else:
-                self.eye_location[i, 1] = -float(data[4][0:-1])
-            if data[5][-1] == "E":
-                self.eye_location[i, 0] = float(data[5][0:-1])
-            else:
-                self.eye_location[i, 0] = -float(data[5][0:-1])
-
-            # Intensity information - radii are not included directly in this
-            # format and instead radii of winds above a threshold are included.
-            # HURDAT2 marks unknown wind as -99 and unknown pressure as -999;
-            # normalize before converting units, or the sentinel is scaled into a
-            # physical-looking value (-999 mbar -> -99900 Pa).
-            self.max_wind_speed[i] = units.convert(
-                _sentinel_to_nan(data[6], HURDAT_SENTINELS), 'knots', 'm/s')
-            self.central_pressure[i] = units.convert(
-                _sentinel_to_nan(data[7], HURDAT_SENTINELS), 'mbar', 'Pa')
-            self.max_wind_radius[i] = np.nan
-            self.storm_radius[i] = np.nan
-
-        # HURDAT2 never supplies RMW or ROCI, so warn once for the file rather
+        # HURDAT2 never supplies RMW or ROCI, so warn once for the storm rather
         # than once per track point.
         warnings.warn(missing_data_warning_str)
 
@@ -474,22 +439,8 @@ class StormTrack(Track):
         return self
 
     @classmethod
-    def read_ibtracs(cls, path, sid=None, storm_name=None, year=None, start_date=None,
-                     agency_pref=['wmo',
-                                  'usa',
-                                  'tokyo',
-                                  'newdelhi',
-                                  'reunion',
-                                  'bom',
-                                  'nadi',
-                                  'wellington',
-                                  'cma',
-                                  'hko',
-                                  'ds824',
-                                  'td9636',
-                                  'td9635',
-                                  'neumann',
-                                  'mlc']):
+    def read_ibtracs(cls, path, sid=None, storm_name=None, year=None,
+                     start_date=None, agency_pref=None):
         r"""Read in IBTrACS formatted storm file
 
         This reads in the netcdf-formatted IBTrACS v4 data. You must either pass
@@ -521,8 +472,6 @@ class StormTrack(Track):
          - *ValueError* If the method cannot find the matching storm then a
              value error is risen.
         """
-        self = cls()
-
         # imports that you don't need for other read functions
         try:
             import xarray as xr
@@ -535,176 +484,18 @@ class StormTrack(Track):
             raise ValueError(
                 'Cannot specify both *sid* and *storm_name* or *year*.')
 
+        if agency_pref is None:
+            agency_pref = list(_IBTRACS_AGENCY_PREF)
+
         with xr.open_dataset(path) as ds:
-
-            # match on sid
-            if sid is not None:
-                match = ds.sid == sid.encode()
-            # or match on storm_name and year
-            else:
-                storm_name = storm_name.upper()
-                # in case storm is unnamed
-                if storm_name.upper() in ['UNNAMED', 'NO-NAME']:
-                    storm_name = 'NOT_NAMED'
-                storm_match = (ds.name == storm_name.encode())
-                year_match = (ds.time.dt.year == year).any(dim='date_time')
-                match = storm_match & year_match
-            # Squeeze only the storm dimension: a bare squeeze() would also
-            # collapse date_time for a storm with a single observation.
-            ds = ds.sel(storm=match)
-            if ds.sizes.get('storm') == 1:
-                ds = ds.squeeze(dim='storm')
-
-            # occurs if we have 0 or >1 matching storms
-            if 'storm' in ds.sizes:
-                if ds.storm.shape[0] == 0:
-                    raise ValueError('Storm/year not found in provided file')
-                else:
-                    # see if a date was provided for multiple unnamed storms
-                    assert start_date is not None, ValueError(
-                        'Multiple storms identified and no start_date specified.')
-
-                    start_times = ds.time.isel(date_time=0)
-                    start_date = np.datetime64(start_date)
-
-                    # find storm with start date closest to provided
-                    storm_ix = abs(start_times - start_date).argmin()
-                    ds = ds.isel(storm=storm_ix)
-                    assert 'storm' not in ds.sizes
-
-            # cut down dataset to only non-null times
-            valid_t = ds.time.notnull()
-            if valid_t.sum() == 0:
-                raise ValueError('No valid wind speeds found for this storm.')
-            ds = ds.sel(date_time=valid_t)
-
-            # list of the agencies that correspond to 'usa_*' variables
-            usa_agencies = [b'atcf', b'hurdat_atl', b'hurdat_epa', b'jtwc_ep',
-                            b'nhc_working_bt', b'tcvightals', b'tcvitals']
-
-            # Create mapping from wmo_ or usa_agency
-            # to the appropriate variable
-            agency_map = {b'': agency_pref.index('wmo')}
-            # account for multiple usa agencies
-            for a in usa_agencies:
-                agency_map[a] = agency_pref.index('usa')
-            # map all other agencies to themselves
-            for i in [a for a in agency_pref if a not in ['wmo', 'usa']]:
-                agency_map[i.encode('utf-8')] = agency_pref.index(i)
-
-            # fill in usa as provider if usa_agency is
-            # non-null when wmo_agency is null
-            provider = ds.wmo_agency.where(ds.wmo_agency != b'', ds.usa_agency)
-
-            # get index into from agency that is wmo_provider
-            def map_val_to_ix(a):
-                def func(x): return agency_map[x]
-                return xr.apply_ufunc(func, a, vectorize=True)
-            pref_agency_ix = map_val_to_ix(provider)
-
-            # GET MAX WIND SPEED and PRES
-            pref_vals = {}
-            for v in ['wind', 'pres']:
-                all_vals = ds[['{}_{}'.format(i, v) for i in agency_pref]].to_array(
-                    dim='agency')
-
-                # get wmo value
-                val_pref = ds['wmo_'+v]
-
-                # fill this value in as a second-best
-                pref_2 = all_vals.isel(agency=pref_agency_ix)
-                val_pref = val_pref.fillna(pref_2)
-
-                # now use the agency_pref order to fill in
-                # any remaining values as third best
-                best_ix = all_vals.notnull().argmax(dim='agency')
-                pref_3 = all_vals.isel(agency=best_ix)
-                val_pref = val_pref.fillna(pref_3)
-
-                # add to dict
-                pref_vals[v] = val_pref
-
-            # THESE CANNOT BE MISSING SO DROP
-            # IF EITHER MISSING
-            valid = pref_vals['wind'].notnull() & pref_vals['pres'].notnull()
-            if not valid.any():
-                raise NoDataError(missing_necessary_data_warning_str)
-            ds = ds.sel(date_time=valid)
-            for i in ['wind', 'pres']:
-                pref_vals[i] = pref_vals[i].sel(date_time=valid)
-
-            # GET RMW and ROCI
-            # (these can be missing)
-            for r in ['rmw', 'roci']:
-                order = ['{}_{}'.format(i, r) for i in agency_pref if
-                         '{}_{}'.format(i, r) in ds.data_vars.keys()]
-                vals = ds[order].to_array(dim='agency')
-                best_ix = vals.notnull().argmax(dim='agency')
-                val_pref = vals.isel(agency=best_ix)
-                pref_vals[r] = val_pref
-
-            # CONVERT TO GEOCLAW FORMAT
-
-            # assign basin to be the basin where track originates
-            # in case track moves across basins
-            self.basin = ds.basin.values[0].astype(str)
-            self.name = ds.name.astype(str).item()
-            self.ID = ds.sid.astype(str).item()
-
-            # Times as a plain datetime64 ndarray, matching every other reader.
-            # Leaving this as a DataArray leaks xarray into consumers -- indexing
-            # it yields 0-d DataArrays, which is what makes
-            # fill_rad_w_other_source's interp fail.  Truncating to seconds also
-            # drops the sub-second float roundoff IBTrACS carries in its times
-            # (e.g. ...T06:00:00.000039936).
-            self.t = ds.time.values.astype('datetime64[s]')
-
-            # events
-            self.event = ds.usa_record.values.astype(str)
-
-            # time offset
-            if (self.event == 'L').any():
-                # if landfall, use last landfall
-                self.time_offset = self.t[self.event == 'L'][-1]
-            else:
-                # if no landfall, use last time of storm
-                self.time_offset = self.t[-1]
-
-            # Classification, note that this is not the category of the storm.
-            # Decode from the netCDF's bytes (b'TD') to str so it compares
-            # against ordinary string literals.
-            self.classification = ds.usa_status.values.astype(str)
-            self.eye_location = np.array([ds.lon, ds.lat]).T
-
-            # Intensity information - for now, including only common, basic intensity
-            # info.
-            # TODO: add more detailed info for storms that have it
-            #
-            # xarray already carries missing values as NaN, which is the
-            # in-memory contract, so these are converted straight through; the
-            # former .where(..., -1) wrappers replaced NaN with a sentinel that
-            # write_geoclaw's NaN-based fill/skip logic could not see.
-            self.max_wind_speed = units.convert(
-                pref_vals['wind'], 'knots', 'm/s').values
-            self.central_pressure = units.convert(
-                pref_vals['pres'], 'mbar', 'Pa').values
-            self.max_wind_radius = units.convert(
-                pref_vals['rmw'], 'nmi', 'm').values
-            self.storm_radius = units.convert(
-                pref_vals['roci'], 'nmi', 'm').values
-
-            # warn if you have any missing vals for RMW or ROCI.  Note this is
-            # deliberately `.any()`: the old `.max() == -1` test only fired when
-            # *every* value was missing, so a partially-observed track warned
-            # nothing and then silently lost rows at write time.
-            if (np.isnan(self.max_wind_radius).any()
-                    or np.isnan(self.storm_radius).any()):
-                warnings.warn(missing_data_warning_str)
+            ds = _select_ibtracs_storm(ds, sid, storm_name, year, start_date)
+            self = _track_from_ibtracs(cls, ds, agency_pref)
 
         self.file_paths.append(path)
         self.file_format = "ibtracs"
 
         return self
+
 
     @classmethod
     def read_jma(cls, path, verbose=False):
@@ -1101,6 +892,574 @@ class StormTrack(Track):
             return category, category_name
         else:
             return category
+
+
+def _select_ibtracs_storm(ds, sid=None, storm_name=None, year=None,
+                          start_date=None):
+    r"""Narrow an IBTrACS dataset to the one storm requested.
+
+    Returns the dataset with the ``storm`` dimension removed.
+    """
+    # match on sid
+    if sid is not None:
+        match = ds.sid == sid.encode()
+    # or match on storm_name and year
+    else:
+        storm_name = storm_name.upper()
+        # in case storm is unnamed
+        if storm_name.upper() in ['UNNAMED', 'NO-NAME']:
+            storm_name = 'NOT_NAMED'
+        storm_match = (ds.name == storm_name.encode())
+        year_match = (ds.time.dt.year == year).any(dim='date_time')
+        match = storm_match & year_match
+    # Squeeze only the storm dimension: a bare squeeze() would also
+    # collapse date_time for a storm with a single observation.
+    ds = ds.sel(storm=match)
+    if ds.sizes.get('storm') == 1:
+        ds = ds.squeeze(dim='storm')
+
+    # occurs if we have 0 or >1 matching storms
+    if 'storm' in ds.sizes:
+        if ds.storm.shape[0] == 0:
+            raise ValueError('Storm/year not found in provided file')
+        else:
+            # see if a date was provided for multiple unnamed storms
+            assert start_date is not None, ValueError(
+                'Multiple storms identified and no start_date specified.')
+
+            start_times = ds.time.isel(date_time=0)
+            start_date = np.datetime64(start_date)
+
+            # find storm with start date closest to provided
+            storm_ix = abs(start_times - start_date).argmin()
+            ds = ds.isel(storm=storm_ix)
+            assert 'storm' not in ds.sizes
+
+    return ds
+
+
+def _track_from_ibtracs(cls, ds, agency_pref):
+    r"""Build a track from a single-storm IBTrACS dataset (no ``storm`` dim)."""
+    import xarray as xr
+
+    self = cls()
+
+    # cut down dataset to only non-null times
+    valid_t = ds.time.notnull()
+    if valid_t.sum() == 0:
+        raise ValueError('No valid wind speeds found for this storm.')
+    ds = ds.sel(date_time=valid_t)
+
+    # list of the agencies that correspond to 'usa_*' variables
+    usa_agencies = [b'atcf', b'hurdat_atl', b'hurdat_epa', b'jtwc_ep',
+                    b'nhc_working_bt', b'tcvightals', b'tcvitals']
+
+    # Create mapping from wmo_ or usa_agency
+    # to the appropriate variable
+    agency_map = {b'': agency_pref.index('wmo')}
+    # account for multiple usa agencies
+    for a in usa_agencies:
+        agency_map[a] = agency_pref.index('usa')
+    # map all other agencies to themselves
+    for i in [a for a in agency_pref if a not in ['wmo', 'usa']]:
+        agency_map[i.encode('utf-8')] = agency_pref.index(i)
+
+    # fill in usa as provider if usa_agency is
+    # non-null when wmo_agency is null
+    provider = ds.wmo_agency.where(ds.wmo_agency != b'', ds.usa_agency)
+
+    # get index into from agency that is wmo_provider
+    def map_val_to_ix(a):
+        def func(x): return agency_map[x]
+        return xr.apply_ufunc(func, a, vectorize=True)
+    pref_agency_ix = map_val_to_ix(provider)
+
+    # GET MAX WIND SPEED and PRES
+    pref_vals = {}
+    for v in ['wind', 'pres']:
+        all_vals = ds[['{}_{}'.format(i, v) for i in agency_pref]].to_array(
+            dim='agency')
+
+        # get wmo value
+        val_pref = ds['wmo_'+v]
+
+        # fill this value in as a second-best
+        pref_2 = all_vals.isel(agency=pref_agency_ix)
+        val_pref = val_pref.fillna(pref_2)
+
+        # now use the agency_pref order to fill in
+        # any remaining values as third best
+        best_ix = all_vals.notnull().argmax(dim='agency')
+        pref_3 = all_vals.isel(agency=best_ix)
+        val_pref = val_pref.fillna(pref_3)
+
+        # add to dict
+        pref_vals[v] = val_pref
+
+    # THESE CANNOT BE MISSING SO DROP
+    # IF EITHER MISSING
+    valid = pref_vals['wind'].notnull() & pref_vals['pres'].notnull()
+    if not valid.any():
+        raise NoDataError(missing_necessary_data_warning_str)
+    ds = ds.sel(date_time=valid)
+    for i in ['wind', 'pres']:
+        pref_vals[i] = pref_vals[i].sel(date_time=valid)
+
+    # GET RMW and ROCI
+    # (these can be missing)
+    for r in ['rmw', 'roci']:
+        order = ['{}_{}'.format(i, r) for i in agency_pref if
+                 '{}_{}'.format(i, r) in ds.data_vars.keys()]
+        vals = ds[order].to_array(dim='agency')
+        best_ix = vals.notnull().argmax(dim='agency')
+        val_pref = vals.isel(agency=best_ix)
+        pref_vals[r] = val_pref
+
+    # CONVERT TO GEOCLAW FORMAT
+
+    # assign basin to be the basin where track originates
+    # in case track moves across basins
+    self.basin = ds.basin.values[0].astype(str)
+    self.name = ds.name.astype(str).item()
+    self.ID = ds.sid.astype(str).item()
+
+    # Times as a plain datetime64 ndarray, matching every other reader.
+    # Leaving this as a DataArray leaks xarray into consumers -- indexing
+    # it yields 0-d DataArrays, which is what makes
+    # fill_rad_w_other_source's interp fail.  Truncating to seconds also
+    # drops the sub-second float roundoff IBTrACS carries in its times
+    # (e.g. ...T06:00:00.000039936).
+    self.t = ds.time.values.astype('datetime64[s]')
+
+    # events
+    self.event = ds.usa_record.values.astype(str)
+
+    # time offset
+    if (self.event == 'L').any():
+        # if landfall, use last landfall
+        self.time_offset = self.t[self.event == 'L'][-1]
+    else:
+        # if no landfall, use last time of storm
+        self.time_offset = self.t[-1]
+
+    # Classification, note that this is not the category of the storm.
+    # Decode from the netCDF's bytes (b'TD') to str so it compares
+    # against ordinary string literals.
+    self.classification = ds.usa_status.values.astype(str)
+    self.eye_location = np.array([ds.lon, ds.lat]).T
+
+    # Intensity information - for now, including only common, basic intensity
+    # info.
+    # TODO: add more detailed info for storms that have it
+    #
+    # xarray already carries missing values as NaN, which is the
+    # in-memory contract, so these are converted straight through; the
+    # former .where(..., -1) wrappers replaced NaN with a sentinel that
+    # write_geoclaw's NaN-based fill/skip logic could not see.
+    self.max_wind_speed = units.convert(
+        pref_vals['wind'], 'knots', 'm/s').values
+    self.central_pressure = units.convert(
+        pref_vals['pres'], 'mbar', 'Pa').values
+    self.max_wind_radius = units.convert(
+        pref_vals['rmw'], 'nmi', 'm').values
+    self.storm_radius = units.convert(
+        pref_vals['roci'], 'nmi', 'm').values
+
+    # warn if you have any missing vals for RMW or ROCI.  Note this is
+    # deliberately `.any()`: the old `.max() == -1` test only fired when
+    # *every* value was missing, so a partially-observed track warned
+    # nothing and then silently lost rows at write time.
+    if (np.isnan(self.max_wind_radius).any()
+            or np.isnan(self.storm_radius).any()):
+        warnings.warn(missing_data_warning_str)
+
+    return self
+
+
+# =============================================================================
+# Multi-storm archive ingestion
+#
+# Both HURDAT2 and IBTrACS distribute one file per basin holding every storm on
+# record, so driving an ensemble means walking a file rather than opening one per
+# storm.  These are module-level generators rather than a collection class: what
+# a driver needs beyond iteration is an *index* (``catalog_*``, a DataFrame), not
+# a container, and a rival container object would fork the one merged object
+# model.  Each ``read_*`` classmethod and its ``iter_*`` counterpart share a
+# single parser, so there is exactly one parsing path to verify.
+# =============================================================================
+
+# A HURDAT2 storm header is "<basin><number><year>, <name>, <count>,", where
+# count is the number of best-track records that follow.  That declared count is
+# free self-validation: it must match what we parse, and the counts must sum to
+# the number of data lines in the file.
+_HURDAT_HEADER_RE = re.compile(r"^([A-Z]{2})(\d{2})(\d{4})\s*,\s*([^,]*?)\s*,"
+                               r"\s*(\d+)\s*,")
+
+
+def _hurdat_blocks(path):
+    r"""Yield ``(header, data_lines)`` for each storm in a HURDAT2 file.
+
+    *header* is a dict with ``storm_id``, ``basin_code``, ``number``, ``year``,
+    ``name`` and ``num_records``.  Each block is framed by its declared record
+    count, and a mismatch raises with the offending line number rather than
+    silently absorbing the next storm's header (which is what the single-storm
+    reader used to do -- it fed ``"AL092008"`` to ``np.datetime64``).
+    """
+    with open(path, "r") as hurdat_file:
+        lines = [line.rstrip("\n") for line in hurdat_file]
+
+    index = 0
+    while index < len(lines):
+        if not lines[index].strip():
+            index += 1
+            continue
+
+        match = _HURDAT_HEADER_RE.match(lines[index])
+        if match is None:
+            raise ValueError(
+                f"{path}:{index + 1}: expected a HURDAT2 storm header, got "
+                f"{lines[index][:60]!r}")
+
+        basin_code, number, year, name, declared = match.groups()
+        header = {"storm_id": f"{basin_code}{number}{year}",
+                  "basin_code": basin_code,
+                  "number": int(number),
+                  "year": int(year),
+                  "name": name.strip(),
+                  "num_records": int(declared)}
+
+        start = index + 1
+        block = [line for line in lines[start:start + header["num_records"]]
+                 if line.strip()]
+        if len(block) != header["num_records"]:
+            raise ValueError(
+                f"{path}:{start + 1}: storm {header['storm_id']} declares "
+                f"{header['num_records']} records but {len(block)} were found.")
+
+        yield header, block
+        index = start + header["num_records"]
+
+
+def _hurdat_selected(header, storm_id, name, year, basins):
+    r"""Whether a HURDAT2 block header matches the given filters."""
+    if storm_id is not None and header["storm_id"].upper() != storm_id.upper():
+        return False
+    if name is not None and header["name"].upper() != name.upper():
+        return False
+    if year is not None:
+        years = (year,) if isinstance(year, int) else tuple(year)
+        if header["year"] not in years:
+            return False
+    if basins is not None:
+        codes = ((basins,) if isinstance(basins, str) else tuple(basins))
+        if header["basin_code"].upper() not in {b.upper() for b in codes}:
+            return False
+    return True
+
+
+def _track_from_hurdat_block(cls, header, block, verbose=False):
+    r"""Build a :class:`StormTrack` from one HURDAT2 header plus its records."""
+    self = cls()
+    self.basin = ATCF_basins.get(header["basin_code"], header["basin_code"])
+    self.name = header["name"]
+    # ATCF-style id ("AL092008").  This used to be the header's record count.
+    self.ID = header["storm_id"]
+
+    num_lines = len(block)
+    self.t = np.empty(num_lines, dtype="datetime64[s]")
+    self.event = np.empty(num_lines, dtype="U2")
+    self.classification = np.empty(num_lines, dtype="U4")
+    self.eye_location = np.empty((num_lines, 2))
+    self.max_wind_speed = np.empty(num_lines)
+    self.central_pressure = np.empty(num_lines)
+    self.max_wind_radius = np.empty(num_lines)
+    self.storm_radius = np.empty(num_lines)
+
+    for (i, line) in enumerate(block):
+        data = [value.strip() for value in line.split(",")]
+
+        # Create time from YYYYMMDD and HHMM fields
+        self.t[i] = np.datetime64(
+            f"{data[0][:4]}"
+            f"-{data[0][4:6]}"
+            f"-{data[0][6:8]}"
+            f"T{data[1][:2]}:{data[1][2:]}"
+        )
+
+        # If an event is occuring record it.  If landfall then use as an
+        # offset.   Note that if there are multiple landfalls the last one
+        # is used as the offset
+        if len(data[2].strip()) > 0:
+            self.event[i] = data[2].strip()
+            if self.event[i].upper() == "L":
+                self.time_offset = self.t[i]
+
+        # Classification, note that this is not the category of the storm
+        self.classification[i] = data[3]
+
+        # Parse eye location
+        if data[4][-1] == "N":
+            self.eye_location[i, 1] = float(data[4][0:-1])
+        else:
+            self.eye_location[i, 1] = -float(data[4][0:-1])
+        if data[5][-1] == "E":
+            self.eye_location[i, 0] = float(data[5][0:-1])
+        else:
+            self.eye_location[i, 0] = -float(data[5][0:-1])
+
+        # Intensity information - radii are not included directly in this
+        # format and instead radii of winds above a threshold are included.
+        # HURDAT2 marks unknown wind as -99 and unknown pressure as -999;
+        # normalize before converting units, or the sentinel is scaled into a
+        # physical-looking value (-999 mbar -> -99900 Pa).
+        self.max_wind_speed[i] = units.convert(
+            _sentinel_to_nan(data[6], HURDAT_SENTINELS), 'knots', 'm/s')
+        self.central_pressure[i] = units.convert(
+            _sentinel_to_nan(data[7], HURDAT_SENTINELS), 'mbar', 'Pa')
+        self.max_wind_radius[i] = np.nan
+        self.storm_radius[i] = np.nan
+
+    if verbose:
+        print(f"  {self.ID} {self.name}: {num_lines} records "
+              f"{self.t[0]} -> {self.t[-1]}")
+    return self
+
+
+def iter_hurdat(path, storm_ids=None, names=None, years=None, basins=None,
+                verbose=False):
+    r"""Iterate the storms in a HURDAT2 file as :class:`StormTrack` objects.
+
+    One pass over the file, yielding in file order.  Every filter is optional and
+    they combine; ``years`` accepts an int or any iterable of ints, so a season
+    range is ``years=range(1980, 2026)``.
+
+    :Input:
+     - *path* (string) Path to a HURDAT2 file (one or many storms).
+     - *storm_ids* (iterable) ATCF-style ids to keep, e.g. ``["AL092008"]``.
+     - *names* (iterable) Storm names to keep (case-insensitive).
+     - *years* (int or iterable) Seasons to keep.
+     - *basins* (string or iterable) Two-letter basin codes to keep.
+     - *verbose* (bool) Print each storm as it is read.
+
+    :Output:
+     - Generator of :class:`StormTrack`, each with ``file_format = "hurdat"``.
+
+    Missing RMW/ROCI is warned about once for the whole iteration rather than
+    once per storm; HURDAT2 never carries either.
+    """
+    wanted_ids = (None if storm_ids is None
+                  else {str(i).upper() for i in storm_ids})
+    wanted_names = (None if names is None
+                    else {str(n).upper() for n in names})
+
+    warned = False
+    for header, block in _hurdat_blocks(path):
+        if wanted_ids is not None and header["storm_id"].upper() not in wanted_ids:
+            continue
+        if wanted_names is not None and header["name"].upper() not in wanted_names:
+            continue
+        if not _hurdat_selected(header, None, None, years, basins):
+            continue
+
+        track = _track_from_hurdat_block(StormTrack, header, block,
+                                         verbose=verbose)
+        if not warned:
+            warnings.warn(missing_data_warning_str)
+            warned = True
+        track.file_paths.append(path)
+        track.file_format = "hurdat"
+        yield track
+
+
+def _ibtracs_seasons(ds):
+    r"""Season (year) per storm, from ``season`` if present else from ``time``.
+
+    The variable is present in the distributed basin files but absent from
+    trimmed subsets, so fall back rather than requiring it.
+    """
+    if "season" in ds.variables:
+        return ds["season"].values.astype(int)
+    return ds.time.isel(date_time=0).dt.year.values.astype(int)
+
+
+def _ibtracs_storm_mask(ds, basin=None, years=None, sids=None, names=None):
+    r"""Boolean mask over the ``storm`` dimension for the requested filters."""
+    mask = np.ones(ds.sizes["storm"], dtype=bool)
+
+    if basin is not None:
+        codes = ((basin,) if isinstance(basin, str) else tuple(basin))
+        wanted = {b.upper().encode() for b in codes}
+        # basin varies along a track; select on where the storm originates,
+        # matching what the reader stores as `basin`.
+        first = ds.basin.isel(date_time=0).values
+        mask &= np.array([b.upper() in wanted for b in first])
+
+    if years is not None:
+        wanted_years = ([int(years)] if isinstance(years, (int, np.integer))
+                        else [int(y) for y in years])
+        mask &= np.isin(_ibtracs_seasons(ds), wanted_years)
+
+    if sids is not None:
+        wanted_sids = {str(s).upper().encode() for s in sids}
+        mask &= np.array([s.upper() in wanted_sids for s in ds.sid.values])
+
+    if names is not None:
+        wanted_names = {str(n).upper().encode() for n in names}
+        mask &= np.array([n.upper() in wanted_names for n in ds.name.values])
+
+    return mask
+
+
+def iter_ibtracs(path, basin=None, years=None, sids=None, names=None,
+                 agency_pref=None, skip_invalid=True, verbose=False):
+    r"""Iterate storms in an IBTrACS v4 netCDF file as :class:`StormTrack`s.
+
+    Opens the file once and slices per storm, rather than re-scanning it for
+    every :meth:`StormTrack.read_ibtracs` call.
+
+    :Input:
+     - *path* (string) Path to an IBTrACS v4 netCDF file.
+     - *basin* (string or iterable) Two-letter basin code(s) of storm *origin*,
+       e.g. ``"NA"``; matches what the reader stores as ``basin``.
+     - *years* (int or iterable) Seasons to keep, e.g. ``range(1980, 2026)``.
+     - *sids* (iterable) IBTrACS storm ids to keep.
+     - *names* (iterable) Storm names to keep (case-insensitive).
+     - *agency_pref* (list) As :meth:`StormTrack.read_ibtracs`.
+     - *skip_invalid* (bool) Skip storms with no time at which both a wind and a
+       pressure were reported, instead of raising.  Load-bearing over a whole
+       basin: such storms exist, and one of them should not abort the sweep.
+     - *verbose* (bool) Report each storm as it is read.
+
+    :Output:
+     - Generator of :class:`StormTrack`, in file order.
+    """
+    try:
+        import xarray as xr
+    except ImportError as e:
+        print("IBTrACS currently requires xarray to work.")
+        raise e
+
+    if agency_pref is None:
+        agency_pref = list(_IBTRACS_AGENCY_PREF)
+
+    n_skipped = 0
+    with xr.open_dataset(path) as ds:
+        if "storm" not in ds.sizes:
+            raise ValueError(
+                f"{path} has no 'storm' dimension; it does not look like an "
+                "IBTrACS basin file.")
+
+        mask = _ibtracs_storm_mask(ds, basin=basin, years=years, sids=sids,
+                                   names=names)
+        indices = np.nonzero(mask)[0]
+        if verbose:
+            print(f"{len(indices)} of {ds.sizes['storm']} storms selected "
+                  f"from {path}")
+
+        for index in indices:
+            one = ds.isel(storm=int(index))
+            sid = one.sid.astype(str).item()
+            try:
+                with warnings.catch_warnings():
+                    # Missing RMW/ROCI is the norm across a whole basin; warn
+                    # once for the sweep rather than once per storm.
+                    warnings.simplefilter("ignore", UserWarning)
+                    track = _track_from_ibtracs(StormTrack, one, agency_pref)
+            except (NoDataError, ValueError) as error:
+                if not skip_invalid:
+                    raise
+                n_skipped += 1
+                if verbose:
+                    print(f"  skipped {sid}: {error}")
+                continue
+
+            track.file_paths.append(path)
+            track.file_format = "ibtracs"
+            if verbose:
+                print(f"  {track.ID} {track.name}: {len(track.t)} records "
+                      f"{track.t[0]} -> {track.t[-1]}")
+            yield track
+
+    if n_skipped:
+        warnings.warn(f"Skipped {n_skipped} IBTrACS storm(s) with no time "
+                      "having both a wind and a pressure observation.")
+
+
+def catalog_ibtracs(path, basin=None, years=None):
+    r"""Index of the storms in an IBTrACS file, as a :class:`pandas.DataFrame`.
+
+    Columns: ``sid``, ``name``, ``season``, ``basin``, ``num_records``,
+    ``t_start``, ``t_end``, ``max_wind`` (m/s, from ``wmo_wind`` where present).
+    Reads summary variables only, so it is far cheaper than building every
+    track -- use it to decide what to run before running it.
+    """
+    try:
+        import xarray as xr
+    except ImportError as e:
+        print("IBTrACS currently requires xarray to work.")
+        raise e
+
+    with xr.open_dataset(path) as ds:
+        mask = _ibtracs_storm_mask(ds, basin=basin, years=years)
+        indices = np.nonzero(mask)[0]
+        seasons = _ibtracs_seasons(ds)
+        times = ds.time.values
+        origin_basin = ds.basin.isel(date_time=0).values
+
+        rows = []
+        for index in indices:
+            valid = ~np.isnat(times[index])
+            if not valid.any():
+                continue
+            track_times = times[index][valid]
+            wind = ds.wmo_wind.isel(storm=int(index)).values
+            rows.append({
+                "sid": ds.sid.values[index].astype(str),
+                "name": ds.name.values[index].astype(str),
+                "season": int(seasons[index]),
+                "basin": origin_basin[index].astype(str),
+                "num_records": int(valid.sum()),
+                "t_start": track_times[0].astype("datetime64[s]"),
+                "t_end": track_times[-1].astype("datetime64[s]"),
+                "max_wind": (float(units.convert(np.nanmax(wind), 'knots', 'm/s'))
+                             if np.isfinite(wind).any() else np.nan),
+            })
+
+    return pd.DataFrame(rows, columns=["sid", "name", "season", "basin",
+                                       "num_records", "t_start", "t_end",
+                                       "max_wind"])
+
+
+
+def catalog_hurdat(path, years=None, basins=None):
+    r"""Index of the storms in a HURDAT2 file, as a :class:`pandas.DataFrame`.
+
+    Columns: ``storm_id``, ``name``, ``year``, ``basin``, ``num_records``,
+    ``t_start``, ``t_end``.  Reads only each storm's first and last record, so it
+    is much cheaper than building every track -- use it to decide what to run
+    before running it.
+    """
+    rows = []
+    for header, block in _hurdat_blocks(path):
+        if not _hurdat_selected(header, None, None, years, basins):
+            continue
+
+        def _time(line):
+            fields = [value.strip() for value in line.split(",")]
+            return np.datetime64(f"{fields[0][:4]}-{fields[0][4:6]}"
+                                 f"-{fields[0][6:8]}T{fields[1][:2]}"
+                                 f":{fields[1][2:]}")
+
+        rows.append({"storm_id": header["storm_id"],
+                     "name": header["name"],
+                     "year": header["year"],
+                     "basin": ATCF_basins.get(header["basin_code"],
+                                              header["basin_code"]),
+                     "num_records": header["num_records"],
+                     "t_start": _time(block[0]),
+                     "t_end": _time(block[-1])})
+    return pd.DataFrame(rows, columns=["storm_id", "name", "year", "basin",
+                                       "num_records", "t_start", "t_end"])
 
 
 # =============================================================================

--- a/tests/data/storm/characterization/read_hurdat.json
+++ b/tests/data/storm/characterization/read_hurdat.json
@@ -1,6 +1,6 @@
 {
-  "ID": "06",
-  "basin": "AL",
+  "ID": "AL082008",
+  "basin": "Atlantic",
   "central_pressure": [
     100600.0,
     100300.0,
@@ -10,12 +10,12 @@
     100200.0
   ],
   "classification": [
-    "L",
-    "L",
-    "L",
-    "L",
-    "L",
-    "L"
+    "LO",
+    "LO",
+    "LO",
+    "LO",
+    "LO",
+    "LO"
   ],
   "crop_extent": null,
   "event": [

--- a/tests/test_met_objects.py
+++ b/tests/test_met_objects.py
@@ -801,3 +801,324 @@ def test_gridded_to_owi(tmp_path):
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))
+
+
+# ---------------------------------------------------------------------------
+# Multi-storm archive ingestion
+#
+# Both HURDAT2 and IBTrACS ship one file per basin holding every storm on
+# record.  The `iter_*` generators and the `read_*` classmethods share a single
+# parser, so the load-bearing check is that the two paths produce identical
+# objects -- not two independent goldens that could drift apart.
+# ---------------------------------------------------------------------------
+
+def _parsed_state(track):
+    """Canonical text of a track's state, excluding provenance.
+
+    Compared as serialized text rather than as a dict, because the state
+    contains NaN and ``nan != nan`` makes dict equality fail spuriously -- the
+    same reason the characterization tests compare golden *text*.
+    ``file_paths`` is dropped: it records where the object came from, which
+    legitimately differs between a bulk walk and a single-storm read, while
+    everything else is the parsed track and must match exactly.
+    """
+    from test_storm_characterization import _storm_state, _dumps
+    state = _storm_state(track)
+    state.pop("file_paths", None)
+    return _dumps(state)
+
+
+def _two_storm_hurdat(tmp_path):
+    """A two-storm HURDAT2 file, relabeled from the bundled single-storm one."""
+    original = _storm_input_path("hurdat").read_text().rstrip("\n").split("\n")
+    header, records = original[0], original[1:]
+
+    # Re-frame with an accurate declared record count, then a second storm with
+    # a different id and name.
+    first = f"AL082008,              IKE,{len(records):>4},"
+    second = f"AL102008,             JOSE,{len(records):>4},"
+    path = tmp_path / "two_storms.txt"
+    path.write_text("\n".join([first] + records + [second] + records) + "\n")
+    assert header  # the bundled fixture really does start with a header
+    return path
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_hurdat_declared_record_count_is_enforced(tmp_path):
+    """A HURDAT2 header declares its record count; a mismatch must be caught.
+
+    This is the framing invariant the format hands us for free.  Without it the
+    single-storm reader walked into the *next* storm's header and fed
+    ``"AL092008"`` to ``np.datetime64``.
+    """
+    path = _two_storm_hurdat(tmp_path)
+    lines = path.read_text().split("\n")
+
+    # Truncate the first storm's declared count by one.
+    from clawpack.geoclaw.met.track import _hurdat_blocks
+    blocks = list(_hurdat_blocks(path))
+    assert len(blocks) == 2
+    assert all(len(records) == header["num_records"]
+               for header, records in blocks)
+    total = sum(header["num_records"] for header, _ in blocks)
+    data_lines = sum(1 for line in lines
+                     if line[:8].isdigit())
+    assert total == data_lines, "declared counts must sum to the data lines"
+
+    # A header claiming more records than follow is an error, not a silent read
+    # into the next storm.
+    lines[0] = lines[0].replace(f"{len(blocks[0][1]):>4},", "  99,")
+    bad = tmp_path / "bad_count.txt"
+    bad.write_text("\n".join(lines))
+    with pytest.raises(ValueError, match="declares"):
+        list(_hurdat_blocks(bad))
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_iter_hurdat_matches_read_hurdat(tmp_path):
+    """Bulk and single-storm HURDAT2 reads produce identical objects."""
+    from clawpack.geoclaw.met.track import iter_hurdat
+
+    path = _two_storm_hurdat(tmp_path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        tracks = list(iter_hurdat(path))
+        selected = StormTrack.read_hurdat(path, storm_id="AL102008")
+
+    assert [t.ID for t in tracks] == ["AL082008", "AL102008"]
+    assert [t.name for t in tracks] == ["IKE", "JOSE"]
+    assert _parsed_state(tracks[1]) == _parsed_state(selected)
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_read_hurdat_requires_a_selector_for_multi_storm_files(tmp_path):
+    """Ambiguity is an error naming the candidates, not an arbitrary pick."""
+    path = _two_storm_hurdat(tmp_path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        with pytest.raises(ValueError, match="2 storms"):
+            StormTrack.read_hurdat(path)
+        with pytest.raises(ValueError, match="No storm"):
+            StormTrack.read_hurdat(path, name="NOSUCHSTORM")
+        # A single-storm file still needs no selector.
+        single = StormTrack.read_hurdat(_storm_input_path("hurdat"))
+        assert single.ID == "AL082008"
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_iter_hurdat_filters(tmp_path):
+    """Filters combine, and years accepts an int or an iterable."""
+    from clawpack.geoclaw.met.track import iter_hurdat, catalog_hurdat
+
+    path = _two_storm_hurdat(tmp_path)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert len(list(iter_hurdat(path, names=["JOSE"]))) == 1
+        assert len(list(iter_hurdat(path, years=2008))) == 2
+        assert len(list(iter_hurdat(path, years=range(2000, 2005)))) == 0
+        assert len(list(iter_hurdat(path, basins="AL"))) == 2
+        assert len(list(iter_hurdat(path, basins="EP"))) == 0
+
+    catalog = catalog_hurdat(path)
+    assert list(catalog.storm_id) == ["AL082008", "AL102008"]
+    assert set(catalog.basin) == {"Atlantic"}
+    assert (catalog.t_start <= catalog.t_end).all()
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_iter_ibtracs_matches_read_ibtracs(tmp_path):
+    """Bulk and single-storm IBTrACS reads produce identical objects."""
+    xr = pytest.importorskip("xarray")
+    from clawpack.geoclaw.met.track import iter_ibtracs
+
+    path = _storm_input_path("ibtracs")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        bulk = list(iter_ibtracs(path, agency_pref=["wmo", "usa"]))
+        single = StormTrack.read_ibtracs(path, **_IBTRACS_KWARGS)
+
+    assert len(bulk) == 1
+    assert _parsed_state(bulk[0]) == _parsed_state(single)
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_iter_ibtracs_over_multiple_storms(tmp_path):
+    """Two storms in one file are read independently, with no cross-contamination.
+
+    The bundled fixture is a stripped single-storm slice, so a second storm is
+    synthesized by relabeling a copy.  Note this cannot exercise real
+    heterogeneity (differing agencies, basins, valid ranges) -- only the
+    remote-marked test over a real basin file does that.
+    """
+    xr = pytest.importorskip("xarray")
+    from clawpack.geoclaw.met.track import iter_ibtracs, catalog_ibtracs
+
+    with xr.open_dataset(_storm_input_path("ibtracs")) as ds:
+        second = ds.copy(deep=True)
+        second["sid"] = second.sid.copy(data=[b"2008245N17999"])
+        second["name"] = second.name.copy(data=[b"NOTIKE"])
+        combined = xr.concat([ds, second], dim="storm")
+        path = tmp_path / "two_storms.nc"
+        combined.to_netcdf(path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        tracks = list(iter_ibtracs(path, agency_pref=["wmo", "usa"]))
+
+    assert [t.ID for t in tracks] == ["2008245N17323", "2008245N17999"]
+    assert [t.name for t in tracks] == ["IKE", "NOTIKE"]
+    # Each track's times stay inside its own record -- no bleed between storms.
+    for track in tracks:
+        assert len(track.t) == len(tracks[0].t)
+        assert np.array_equal(track.t, tracks[0].t)
+
+    # Selecting by sid picks exactly one of them.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        agencies = {"agency_pref": ["wmo", "usa"]}
+        assert len(list(iter_ibtracs(path, sids=["2008245N17999"],
+                                     **agencies))) == 1
+        assert len(list(iter_ibtracs(path, names=["IKE"], **agencies))) == 1
+
+    catalog = catalog_ibtracs(path)
+    assert list(catalog.sid) == ["2008245N17323", "2008245N17999"]
+    assert (catalog.num_records > 0).all()
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_iter_ibtracs_skip_invalid(tmp_path):
+    """A storm with no coincident wind and pressure is skipped, not fatal.
+
+    Over a whole basin these exist (57 of 741 for the North Atlantic
+    1980-2025), so one of them must not abort the sweep.
+    """
+    xr = pytest.importorskip("xarray")
+    from clawpack.geoclaw.met.track import iter_ibtracs
+
+    with xr.open_dataset(_storm_input_path("ibtracs")) as ds:
+        broken = ds.copy(deep=True)
+        broken["sid"] = broken.sid.copy(data=[b"2008245N17999"])
+        for name in list(broken.data_vars):
+            if name.endswith("_wind"):
+                broken[name] = broken[name] * np.nan
+        combined = xr.concat([ds, broken], dim="storm")
+        path = tmp_path / "one_broken.nc"
+        combined.to_netcdf(path)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        tracks = list(iter_ibtracs(path, agency_pref=["wmo", "usa"]))
+    assert [t.ID for t in tracks] == ["2008245N17323"]
+    assert any("Skipped 1" in str(w.message) for w in caught)
+
+    with pytest.raises((ValueError, RuntimeError)):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            list(iter_ibtracs(path, agency_pref=["wmo", "usa"],
+                              skip_invalid=False))
+
+
+@pytest.mark.python
+@pytest.mark.storm
+def test_iter_atcf_matches_make_multi_structure(tmp_path):
+    """The in-memory ATCF walk agrees with the split-to-disk one.
+
+    ``make_multi_structure`` is now a thin wrapper over ``iter_atcf``; this
+    pins that they stay equivalent, and that ``iter_atcf`` leaves nothing behind.
+    """
+    pytest.importorskip("pandas")
+    from clawpack.geoclaw.met.tools import iter_atcf, make_multi_structure
+
+    path = _storm_input_path("atcf")
+    before = set(Path.cwd().iterdir())
+    walked = list(iter_atcf(path))
+    assert set(Path.cwd().iterdir()) == before, "iter_atcf must not write files"
+
+    split = make_multi_structure(path, output_dir=str(tmp_path / "clipped"))
+    assert [storm_id for storm_id, _ in walked] == list(split.keys())
+    for storm_id, storm in walked:
+        assert _parsed_state(storm) == _parsed_state(split[storm_id])
+
+
+@pytest.mark.remote
+@pytest.mark.storm
+@pytest.mark.slow
+def test_full_basin_sweep():
+    """End-to-end over the real archives; the only test of real heterogeneity.
+
+    The bundled fixtures are a single-storm HURDAT2 excerpt and a stripped
+    single-storm IBTrACS slice, so nothing offline exercises differing agencies,
+    basin crossings, or the ~8% of storms with no coincident wind and pressure.
+    Requires the archives on disk; set ``GEOCLAW_TRACK_ARCHIVES`` to the
+    directory holding ``IBTrACS.NA.v04r01.nc`` and a HURDAT2 Atlantic text file.
+    """
+    import os
+    from clawpack.geoclaw.met.track import (iter_hurdat, iter_ibtracs,
+                                            catalog_hurdat, catalog_ibtracs,
+                                            _hurdat_blocks)
+
+    archives = os.environ.get("GEOCLAW_TRACK_ARCHIVES")
+    if archives is None:
+        pytest.skip("set GEOCLAW_TRACK_ARCHIVES to the archive directory")
+    hurdat_path = Path(archives) / "hurdat2_atlantic.txt"
+    ibtracs_path = Path(archives) / "IBTrACS.NA.v04r01.nc"
+    if not hurdat_path.exists() or not ibtracs_path.exists():
+        pytest.skip(f"archives not found under {archives}")
+
+    # --- HURDAT2: record-count conservation over the whole file -------------
+    blocks = list(_hurdat_blocks(hurdat_path))
+    declared = sum(header["num_records"] for header, _ in blocks)
+    parsed = sum(len(records) for _, records in blocks)
+    assert declared == parsed, "declared record counts must match what parsed"
+
+    with open(hurdat_path) as handle:
+        data_lines = sum(1 for line in handle if line[:8].isdigit())
+    assert declared == data_lines, "and must account for every data line"
+
+    catalog = catalog_hurdat(hurdat_path)
+    assert len(catalog) == len(blocks)
+    assert catalog.num_records.sum() == declared
+
+    # --- IBTrACS: catalog agrees with the sweep, no cross-contamination -----
+    years = range(1980, 2026)
+    index = catalog_ibtracs(ibtracs_path, basin="NA", years=years)
+    assert len(index) > 500, "the North Atlantic 1980-2025 has ~740 storms"
+    spans = {row.sid: (row.t_start, row.t_end) for row in index.itertuples()}
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        tracks = list(iter_ibtracs(ibtracs_path, basin="NA", years=years))
+
+    assert 0 < len(tracks) <= len(index)
+    for track in tracks:
+        assert track.t.dtype == np.dtype("datetime64[s]")
+        # Times are monotone within a storm...
+        assert (np.diff(track.t) >= np.timedelta64(0, "s")).all()
+        # ...and stay inside that storm's own span from the catalog, which is
+        # the check that would catch one storm's records bleeding into another.
+        t_start, t_end = spans[track.ID]
+        assert track.t[0] >= t_start
+        assert track.t[-1] <= t_end
+        assert track.basin == "NA"
+
+    # --- Cross-archive: the same storm agrees between the two archives ------
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        ike_hurdat = next(iter_hurdat(hurdat_path, names=["IKE"], years=2008))
+        ike_ibtracs = next(iter_ibtracs(ibtracs_path, names=["IKE"],
+                                        years=2008))
+
+    # Both archives are NHC best track for the Atlantic, so coincident times
+    # must carry the same eye position to best-track precision (0.1 deg).
+    shared, h_index, i_index = np.intersect1d(
+        ike_hurdat.t, ike_ibtracs.t, return_indices=True)
+    assert len(shared) > 20, "the two archives should share most of Ike's track"
+    assert np.allclose(ike_hurdat.eye_location[h_index],
+                       ike_ibtracs.eye_location[i_index], atol=0.11)


### PR DESCRIPTION
## Summary

HURDAT2 and IBTrACS both distribute **one file per basin holding every storm on
record** — 2,004 Atlantic storms / 55,605 records for HURDAT2, 2,298 North
Atlantic storms for IBTrACS v4. Neither reader could use them that way:

- `read_hurdat` assumed one storm per file and **crashes on a real archive**. It
  reads the next storm's header as a data line and feeds `"AL092008"` to
  `np.datetime64`:
  ```
  ValueError: Error parsing datetime string "AL02-18-51TUN:NAMED" at position 0
  ```
  So the multi-storm behaviour the docstring promised ("Future features will be
  added…") has never worked, and nothing can be depending on it.
- `read_ibtracs` selects one storm and re-scans the file for each call, which is
  O(N) file scans to walk a basin.

This adds bulk iteration to both, plus ATCF, without forking the object model.

## API

```python
from clawpack.geoclaw.met import (iter_hurdat, iter_ibtracs, iter_atcf,
                                  catalog_hurdat, catalog_ibtracs)

# Walk a basin
for track in iter_ibtracs(path, basin="NA", years=range(1980, 2026)):
    ...

# Or decide what to run first
index = catalog_ibtracs(path, basin="NA", years=range(1980, 2026))
# -> DataFrame: sid, name, season, basin, num_records, t_start, t_end, max_wind
```

`iter_hurdat` filters on `storm_ids` / `names` / `years` / `basins`;
`iter_ibtracs` on `basin` / `years` / `sids` / `names`, plus `agency_pref` and
`skip_invalid`. `years` takes an int or any iterable, so a season range is just
`range(1980, 2026)`.

**Module-level generators, and deliberately no collection class.** What an
ensemble driver needs beyond iteration is an *index*, not a container, so the
companion is a `pandas.DataFrame` rather than a `TrackCollection` — which would
have been precisely the parallel object model this repo's roadmap names as the
recurring failure mode.

**S5/M2 boundary**, stated so it doesn't drift later: M2 (`to_xarray()` / CF
track I/O) is *serialization of our tracks*; this is *ingestion of foreign
archives*. They compose — once M2 lands, the multi-storm container is
`xr.concat(t.to_xarray() for t in iter_*(...))` — and M2 doesn't need to
re-solve ingestion.

## One parser per format

Every existing entry point keeps its signature and its single-storm behaviour,
and is reimplemented on the same parser its `iter_*` counterpart uses:

| Format | Shared internals | Public |
|---|---|---|
| HURDAT2 | `_hurdat_blocks`, `_hurdat_selected`, `_track_from_hurdat_block` | `read_hurdat` (+ `storm_id`/`name`/`year` selectors), `iter_hurdat`, `catalog_hurdat` |
| IBTrACS | `_select_ibtracs_storm`, `_track_from_ibtracs`, `_ibtracs_storm_mask` | `read_ibtracs` (unchanged signature), `iter_ibtracs`, `catalog_ibtracs` |
| ATCF | `_group_atcf_records` | `make_multi_structure` (unchanged), `iter_atcf` |

So the verification is **path equivalence** — bulk and single-storm reads produce
identical objects — rather than a second set of goldens that could drift from the
first. `make_multi_structure` keeps its disk output and `OrderedDict` return and
its existing test passes unmodified; `iter_atcf` stages through a
`TemporaryDirectory` instead of writing `Clipped_ATCFs/` into the caller's cwd.

`_IBTRACS_AGENCY_PREF` is now a module constant instead of a mutable default
argument on `read_ibtracs`, so the reader and the iterator cannot drift apart.

## Verification

**Record-count conservation** is the primary HURDAT2 integrity check, and the
format hands it to us: each header declares how many records follow
(`AL092008, IKE, 62,`), so declared totals must equal what parsed *and* the
number of data lines in the file. Over the whole Atlantic archive: **55,605 both
ways**. A header claiming more records than follow now raises with the file and
line number instead of absorbing the next storm's header.

Measured on the real archives (`iter_ibtracs`, North Atlantic 1980–2025):

| | |
|---|---|
| storms selected | 741 |
| tracks yielded | 684 |
| skipped (no coincident wind *and* pressure) | **57** |
| wall time | 8.8 s (13 ms/storm) |
| `catalog_ibtracs` over the same selection | 0.2 s |

That 57 is why `skip_invalid=True` is load-bearing rather than a convenience:
`_track_from_ibtracs` raises `NoDataError` for those storms, and one of them must
not abort a basin sweep. It warns with a count at the end, and
`skip_invalid=False` still raises for callers who want that.

Offline tests (9 new, in `tests/test_met_objects.py`):

- `test_hurdat_declared_record_count_is_enforced` — the framing invariant, plus a
  deliberately corrupted count.
- `test_iter_hurdat_matches_read_hurdat`, `test_iter_ibtracs_matches_read_ibtracs`,
  `test_iter_atcf_matches_make_multi_structure` — path equivalence.
- `test_read_hurdat_requires_a_selector_for_multi_storm_files` — ambiguity raises
  and names candidates rather than silently picking one; a single-storm file still
  needs no selector.
- `test_iter_hurdat_filters`, `test_iter_ibtracs_over_multiple_storms`,
  `test_iter_ibtracs_skip_invalid`.
- `test_full_basin_sweep` (`@pytest.mark.remote @pytest.mark.slow`) — see below.

Full suite: **350 passed, 3 skipped, 1 xfailed**, and the remote test verified
excluded from the CI selector (`-m "python and not remote"`).

## Coverage gap, stated plainly

The bundled fixtures are a single-storm HURDAT2 excerpt and a stripped
single-storm IBTrACS slice (`storm: 1`, 13 variables, no `quadrant` dimension, no
`season`, only `wmo_*`/`usa_*` agencies). The offline multi-storm tests
synthesize files by relabeling those, which exercises framing and selection but
**cannot** exercise differing agencies, basin crossings, or genuinely invalid
storms.

Real heterogeneity is covered only by `test_full_basin_sweep`, driven by
`GEOCLAW_TRACK_ARCHIVES` pointing at a directory holding the two archives. It
checks record-count conservation over the full HURDAT2 file, that the catalog
agrees with the sweep, that each track's times are monotone and stay inside that
storm's own catalog span (the check that would catch one storm's records bleeding
into another), and — the nice one — that **Ike read from HURDAT2 and from IBTrACS
agrees on eye position to 0.11°**: the same storm, two independent archives, two
independent readers.

So: either commit a small real multi-storm NA slice as a fixture, or accept that
offline coverage here is structural only. I'd rather say that than imply the
synthesized fixtures prove multi-storm correctness.

## Fixes pulled forward from S3

Three reader-correctness bugs were **inseparable from rewriting the HURDAT2
parser**, so they land here rather than in the S3 harvest:

- **`ID` held the header's record count.** `AL082008, IKE, 06,` gave
  `ID == "06"`. That third field is now what *frames* the block, so it cannot
  also be the id; `ID` is the ATCF-style `"AL082008"`.
- **`basin` was the raw code.** `"AL"` where `read_atcf` gives `"Atlantic"` —
  two readers disagreeing on one field's vocabulary.
- **`classification` / `event` were `<U1`-truncated.** `np.empty(n, dtype=str)`
  is `<U1`, so `"LO"` became `"L"`, colliding with the landfall event code. The
  arrays are allocated in the rewritten parser, so fixing it here was
  unavoidable.

**S3 retains** the quadrant wind radii, the `Basin`/`StormStatus` enums, the same
`<U1` fix for `read_jma`/`read_tcvitals`, and the `StormTrack.plot` swath masking.

## Golden regeneration

**One file:** `tests/data/storm/characterization/read_hurdat.json`. The complete
diff is the three fixes above:

```
-  "ID": "06",              +  "ID": "AL082008",
-  "basin": "AL",           +  "basin": "Atlantic",
-  "L", ... (×6)            +  "LO", ... (×6)
```

**No other golden moves.** In particular no IBTrACS golden moves, which confirms
that splitting `read_ibtracs` into selection plus construction is
behaviour-neutral. `ibtracs_geoclaw.txt`, `hurdat_geoclaw.txt`,
`atcf_geoclaw.txt`, the `write_geoclaw_*` goldens and the Fortran aux/regression
goldens are all untouched — no `GEOCLAW_REGEN` needed for any of them.

## Backward compatibility

Additive, with two behaviour changes worth calling out in release notes:

1. `read_hurdat` on a file with more than one storm now raises a `ValueError`
   listing the candidates, instead of crashing in `np.datetime64`. Strictly an
   improvement, but the exception type and message change.
2. `read_hurdat`'s `ID` and `basin` values change as described above. Anyone
   matching on `classification == "T"` (the truncated `"TS"`) or `basin == "AL"`
   is affected. That code was already reading a bug.

## Note for future test authors

`_storm_state` dictionaries **cannot** be compared with `==`: the state contains
NaN, and `nan != nan` makes dict equality fail spuriously on any NaN-bearing
track. Three of the equivalence tests here failed that way before switching to
comparing `_dumps(...)` text — which is what the characterization tests already
do, and why they work. Recorded in the roadmap so the next person doesn't lose
time to it.

## Design doc

`dev/design/met_forcing_roadmap.md` updated in this PR: new **S5** item marked
done with the API rationale, the S5/M2 boundary, the measurements above, the
coverage gap, the S3 fixes pulled forward, and the NaN-comparison note. The
2026-09 progress paragraph is updated to point at **S3 proper** next, then **S4**
— which the 55%-RMW-coverage figure above motivates: RMW is observed at only 55%
of North Atlantic 1980–2025 track points, and HURDAT2 never supplies it at all.
