### PR TITLE
Include FFLAGS on the multilayer link line so OpenMP builds link correctly

### DIFF
--- a/src/2d/shallow/multilayer/Makefile.multilayer
+++ b/src/2d/shallow/multilayer/Makefile.multilayer
@@ -1,3 +1,19 @@
+# Carry the compile flags onto the link line.
+#
+# Makefile.common defaults the link flags with
+#
+#     LFLAGS ?= $(FFLAGS)
+#
+# but `?=` only fires when LFLAGS is still unset, and this file is included
+# *before* Makefile.common.  So the moment the LAPACK additions below touch
+# LFLAGS, that default is silently cancelled and FFLAGS never reaches the
+# linker -- an OpenMP build then compiles with -fopenmp but links without it
+# and fails on undefined _GOMP_* symbols, even under `make new`.  Adding
+# $(FFLAGS) here restores what the default would have supplied.  LFLAGS stays
+# recursively expanded, so this picks up any later FFLAGS additions (including
+# the MKL include path added below) at link time.
+LFLAGS += $(FFLAGS)
+
 # Include flags for LAPACK linking
 # Match on a substring of FC so versioned/pathed compiler names also work
 # (e.g. setup-fortran >= 1.9.2 exports FC=gfortran-14 rather than gfortran).


### PR DESCRIPTION
There was an inconsistency in the way link flags `$(LFLAGS)` were dealt with in the multilayer Makefile.  This was mostly due to the requirement that it needs to build against something that looks like LAPACK.

While we were reviewing the Makefile behavior in other places we did notice that `examples/bouss/radial_flat/Makefile` hardcodes `-fopenmp` instead of $(FFLAGS). This is fragile as and drops other flags that may be included elsewhere.  It may argue for making `ALL_LFLAGS` always include `FFLAGS`.
