### PR TITLE
fix fgmax_tools for 1d point_styles

### DIFF
--- a/src/python/geoclaw/fgmax_tools.py
+++ b/src/python/geoclaw/fgmax_tools.py
@@ -392,6 +392,10 @@ class FGmaxGrid(object):
 
             self.indexing = indexing  # make available to user
 
+        else:
+            # arrays are 1D, so 'F' or 'C' doesn't matter, but still used below
+            reshape_order = 'C'
+
 
 
         if fgno is not None:


### PR DESCRIPTION
A bug when reading data with `point_style` 0 or 1 that showed up in running `examples/tsunami/radial-ocean-island-fgmax`.