### PR TITLE
Install center_points, center_gauges and xarray_backends

### DIFF
--- a/src/python/geoclaw/meson.build
+++ b/src/python/geoclaw/meson.build
@@ -4,6 +4,8 @@ pkg_dir = join_paths(package.split('.'))
 python_sources = {
   '': [
     '__init__.py',
+    'center_gauges.py',
+    'center_points.py',
     'data.py',
     'dtopotools.py',
     'etopotools.py',
@@ -22,6 +24,7 @@ python_sources = {
     'topotools.py',
     'units.py',
     'util.py',
+    'xarray_backends.py',
   ],
   'datatools': [
     '__init__.py',

--- a/src/python/geoclaw/met/__init__.py
+++ b/src/python/geoclaw/met/__init__.py
@@ -16,7 +16,24 @@ unchanged.
 
 The ``plot`` submodule (:mod:`clawpack.geoclaw.met.plot`) is imported lazily to
 avoid a hard ``matplotlib`` dependency for non-plotting use.
+
+``pandas`` *is* required here, and is an optional dependency of Clawpack:
+install it with ``pip install "clawpack[met]"``.
 """
+
+# track, parametric and plot each import pandas at module scope, and importing
+# any of them runs this file first, so one check here covers every way into the
+# package.  Chained deliberately: `from exc` keeps __cause__.name == 'pandas',
+# which is how tooling tells an absent optional dependency apart from a module
+# missing from the install.
+try:
+    import pandas as _pandas
+except ImportError as exc:
+    raise ImportError(
+        'pandas is required for clawpack.geoclaw.met '
+        '(pip install "clawpack[met]")') from exc
+else:
+    del _pandas
 
 from clawpack.geoclaw.met.storm import (  # noqa: F401
     Storm, construct_fields, available_formats, available_models)

--- a/src/python/geoclaw/xarray_backends.py
+++ b/src/python/geoclaw/xarray_backends.py
@@ -134,13 +134,16 @@ import numpy as np
 try:
     import rioxarray  # activate the rio accessor
     import xarray as xr
-except ImportError:
+    from xarray.backends import BackendEntrypoint
+except ImportError as exc:
+    # Chained deliberately: the original exception names the module that is
+    # actually missing, which is what lets tooling tell an absent optional
+    # dependency apart from a module missing from the install.
     raise ImportError(
         "rioxarray and xarray are required to use the FGOutBackend and FGMaxBackend"
-    )
+    ) from exc
 
 from clawpack.geoclaw import fgmax_tools, fgout_tools
-from xarray.backends import BackendEntrypoint
 
 _qunits = {
     "h": "meters",


### PR DESCRIPTION
Adds missing modules to meson.build and guards `xarray` imports.